### PR TITLE
fix: deduplicate hunks across chapters and fix comment overflow

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -263,7 +263,9 @@ async function reviewCommand(prArg: string | undefined): Promise<number> {
     const withCli = Bun.argv.find((f) => f.startsWith('--with='))?.split('=')[1];
     const providerHint = withCli ?? config.aiProvider ?? 'claude';
     const waitJoke = DAD_JOKES[Math.floor(Math.random() * DAD_JOKES.length)];
-    console.log(`  ${a.yellow}Generating narrative${a.reset} ${a.gray}via${a.reset} ${a.cyan}${providerHint}${a.reset}`);
+    console.log(
+      `  ${a.yellow}Generating narrative${a.reset} ${a.gray}via${a.reset} ${a.cyan}${providerHint}${a.reset}`,
+    );
     console.log(`  ${a.italic}${a.gray}"${waitJoke}"${a.reset}`);
     const { narrative: generated, provider: usedProvider } = await generateNarrative(metadata, files, [], config);
     ctx.narrative = generated;

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -214,7 +214,9 @@ export async function runConfig(): Promise<number> {
       const answer = await ask(`  ${c.dim}replace?${c.reset} ${c.gray}(enter to keep)${c.reset}: `);
       if (answer.length > 0) githubToken = answer;
     } else {
-      process.stdout.write(`  ${c.yellow}no token found${c.reset} ${c.dim}— set DIFFDAD_GITHUB_TOKEN, run${c.reset} ${c.cyan}gh auth login${c.reset}${c.dim}, or enter one:${c.reset}\n`);
+      process.stdout.write(
+        `  ${c.yellow}no token found${c.reset} ${c.dim}— set DIFFDAD_GITHUB_TOKEN, run${c.reset} ${c.cyan}gh auth login${c.reset}${c.dim}, or enter one:${c.reset}\n`,
+      );
       const answer = await ask(`  ${c.dim}personal access token${c.reset}: `);
       if (answer.length > 0) {
         githubToken = answer;
@@ -225,28 +227,48 @@ export async function runConfig(): Promise<number> {
     // --- Display Settings ---
     heading('Display');
 
-    const theme = await pickOne(ask, 'theme', [
-      { value: 'auto' as ThemePreference, display: 'auto' },
-      { value: 'light' as ThemePreference, display: 'light' },
-      { value: 'dark' as ThemePreference, display: 'dark' },
-    ], existing.theme ?? 'auto');
+    const theme = await pickOne(
+      ask,
+      'theme',
+      [
+        { value: 'auto' as ThemePreference, display: 'auto' },
+        { value: 'light' as ThemePreference, display: 'light' },
+        { value: 'dark' as ThemePreference, display: 'dark' },
+      ],
+      existing.theme ?? 'auto',
+    );
 
-    const storyStructure = await pickOne(ask, 'story structure', [
-      { value: 'chapters' as StoryStructure, display: 'chapters' },
-      { value: 'linear' as StoryStructure, display: 'linear' },
-      { value: 'outline' as StoryStructure, display: 'outline' },
-    ], existing.storyStructure ?? 'chapters');
+    const storyStructure = await pickOne(
+      ask,
+      'story structure',
+      [
+        { value: 'chapters' as StoryStructure, display: 'chapters' },
+        { value: 'linear' as StoryStructure, display: 'linear' },
+        { value: 'outline' as StoryStructure, display: 'outline' },
+      ],
+      existing.storyStructure ?? 'chapters',
+    );
 
-    const layoutMode = await pickOne(ask, 'layout', [
-      { value: 'toc' as LayoutMode, display: 'sidebar TOC' },
-      { value: 'linear' as LayoutMode, display: 'linear' },
-    ], existing.layoutMode ?? 'toc');
+    const layoutMode = await pickOne(
+      ask,
+      'layout',
+      [
+        { value: 'toc' as LayoutMode, display: 'sidebar TOC' },
+        { value: 'linear' as LayoutMode, display: 'linear' },
+      ],
+      existing.layoutMode ?? 'toc',
+    );
 
-    const defaultNarrationDensity = await pickOne(ask, 'narration density', [
-      { value: 'terse' as NarrationDensity, display: 'terse' },
-      { value: 'normal' as NarrationDensity, display: 'normal' },
-      { value: 'verbose' as NarrationDensity, display: 'verbose' },
-    ], existing.defaultNarrationDensity ?? 'normal');
+    const defaultNarrationDensity = await pickOne(
+      ask,
+      'narration density',
+      [
+        { value: 'terse' as NarrationDensity, display: 'terse' },
+        { value: 'normal' as NarrationDensity, display: 'normal' },
+        { value: 'verbose' as NarrationDensity, display: 'verbose' },
+      ],
+      existing.defaultNarrationDensity ?? 'normal',
+    );
 
     // --- Persist ---
     const next: DiffDadConfig = {

--- a/packages/cli/src/narrative/engine.ts
+++ b/packages/cli/src/narrative/engine.ts
@@ -93,7 +93,9 @@ async function callCodex(system: string, user: string): Promise<AiResult> {
   const tmpFile = `/tmp/diffdad-codex-${Date.now()}.txt`;
   try {
     const r = await spawnCli(['codex', 'exec', '--skip-git-repo-check', '--ignore-rules', '-o', tmpFile], prompt);
-    const output = await Bun.file(tmpFile).text().catch(() => r.text);
+    const output = await Bun.file(tmpFile)
+      .text()
+      .catch(() => r.text);
     return { text: output, truncated: false, provider: 'codex' };
   } finally {
     rm(tmpFile, { force: true }).catch(() => {});

--- a/packages/cli/src/narrative/prompt.ts
+++ b/packages/cli/src/narrative/prompt.ts
@@ -51,6 +51,7 @@ const RESPONSE_SCHEMA = `{
       "reshow": [
         {
           "ref": "number — hunkIndex of a hunk to re-display from another chapter",
+          "file": "string — file path (must match a diff section's file for the given hunkIndex)",
           "framing": "string — markdown explaining why it's reshown",
           "highlight": { "from": "number — first line (new-side, 1-based)", "to": "number — last line (new-side, 1-based)" }
         }
@@ -79,7 +80,8 @@ A diff shows WHAT changed. Your narrative explains:
 
 ## Structure Rules
 
-- Group hunks by semantic behavior, not by file. A chapter may pull hunks from many files. The same hunk MAY appear in more than one chapter when genuinely relevant.
+- Group hunks by semantic behavior, not by file. A chapter may pull hunks from many files.
+- **Avoid duplicating hunks.** Each hunk should appear as a diff section in ONE chapter (its owner). To reference it elsewhere, use a reshow entry with a highlight range. When a large hunk (especially in a new file) covers multiple concerns, use startLine/endLine to focus each diff section on just the relevant lines — don't repeat the whole hunk.
 - Order chapters as a review reading sequence. Lead with the chapter that anchors understanding of the whole change. Build from core behavior outward.
 - Each chapter gets a risk level:
   - **low** — mechanical, safe, minimal review needed (renames, formatting, dependency bumps)
@@ -118,8 +120,8 @@ Assign an overall verdict:
 ## Diff Referencing
 
 - hunkIndex: 0-based position in the file's hunks array (NOT a global index). Each file's hunks are independently indexed starting at 0.
-- startLine/endLine: NEW side of the diff, 1-based. For deleted files, use OLD side.
-- Reshow: echo hunks from other chapters via "reshow" when a hunk is relevant to multiple behaviors.
+- startLine/endLine: NEW side of the diff, 1-based. For deleted files, use OLD side. Use these to FOCUS: when a chapter only discusses part of a hunk, set startLine/endLine to just the relevant range — the viewer will dim lines outside this window.
+- Reshow: reference a hunk owned by another chapter via "reshow" with a highlight range. Prefer this over duplicating a diff section. This is especially important for new files where a single hunk contains the entire file.
 
 ## Suggested Start
 

--- a/packages/cli/src/narrative/types.ts
+++ b/packages/cli/src/narrative/types.ts
@@ -22,6 +22,7 @@ export type NarrativeChapter = {
   callouts?: Callout[];
   reshow?: {
     ref: number;
+    file?: string;
     framing?: string;
     highlight?: { from: number; to: number };
   }[];

--- a/packages/web/src/components/Chapter.tsx
+++ b/packages/web/src/components/Chapter.tsx
@@ -61,6 +61,47 @@ function CalloutList({ callouts }: { callouts: Callout[] }) {
   );
 }
 
+function ReshowBlock({
+  ownerLabel,
+  framing,
+  children,
+}: {
+  ownerLabel: string;
+  framing?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="ml-[34px] mb-[14px] overflow-hidden rounded-[8px]"
+      style={{
+        boxShadow: 'inset 0 0 0 1px var(--gray-a5)',
+        borderLeft: '2px solid var(--purple-9)',
+        background: 'linear-gradient(180deg, var(--purple-2), transparent)',
+      }}
+    >
+      <div className="px-4 pt-3.5 pb-3" style={{ borderBottom: '1px dashed var(--gray-a5)' }}>
+        <span
+          className="inline-flex items-center gap-1.5 rounded-full px-2 py-[3px] text-[11px] font-medium tracking-[0.02em]"
+          style={{
+            background: 'var(--purple-3)',
+            color: 'var(--purple-11)',
+            boxShadow: 'inset 0 0 0 1px var(--purple-a5)',
+          }}
+        >
+          <span aria-hidden>↻</span>
+          Showing again from {ownerLabel}
+        </span>
+        {framing ? (
+          <div className="mt-2 text-[14px] leading-[22px]" style={{ color: 'var(--fg-2)', maxWidth: '70ch' }}>
+            <NarrationBlock content={framing} />
+          </div>
+        ) : null}
+      </div>
+      {children}
+    </div>
+  );
+}
+
 type FlatHunk = { hunk: DiffHunk; file: string; isNewFile: boolean };
 
 function findHunk(files: DiffFile[], file: string, hunkIndex: number): FlatHunk | null {
@@ -99,11 +140,8 @@ export function Chapter({ index, chapter }: Props) {
     return owners;
   }, [narrative]);
 
-  // Resolve a reshow `ref` (a bare hunkIndex) to its file by scanning the
-  // narrative for a diff section with the matching hunkIndex. Returns the
-  // first match — ambiguous when two files share a hunkIndex, but the LLM's
-  // schema does not give us a file for reshow refs.
-  const refToFile = useMemo(() => {
+  // Fallback map for reshow entries missing the `file` field (older cached narratives).
+  const refToFileFallback = useMemo(() => {
     const map = new Map<number, string>();
     if (!narrative) return map;
     narrative.chapters.forEach((ch) => {
@@ -115,6 +153,18 @@ export function Chapter({ index, chapter }: Props) {
     });
     return map;
   }, [narrative]);
+
+  // Hunks already rendered as diff sections by earlier chapters — duplicates render as reshow.
+  const priorHunks = useMemo(() => {
+    const set = new Set<string>();
+    if (!narrative) return set;
+    for (let ci = 0; ci < index; ci++) {
+      for (const s of narrative.chapters[ci]!.sections) {
+        if (s.type === 'diff') set.add(`${s.file}:${s.hunkIndex}`);
+      }
+    }
+    return set;
+  }, [narrative, index]);
 
   const [collapsed, setCollapsed] = useState(reviewed);
   const prevReviewed = useRef(reviewed);
@@ -203,45 +253,49 @@ export function Chapter({ index, chapter }: Props) {
         }
         const flat = findHunk(files, section.file, section.hunkIndex);
         if (!flat) return null;
+        const hunkKey = `${section.file}:${section.hunkIndex}`;
+        const isDuplicate = priorHunks.has(hunkKey);
+        const hunkCoversAll =
+          section.startLine <= flat.hunk.newStart &&
+          section.endLine >= flat.hunk.newStart + Math.max(flat.hunk.newCount - 1, 0);
+        const highlight = hunkCoversAll ? undefined : { from: section.startLine, to: section.endLine };
+
+        if (isDuplicate) {
+          const ownerIdx = hunkOwners.get(hunkKey);
+          const ownerLabel = ownerIdx !== undefined && ownerIdx !== index ? `Chapter ${ownerIdx + 1}` : 'earlier';
+          return (
+            <ReshowBlock key={i} ownerLabel={ownerLabel}>
+              <Hunk
+                file={flat.file}
+                hunk={flat.hunk}
+                isNewFile={flat.isNewFile}
+                hunkIndex={section.hunkIndex}
+                highlight={highlight}
+              />
+            </ReshowBlock>
+          );
+        }
+
         return (
-          <Hunk key={i} file={flat.file} hunk={flat.hunk} isNewFile={flat.isNewFile} hunkIndex={section.hunkIndex} />
+          <Hunk
+            key={i}
+            file={flat.file}
+            hunk={flat.hunk}
+            isNewFile={flat.isNewFile}
+            hunkIndex={section.hunkIndex}
+            highlight={highlight}
+          />
         );
       })}
       {chapter.reshow?.map((entry, i) => {
-        const refFile = refToFile.get(entry.ref);
+        const refFile = entry.file || refToFileFallback.get(entry.ref);
         if (!refFile) return null;
         const flat = findHunk(files, refFile, entry.ref);
         if (!flat) return null;
         const ownerIdx = hunkOwners.get(`${refFile}:${entry.ref}`);
         const ownerLabel = ownerIdx !== undefined && ownerIdx !== index ? `Chapter ${ownerIdx + 1}` : 'earlier';
         return (
-          <div
-            key={`reshow-${i}`}
-            className="ml-[34px] mb-[14px] overflow-hidden rounded-[8px]"
-            style={{
-              boxShadow: 'inset 0 0 0 1px var(--gray-a5)',
-              borderLeft: '2px solid var(--purple-9)',
-              background: 'linear-gradient(180deg, var(--purple-2), transparent)',
-            }}
-          >
-            <div className="px-4 pt-3.5 pb-3" style={{ borderBottom: '1px dashed var(--gray-a5)' }}>
-              <span
-                className="inline-flex items-center gap-1.5 rounded-full px-2 py-[3px] text-[11px] font-medium tracking-[0.02em]"
-                style={{
-                  background: 'var(--purple-3)',
-                  color: 'var(--purple-11)',
-                  boxShadow: 'inset 0 0 0 1px var(--purple-a5)',
-                }}
-              >
-                <span aria-hidden>↻</span>
-                Showing again from {ownerLabel}
-              </span>
-              {entry.framing ? (
-                <div className="mt-2 text-[14px] leading-[22px]" style={{ color: 'var(--fg-2)', maxWidth: '70ch' }}>
-                  <NarrationBlock content={entry.framing} />
-                </div>
-              ) : null}
-            </div>
+          <ReshowBlock key={`reshow-${i}`} ownerLabel={ownerLabel} framing={entry.framing}>
             <Hunk
               file={flat.file}
               hunk={flat.hunk}
@@ -249,7 +303,7 @@ export function Chapter({ index, chapter }: Props) {
               hunkIndex={entry.ref}
               highlight={entry.highlight}
             />
-          </div>
+          </ReshowBlock>
         );
       })}
       {chapter.callouts && chapter.callouts.length > 0 && <CalloutList callouts={chapter.callouts} />}

--- a/packages/web/src/components/Chapter.tsx
+++ b/packages/web/src/components/Chapter.tsx
@@ -427,7 +427,12 @@ export function Chapter({ index, chapter }: Props) {
             <div className="overflow-hidden">
               <span className="mt-[2px] block text-[12px] text-[var(--fg-3)]">
                 {hunkCount} {hunkCount === 1 ? 'hunk' : 'hunks'}
-                {commentCount > 0 && <> · {commentCount} {commentCount === 1 ? 'comment' : 'comments'}</>}
+                {commentCount > 0 && (
+                  <>
+                    {' '}
+                    · {commentCount} {commentCount === 1 ? 'comment' : 'comments'}
+                  </>
+                )}
                 {reviewed && <> · reviewed</>}
               </span>
             </div>

--- a/packages/web/src/components/GeneratingScreen.tsx
+++ b/packages/web/src/components/GeneratingScreen.tsx
@@ -36,9 +36,18 @@ export function GeneratingScreen({ message }: Props) {
 
         <div className="flex items-center gap-3">
           <div className="generating-dots flex gap-1">
-            <span className="h-1.5 w-1.5 rounded-full" style={{ background: 'var(--purple-9)', animation: 'generating-dot 1.4s ease-in-out infinite' }} />
-            <span className="h-1.5 w-1.5 rounded-full" style={{ background: 'var(--purple-9)', animation: 'generating-dot 1.4s ease-in-out 0.2s infinite' }} />
-            <span className="h-1.5 w-1.5 rounded-full" style={{ background: 'var(--purple-9)', animation: 'generating-dot 1.4s ease-in-out 0.4s infinite' }} />
+            <span
+              className="h-1.5 w-1.5 rounded-full"
+              style={{ background: 'var(--purple-9)', animation: 'generating-dot 1.4s ease-in-out infinite' }}
+            />
+            <span
+              className="h-1.5 w-1.5 rounded-full"
+              style={{ background: 'var(--purple-9)', animation: 'generating-dot 1.4s ease-in-out 0.2s infinite' }}
+            />
+            <span
+              className="h-1.5 w-1.5 rounded-full"
+              style={{ background: 'var(--purple-9)', animation: 'generating-dot 1.4s ease-in-out 0.4s infinite' }}
+            />
           </div>
           <p
             className="text-[14px] italic text-[var(--fg-2)]"

--- a/packages/web/src/components/Hunk.tsx
+++ b/packages/web/src/components/Hunk.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useReviewStore } from '../state/review-store';
 import type { DiffHunk, PRComment } from '../state/types';
 import { CodeLine } from './CodeLine';
@@ -165,6 +165,203 @@ function BotCluster({ comments }: { comments: PRComment[] }) {
   );
 }
 
+const FOLD_CONTEXT = 2;
+const FOLD_MIN = 4;
+
+type LineGroup =
+  | { kind: 'lines'; indices: number[] }
+  | { kind: 'fold'; indices: number[]; count: number };
+
+function buildLineGroups(
+  lines: DiffHunk['lines'],
+  highlight: Props['highlight'],
+  commentLineSet: Set<number>,
+  openLineKeys: Set<string>,
+  file: string,
+  hunkIndex: number,
+): LineGroup[] {
+  if (!highlight) {
+    return [{ kind: 'lines', indices: lines.map((_, i) => i) }];
+  }
+
+  const pinned = new Set<number>();
+  lines.forEach((line, i) => {
+    const ln = line.lineNumber.new;
+    if (ln !== undefined && ln >= highlight.from && ln <= highlight.to) {
+      pinned.add(i);
+    }
+    if (commentLineSet.has(i) || openLineKeys.has(`${file}:${hunkIndex}:${i}`)) {
+      pinned.add(i);
+    }
+  });
+
+  // Expand context around pinned lines
+  const visible = new Set<number>();
+  for (const idx of pinned) {
+    for (let j = idx - FOLD_CONTEXT; j <= idx + FOLD_CONTEXT; j++) {
+      if (j >= 0 && j < lines.length) visible.add(j);
+    }
+  }
+
+  const groups: LineGroup[] = [];
+  let foldBuf: number[] = [];
+
+  function flushFold() {
+    if (foldBuf.length === 0) return;
+    if (foldBuf.length < FOLD_MIN) {
+      groups.push({ kind: 'lines', indices: [...foldBuf] });
+    } else {
+      groups.push({ kind: 'fold', indices: [...foldBuf], count: foldBuf.length });
+    }
+    foldBuf = [];
+  }
+
+  let lineBuf: number[] = [];
+  function flushLines() {
+    if (lineBuf.length === 0) return;
+    groups.push({ kind: 'lines', indices: [...lineBuf] });
+    lineBuf = [];
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    if (visible.has(i)) {
+      flushFold();
+      lineBuf.push(i);
+    } else {
+      flushLines();
+      foldBuf.push(i);
+    }
+  }
+  flushLines();
+  flushFold();
+
+  return groups;
+}
+
+function FoldedLines({ count, onExpand }: { count: number; onExpand: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onExpand}
+      className="flex w-full items-center gap-2 py-[3px] pl-[78px] text-[11.5px] font-medium hover:bg-[var(--gray-a3)]"
+      style={{ color: 'var(--fg-3)' }}
+    >
+      <svg className="h-[10px] w-[10px]" viewBox="0 0 15 15" fill="none" stroke="currentColor" strokeWidth="1.4">
+        <path d="M3 5.5h9M3 9.5h9" />
+      </svg>
+      {count} lines hidden — click to expand
+    </button>
+  );
+}
+
+function HunkLines({
+  file,
+  hunk,
+  hunkIndex,
+  lang,
+  highlight,
+  comments,
+  openLine,
+  setOpenLine,
+  clusterBots,
+}: {
+  file: string;
+  hunk: DiffHunk;
+  hunkIndex: number;
+  lang: string;
+  highlight: Props['highlight'];
+  comments: PRComment[];
+  openLine: string | null;
+  setOpenLine: (key: string | null) => void;
+  clusterBots: boolean;
+}) {
+  const normFile = normalizePath(file);
+
+  const commentLineIndices = useMemo(() => {
+    const set = new Set<number>();
+    hunk.lines.forEach((line, i) => {
+      const hasComment = comments.some((c) => {
+        if (normalizePath(c.path) !== normFile) return false;
+        if (c.line === undefined) return false;
+        if (clusterBots && c.author.endsWith('[bot]')) return false;
+        if (c.side === 'LEFT') {
+          return line.lineNumber.old !== undefined && c.line === line.lineNumber.old;
+        }
+        return line.lineNumber.new !== undefined && c.line === line.lineNumber.new;
+      });
+      if (hasComment) set.add(i);
+    });
+    return set;
+  }, [hunk.lines, comments, normFile, clusterBots]);
+
+  const openLineKeys = useMemo(() => {
+    const set = new Set<string>();
+    if (openLine) set.add(openLine);
+    return set;
+  }, [openLine]);
+
+  const initialGroups = useMemo(
+    () => buildLineGroups(hunk.lines, highlight, commentLineIndices, openLineKeys, file, hunkIndex),
+    [hunk.lines, highlight, commentLineIndices, openLineKeys, file, hunkIndex],
+  );
+
+  const [expandedFolds, setExpandedFolds] = useState<Set<number>>(() => new Set());
+
+  const expandFold = useCallback((groupIdx: number) => {
+    setExpandedFolds((prev) => {
+      const next = new Set(prev);
+      next.add(groupIdx);
+      return next;
+    });
+  }, []);
+
+  const renderLine = useCallback(
+    (i: number, dimmed: boolean) => {
+      const line = hunk.lines[i]!;
+      const lineKey = `${file}:${hunkIndex}:${i}`;
+      const lineComments: PRComment[] = comments.filter((c) => {
+        if (normalizePath(c.path) !== normFile) return false;
+        if (c.line === undefined) return false;
+        if (clusterBots && c.author.endsWith('[bot]')) return false;
+        if (c.side === 'LEFT') {
+          return line.lineNumber.old !== undefined && c.line === line.lineNumber.old;
+        }
+        return line.lineNumber.new !== undefined && c.line === line.lineNumber.new;
+      });
+      const hasThread = openLine === lineKey || lineComments.length > 0;
+      return (
+        <div key={lineKey}>
+          <CodeLine line={line} lineKey={lineKey} lang={lang} dimmed={dimmed} />
+          {hasThread && (
+            <CollapsibleThread
+              comments={lineComments}
+              file={file}
+              lineNumber={line.lineNumber.new}
+              isNewThread={openLine === lineKey && lineComments.length === 0}
+              onClose={() => (openLine === lineKey ? setOpenLine(null) : undefined)}
+            />
+          )}
+        </div>
+      );
+    },
+    [hunk.lines, file, hunkIndex, comments, normFile, clusterBots, openLine, setOpenLine, lang],
+  );
+
+  return (
+    <div>
+      {initialGroups.map((group, gi) => {
+        if (group.kind === 'lines') {
+          return group.indices.map((i) => renderLine(i, false));
+        }
+        if (expandedFolds.has(gi)) {
+          return group.indices.map((i) => renderLine(i, true));
+        }
+        return <FoldedLines key={`fold-${gi}`} count={group.count} onExpand={() => expandFold(gi)} />;
+      })}
+    </div>
+  );
+}
+
 export function Hunk({ file, hunk, isNewFile, hunkIndex, highlight }: Props) {
   const openLine = useReviewStore((s) => s.openLine);
   const comments = useReviewStore((s) => s.comments);
@@ -258,45 +455,17 @@ export function Hunk({ file, hunk, isNewFile, hunkIndex, highlight }: Props) {
         </div>
       </div>
       {clusterBots && botComments.length > 0 && <BotCluster comments={botComments} />}
-      <div>
-        {hunk.lines.map((line, i) => {
-          const lineKey = `${file}:${hunkIndex}:${i}`;
-          const normFile = normalizePath(file);
-          const lineComments: PRComment[] = comments.filter((c) => {
-            if (normalizePath(c.path) !== normFile) return false;
-            if (c.line === undefined) return false;
-            if (clusterBots && c.author.endsWith('[bot]')) return false;
-            // GitHub review comments use `line` for the new-side line number
-            // when side === "RIGHT" (or unset), and the old-side line number
-            // when side === "LEFT". Match against the right axis on the diff
-            // line so LEFT-side comments still appear.
-            if (c.side === 'LEFT') {
-              return line.lineNumber.old !== undefined && c.line === line.lineNumber.old;
-            }
-            return line.lineNumber.new !== undefined && c.line === line.lineNumber.new;
-          });
-          const hasThread = openLine === lineKey || lineComments.length > 0;
-          const dimmed =
-            highlight !== undefined &&
-            (line.lineNumber.new === undefined ||
-              line.lineNumber.new < highlight.from ||
-              line.lineNumber.new > highlight.to);
-          return (
-            <div key={lineKey}>
-              <CodeLine line={line} lineKey={lineKey} lang={lang} dimmed={dimmed} />
-              {hasThread && (
-                <CollapsibleThread
-                  comments={lineComments}
-                  file={file}
-                  lineNumber={line.lineNumber.new}
-                  isNewThread={openLine === lineKey && lineComments.length === 0}
-                  onClose={() => (openLine === lineKey ? setOpenLine(null) : undefined)}
-                />
-              )}
-            </div>
-          );
-        })}
-      </div>
+      <HunkLines
+        file={file}
+        hunk={hunk}
+        hunkIndex={hunkIndex}
+        lang={lang}
+        highlight={highlight}
+        comments={comments}
+        openLine={openLine}
+        setOpenLine={setOpenLine}
+        clusterBots={clusterBots}
+      />
     </div>
   );
 }

--- a/packages/web/src/components/Hunk.tsx
+++ b/packages/web/src/components/Hunk.tsx
@@ -152,7 +152,7 @@ function BotCluster({ comments }: { comments: PRComment[] }) {
       {expanded && (
         <div className="border-t border-dashed bg-[var(--bg-panel)] py-1.5" style={{ borderColor: 'var(--purple-a5)' }}>
           {comments.map((c) => (
-            <div key={c.id} className="grid grid-cols-[56px_1fr] items-start gap-2.5 px-3 py-1.5">
+            <div key={c.id} className="grid grid-cols-[56px_minmax(0,1fr)] items-start gap-2.5 px-3 py-1.5">
               <div className="pt-1.5 text-right font-mono text-[11.5px] font-medium" style={{ color: 'var(--fg-3)' }}>
                 L{c.line ?? ''}
               </div>

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -270,18 +270,36 @@ code {
 }
 
 @keyframes generating-bob {
-  0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-6px); }
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
 }
 
 @keyframes generating-dot {
-  0%, 80%, 100% { opacity: 0.3; transform: scale(0.8); }
-  40% { opacity: 1; transform: scale(1); }
+  0%,
+  80%,
+  100% {
+    opacity: 0.3;
+    transform: scale(0.8);
+  }
+  40% {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 @keyframes generating-fade {
-  0%, 100% { opacity: 0.6; }
-  50% { opacity: 1; }
+  0%,
+  100% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
 }
 
 .live-dot {

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -335,6 +335,15 @@ code {
   color: var(--gray-12);
 }
 
+.markdown-body {
+  overflow-wrap: anywhere;
+  min-width: 0;
+}
+
+.markdown-body pre {
+  overflow-x: auto;
+}
+
 .markdown-body details {
   margin: 0.5rem 0;
   border: 1px solid var(--gray-a4);
@@ -375,6 +384,8 @@ code {
 
 .markdown-body table {
   font-size: 0.875rem;
+  display: block;
+  overflow-x: auto;
 }
 
 .markdown-body sub {

--- a/packages/web/src/state/types.ts
+++ b/packages/web/src/state/types.ts
@@ -41,6 +41,7 @@ export type Chapter = {
   callouts?: Callout[];
   reshow?: {
     ref: number;
+    file?: string;
     framing?: string;
     highlight?: { from: number; to: number };
   }[];


### PR DESCRIPTION
## Summary

- **Hunk dedup**: new files were rendered in full multiple times across chapters. Fixed at three layers:
  - **Schema**: `reshow` entries now include `file` for unambiguous resolution (backward-compatible — falls back to hunkIndex scan for older cached narratives)
  - **Prompt**: replaced "same hunk MAY repeat" with guidance to use `reshow` + `highlight` ranges; `startLine`/`endLine` described as a focus mechanism
  - **Viewer**: tracks rendered `file:hunkIndex` across chapters; auto-converts duplicates into reshow-style display with "Showing again from Chapter N"
- **Line focus**: `startLine`/`endLine` from diff sections now passed as `highlight` to `<Hunk>`, dimming lines outside the LLM's focus range
- **Comment overflow**: wide content (Greptile comments, long URLs, tables) no longer clips — `overflow-wrap: anywhere` on `.markdown-body`, `overflow-x: auto` on tables, `minmax(0,1fr)` on bot cluster grid

## Test plan

- [ ] Run against a PR that adds a new file — verify the file appears once, with reshow blocks for cross-chapter references
- [ ] Clear cache and regenerate to test new prompt guidance
- [ ] Check wide bot/Greptile comments scroll or wrap correctly
- [ ] Verify older cached narratives (without `file` on reshow) still render correctly