### PR TITLE
fix: live-update PR metadata over SSE

### DIFF
--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -239,6 +239,16 @@ export function createServer(ctx: ServerContext) {
             const freshPr = await ctx.github.getPR(ctx.owner, ctx.repo, ctx.pr.number);
             const shaChanged = freshPr.headSha !== ctx.headSha;
 
+            const prMetaChanged =
+              freshPr.draft !== ctx.pr.draft ||
+              freshPr.state !== ctx.pr.state ||
+              freshPr.title !== ctx.pr.title ||
+              freshPr.labels.join(',') !== ctx.pr.labels.join(',');
+            if (prMetaChanged && !shaChanged) {
+              ctx.pr = freshPr;
+              send('pr', ctx.pr);
+            }
+
             const fresh = await ctx.github.getComments(ctx.owner, ctx.repo, ctx.pr.number);
             const prevIds = new Set(ctx.comments.map((cm) => cm.id));
             const freshIds = new Set(fresh.map((cm) => cm.id));

--- a/packages/web/src/hooks/useLiveStream.ts
+++ b/packages/web/src/hooks/useLiveStream.ts
@@ -86,6 +86,16 @@ export function useLiveStream() {
       }
     };
 
+    const onPr = (e: MessageEvent) => {
+      try {
+        const pr = JSON.parse(e.data) as PRData;
+        useReviewStore.getState().setPr(pr);
+        setLastEventAt(Date.now());
+      } catch {
+        // ignore
+      }
+    };
+
     const onRegenerating = (e: MessageEvent) => {
       try {
         const data = JSON.parse(e.data) as { previousSha: string; newSha: string };
@@ -130,6 +140,7 @@ export function useLiveStream() {
     es.addEventListener('comments', onComments as EventListener);
     es.addEventListener('checks', onChecks as EventListener);
     es.addEventListener('reviews', onReviews as EventListener);
+    es.addEventListener('pr', onPr as EventListener);
     es.addEventListener('regenerating', onRegenerating as EventListener);
     es.addEventListener('narrative', onNarrative as EventListener);
 
@@ -147,6 +158,7 @@ export function useLiveStream() {
       es.removeEventListener('comments', onComments as EventListener);
       es.removeEventListener('checks', onChecks as EventListener);
       es.removeEventListener('reviews', onReviews as EventListener);
+      es.removeEventListener('pr', onPr as EventListener);
       es.removeEventListener('regenerating', onRegenerating as EventListener);
       es.removeEventListener('narrative', onNarrative as EventListener);
       es.close();

--- a/packages/web/src/state/review-store.ts
+++ b/packages/web/src/state/review-store.ts
@@ -92,6 +92,7 @@ type ReviewState = {
   setCollapseNarration: (v: boolean) => void;
   setClusterBots: (v: boolean) => void;
   setRegenerating: (v: boolean) => void;
+  setPr: (pr: PRData) => void;
 };
 
 export const useReviewStore = create<ReviewState>((set) => ({
@@ -225,6 +226,7 @@ export const useReviewStore = create<ReviewState>((set) => ({
   setCollapseNarration: (collapseNarration) => set({ collapseNarration }),
   setClusterBots: (clusterBots) => set({ clusterBots }),
   setRegenerating: (regenerating) => set({ regenerating }),
+  setPr: (pr) => set({ pr }),
   setNarrationOverride: (chapterKey: string, text: string) =>
     set((s) => ({ narrationOverrides: { ...s.narrationOverrides, [chapterKey]: text } })),
   clearNarrationOverride: (chapterKey: string) =>


### PR DESCRIPTION
## Summary

### Live PR metadata updates
- Server already fetches fresh PR data every 10s but discarded it unless HEAD SHA changed
- Now compares `draft`, `state`, `title`, and `labels` against current values
- Emits a new `pr` SSE event when metadata changes
- Frontend handles the `pr` event via new `setPr` store action
- Fixes: "Draft" badge staying stale when a PR is marked ready on GitHub

### Draft comments submitted with review
- "Save as draft" comments were stored in memory only and silently discarded on "Submit review"
- Now drafts are persisted to `localStorage` keyed by PR number (survive page reload)
- Drafts are included as `comments[]` in the `POST /api/review` payload
- Server forwards them to GitHub's review API which atomically creates the review + all inline comments
- SubmitDialog shows count of inline comments being submitted

## Test plan

- [ ] Open a draft PR with `dad review`, verify "Draft" badge shows
- [ ] Mark the PR as ready on GitHub — badge should update to "Open" within ~10s
- [ ] Save a few inline draft comments, reload the page — verify they persist
- [ ] Click "Submit review" — verify all drafts appear as inline comments on the GitHub PR
- [ ] Verify drafts are cleared from localStorage after successful submit