### PR TITLE
feat: accent themes, DadMark logo, and font upgrade

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -11,6 +11,7 @@ export type LayoutMode = 'toc' | 'linear';
 export type DisplayDensity = 'comfortable' | 'compact';
 export type NarrationDensity = 'terse' | 'normal' | 'verbose';
 export type ThemePreference = 'light' | 'dark' | 'auto';
+export type AccentId = 'classic' | 'paprika' | 'tomato' | 'forest' | 'plum' | 'sky' | 'dadcore';
 
 export interface DiffDadConfig {
   githubToken?: string;
@@ -24,6 +25,7 @@ export interface DiffDadConfig {
   defaultNarrationDensity?: NarrationDensity;
   clusterBots?: boolean;
   theme?: ThemePreference;
+  accent?: AccentId;
 }
 
 export function getConfigPath(): string {
@@ -238,6 +240,21 @@ export async function runConfig(): Promise<number> {
       existing.theme ?? 'auto',
     );
 
+    const accent = await pickOne(
+      ask,
+      'accent',
+      [
+        { value: 'classic' as AccentId, display: 'classic (purple)' },
+        { value: 'paprika' as AccentId, display: 'paprika (orange)' },
+        { value: 'tomato' as AccentId, display: 'tomato (red-orange)' },
+        { value: 'forest' as AccentId, display: 'forest (green)' },
+        { value: 'plum' as AccentId, display: 'plum (purple)' },
+        { value: 'sky' as AccentId, display: 'sky (blue)' },
+        { value: 'dadcore' as AccentId, display: 'dadcore (warm paprika)' },
+      ],
+      existing.accent ?? 'classic',
+    );
+
     const storyStructure = await pickOne(
       ask,
       'story structure',
@@ -276,6 +293,7 @@ export async function runConfig(): Promise<number> {
       aiProvider: useClaudeCli ? undefined : provider,
       aiModel,
       theme,
+      accent,
       storyStructure,
       layoutMode,
       defaultNarrationDensity,

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -37,6 +37,7 @@ export function createServer(ctx: ServerContext) {
   type SseClient = (event: string, data: unknown) => void;
   const sseClients = new Set<SseClient>();
   let hadClients = false;
+  let exitTimer: ReturnType<typeof setTimeout> | null = null;
 
   function broadcast(event: string, data: unknown) {
     for (const send of sseClients) {
@@ -236,6 +237,10 @@ export function createServer(ctx: ServerContext) {
         send('connected', { timestamp: Date.now() });
         sseClients.add(send);
         hadClients = true;
+        if (exitTimer) {
+          clearTimeout(exitTimer);
+          exitTimer = null;
+        }
 
         let regenerating = false;
         const interval = setInterval(async () => {
@@ -332,19 +337,22 @@ export function createServer(ctx: ServerContext) {
             // already closed
           }
           if (hadClients && sseClients.size === 0) {
-            const jokes = [
-              "I'm not angry, just diff-appointed.",
-              "That's a wrap — like my git commits.",
-              'Time to checkout. Get it? ...checkout?',
-              "I'd tell you a UDP joke, but you might not get it.",
-              "Don't worry, I'll be back. I always rebase.",
-              'Remember: a clean diff is a happy diff.',
-              "I'm going to sleep now. Unlike my PRs, I don't stay open forever.",
-            ];
-            const joke = jokes[Math.floor(Math.random() * jokes.length)];
-            console.log(`\n  \x1b[2mBrowser disconnected — shutting down.\x1b[0m`);
-            console.log(`  \x1b[38;5;141m${joke}\x1b[0m\n`);
-            setTimeout(() => process.exit(0), 500);
+            exitTimer = setTimeout(() => {
+              if (sseClients.size > 0) return;
+              const jokes = [
+                "I'm not angry, just diff-appointed.",
+                "That's a wrap — like my git commits.",
+                'Time to checkout. Get it? ...checkout?',
+                "I'd tell you a UDP joke, but you might not get it.",
+                "Don't worry, I'll be back. I always rebase.",
+                'Remember: a clean diff is a happy diff.',
+                "I'm going to sleep now. Unlike my PRs, I don't stay open forever.",
+              ];
+              const joke = jokes[Math.floor(Math.random() * jokes.length)];
+              console.log(`\n  \x1b[2mBrowser disconnected — shutting down.\x1b[0m`);
+              console.log(`  \x1b[38;5;141m${joke}\x1b[0m\n`);
+              setTimeout(() => process.exit(0), 500);
+            }, 3000);
           }
         });
       },

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -62,6 +62,7 @@ export function createServer(ctx: ServerContext) {
           displayDensity: config.displayDensity ?? 'comfortable',
           defaultNarrationDensity: config.defaultNarrationDensity ?? 'normal',
           clusterBots: config.clusterBots ?? true,
+          accent: config.accent ?? 'classic',
         },
       });
     }
@@ -89,6 +90,7 @@ export function createServer(ctx: ServerContext) {
         displayDensity: config.displayDensity ?? 'comfortable',
         defaultNarrationDensity: config.defaultNarrationDensity ?? 'normal',
         clusterBots: config.clusterBots ?? true,
+        accent: config.accent ?? 'classic',
       },
       _debug: {
         totalComments: ctx.comments.length,

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -336,9 +336,9 @@ export function createServer(ctx: ServerContext) {
           } catch {
             // already closed
           }
-          if (hadClients && sseClients.size === 0) {
+          if (hadClients && sseClients.size === 0 && ctx.narrative) {
             exitTimer = setTimeout(() => {
-              if (sseClients.size > 0) return;
+              if (sseClients.size > 0 || !ctx.narrative) return;
               const jokes = [
                 "I'm not angry, just diff-appointed.",
                 "That's a wrap — like my git commits.",

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -352,7 +352,7 @@ export function createServer(ctx: ServerContext) {
               console.log(`\n  \x1b[2mBrowser disconnected — shutting down.\x1b[0m`);
               console.log(`  \x1b[38;5;141m${joke}\x1b[0m\n`);
               setTimeout(() => process.exit(0), 500);
-            }, 3000);
+            }, 30_000);
           }
         });
       },

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -10,7 +10,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700&family=Source+Serif+4:ital,wght@0,400;0,600;1,400&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,700;1,9..144,400&amp;family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap"
       rel="stylesheet"
     />
   </head>

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -12,9 +12,12 @@ import { ShortcutsHelp } from './components/ShortcutsHelp';
 import { StoryView } from './components/StoryView';
 import { SubmitBar } from './components/SubmitBar';
 import { copy } from './lib/microcopy';
+import { getAccentMeta } from './lib/accents';
+import { renderDadMarkSVG } from './components/DadMark';
 
 export default function App() {
   const theme = useReviewStore((s) => s.theme);
+  const accent = useReviewStore((s) => s.accent);
   const view = useReviewStore((s) => s.view);
   const pr = useReviewStore((s) => s.pr);
   const narrative = useReviewStore((s) => s.narrative);
@@ -56,6 +59,28 @@ export default function App() {
       return () => mq.removeEventListener('change', applyTheme);
     }
   }, [theme]);
+
+  useEffect(() => {
+    if (accent === 'classic') {
+      document.documentElement.removeAttribute('data-accent');
+    } else {
+      document.documentElement.setAttribute('data-accent', accent);
+    }
+  }, [accent]);
+
+  useEffect(() => {
+    const { markBg } = getAccentMeta(accent);
+    const svg = renderDadMarkSVG({ size: 32, bg: markBg, shape: 'circle', showBadge: false });
+    const encoded = `data:image/svg+xml,${encodeURIComponent(svg)}`;
+    let link = document.querySelector<HTMLLinkElement>('link[rel="icon"][type="image/svg+xml"]');
+    if (!link) {
+      link = document.createElement('link');
+      link.rel = 'icon';
+      link.type = 'image/svg+xml';
+      document.head.appendChild(link);
+    }
+    link.href = encoded;
+  }, [accent]);
 
   // Escape closes the activity drawer when nothing else is open.
   useEffect(() => {

--- a/packages/web/src/components/AppBar.tsx
+++ b/packages/web/src/components/AppBar.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react';
 import { ACCENTS, getAccentMeta } from '../lib/accents';
 import { useReviewStore } from '../state/review-store';
 import { DadMark } from './DadMark';
@@ -8,6 +9,88 @@ function repoSlug(repoUrl: string | null): string | null {
   if (!repoUrl) return null;
   const m = repoUrl.match(/github\.com\/([^/]+\/[^/]+)/);
   return m ? m[1] : null;
+}
+
+function AccentPicker({
+  accent,
+  onSelect,
+}: {
+  accent: string;
+  onSelect: (id: (typeof ACCENTS)[number]['id']) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('mousedown', onClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const current = getAccentMeta(accent as (typeof ACCENTS)[number]['id']);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        aria-label={`Accent: ${current.name}`}
+        title={`Accent: ${current.name}`}
+        onClick={() => setOpen(!open)}
+        className="inline-flex h-[30px] w-[30px] items-center justify-center rounded-[6px] bg-[var(--bg-panel)] hover:bg-[var(--gray-2)]"
+        style={{ boxShadow: 'inset 0 0 0 1px var(--gray-a5)' }}
+      >
+        <span
+          className="h-3.5 w-3.5 rounded-full"
+          style={{
+            background: current.dot,
+            boxShadow: `0 0 0 1.5px var(--bg-panel), 0 0 0 2.5px ${current.dot}40`,
+          }}
+        />
+      </button>
+      {open && (
+        <div
+          className="absolute right-0 top-[calc(100%+6px)] z-40 rounded-[10px] bg-[var(--bg-panel)] p-2"
+          style={{
+            boxShadow: 'var(--shadow-elevated), inset 0 0 0 1px var(--gray-a4)',
+            animation: 'fade-in 120ms ease-out',
+          }}
+        >
+          <div className="flex flex-col gap-1">
+            {ACCENTS.map((a) => (
+              <button
+                key={a.id}
+                type="button"
+                onClick={() => {
+                  onSelect(a.id);
+                  setOpen(false);
+                }}
+                className="flex items-center gap-2.5 rounded-[6px] px-2.5 py-1.5 text-left text-[12px] font-medium text-[var(--fg-2)] hover:bg-[var(--gray-3)] hover:text-[var(--fg-1)]"
+              >
+                <span
+                  className="h-3 w-3 flex-shrink-0 rounded-full"
+                  style={{
+                    background: a.dot,
+                    boxShadow: accent === a.id ? `0 0 0 2px var(--bg-panel), 0 0 0 3px ${a.dot}` : undefined,
+                  }}
+                />
+                <span className="whitespace-nowrap">{a.name}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }
 
 type AppBarProps = {
@@ -75,25 +158,7 @@ export function AppBar({ onOpenActivity }: AppBarProps) {
         <LivePill onClick={onOpenActivity} />
 
         {/* Accent picker */}
-        <div
-          className="flex items-center gap-1.5 rounded-[6px] px-1.5 py-1"
-          style={{ boxShadow: 'inset 0 0 0 1px var(--gray-a5)' }}
-        >
-          {ACCENTS.map((a) => (
-            <button
-              key={a.id}
-              type="button"
-              aria-label={a.name}
-              title={a.name}
-              onClick={() => setAccent(a.id)}
-              className="relative h-3 w-3 rounded-full transition-transform hover:scale-125"
-              style={{
-                background: a.dot,
-                boxShadow: accent === a.id ? `0 0 0 2px var(--bg-panel), 0 0 0 3.5px ${a.dot}` : undefined,
-              }}
-            />
-          ))}
-        </div>
+        <AccentPicker accent={accent} onSelect={setAccent} />
 
         {/* Theme toggle: light → dark → auto */}
         <button

--- a/packages/web/src/components/AppBar.tsx
+++ b/packages/web/src/components/AppBar.tsx
@@ -1,5 +1,6 @@
-import { copy } from '../lib/microcopy';
+import { ACCENTS, getAccentMeta } from '../lib/accents';
 import { useReviewStore } from '../state/review-store';
+import { DadMark } from './DadMark';
 import { LivePill } from './LivePill';
 import { IconMoon, IconMonitor, IconSun, IconArrowRight } from './Icons';
 
@@ -17,9 +18,12 @@ export function AppBar({ onOpenActivity }: AppBarProps) {
   const pr = useReviewStore((s) => s.pr);
   const theme = useReviewStore((s) => s.theme);
   const setTheme = useReviewStore((s) => s.setTheme);
+  const accent = useReviewStore((s) => s.accent);
+  const setAccent = useReviewStore((s) => s.setAccent);
   const repoUrl = useReviewStore((s) => s.repoUrl);
 
   const slug = repoSlug(repoUrl);
+  const { markBg } = getAccentMeta(accent);
   const prNum = pr ? pr.number : null;
 
   return (
@@ -28,7 +32,7 @@ export function AppBar({ onOpenActivity }: AppBarProps) {
       style={{ boxShadow: 'inset 0 -1px 0 var(--gray-a4)' }}
     >
       {/* Brand mark */}
-      <img src="/diff-dad-mark.svg" alt="Diff Dad" title={copy.brandTooltip} className="h-[26px] w-[26px]" />
+      <DadMark size={26} bg={markBg} shape="circle" showBadge={false} />
 
       {/* Separator */}
       <span aria-hidden className="mx-1 inline-block h-5 w-px" style={{ background: 'var(--gray-a4)' }} />
@@ -69,6 +73,27 @@ export function AppBar({ onOpenActivity }: AppBarProps) {
       <div className="flex items-center gap-2">
         {/* Live pill */}
         <LivePill onClick={onOpenActivity} />
+
+        {/* Accent picker */}
+        <div
+          className="flex items-center gap-1.5 rounded-[6px] px-1.5 py-1"
+          style={{ boxShadow: 'inset 0 0 0 1px var(--gray-a5)' }}
+        >
+          {ACCENTS.map((a) => (
+            <button
+              key={a.id}
+              type="button"
+              aria-label={a.name}
+              title={a.name}
+              onClick={() => setAccent(a.id)}
+              className="relative h-3 w-3 rounded-full transition-transform hover:scale-125"
+              style={{
+                background: a.dot,
+                boxShadow: accent === a.id ? `0 0 0 2px var(--bg-panel), 0 0 0 3.5px ${a.dot}` : undefined,
+              }}
+            />
+          ))}
+        </div>
 
         {/* Theme toggle: light → dark → auto */}
         <button

--- a/packages/web/src/components/ApprovalCelebration.tsx
+++ b/packages/web/src/components/ApprovalCelebration.tsx
@@ -1,10 +1,15 @@
 import { useEffect, useMemo } from 'react';
+import { DadMark } from './DadMark';
+import { getAccentMeta } from '../lib/accents';
+import { useReviewStore } from '../state/review-store';
 
 type Props = {
   onDone: () => void;
 };
 
 export function ApprovalCelebration({ onDone }: Props) {
+  const accent = useReviewStore((s) => s.accent);
+  const { markBg } = getAccentMeta(accent);
   useEffect(() => {
     const t = setTimeout(onDone, 3500);
     return () => clearTimeout(t);
@@ -56,12 +61,7 @@ export function ApprovalCelebration({ onDone }: Props) {
           boxShadow: '0 24px 48px -8px rgba(3,2,13,0.25)',
         }}
       >
-        <div
-          className="flex h-16 w-16 items-center justify-center rounded-full text-white text-2xl"
-          style={{ background: 'var(--green-9)' }}
-        >
-          ✓
-        </div>
+        <DadMark size={80} bg={markBg} shape="circle" showBadge={false} showWink />
         <div className="text-[28px] font-bold tracking-tight text-[var(--fg-1)]">Proud of you, champ.</div>
         <div className="text-sm text-[var(--fg-2)]">Review approved and sent to GitHub</div>
       </div>

--- a/packages/web/src/components/CodeLine.tsx
+++ b/packages/web/src/components/CodeLine.tsx
@@ -9,9 +9,10 @@ type Props = {
   lineKey: string;
   lang: string;
   dimmed?: boolean;
+  highlighterReady?: boolean;
 };
 
-export function CodeLine({ line, lineKey, lang, dimmed }: Props) {
+export function CodeLine({ line, lineKey, lang, dimmed, highlighterReady }: Props) {
   const setOpenLine = useReviewStore((s) => s.setOpenLine);
   const theme = useResolvedTheme();
 
@@ -21,7 +22,10 @@ export function CodeLine({ line, lineKey, lang, dimmed }: Props) {
   const sign = isAdd ? '+' : isRem ? '−' : '';
 
   // Shiki output
-  const highlighted = useMemo(() => highlightLine(line.content, lang, theme), [line.content, lang, theme]);
+  const highlighted = useMemo(
+    () => highlightLine(line.content, lang, theme),
+    [line.content, lang, theme, highlighterReady],
+  );
 
   // Row background tints (matching design CSS: rgba(41,163,131,0.08) / rgba(229,70,102,0.08))
   const rowBg = isAdd ? 'rgba(41, 163, 131, 0.08)' : isRem ? 'rgba(229, 70, 102, 0.08)' : 'var(--bg-panel)';
@@ -29,7 +33,7 @@ export function CodeLine({ line, lineKey, lang, dimmed }: Props) {
   // Line number tints (slightly more saturated)
   const lnBg = isAdd ? 'rgba(41, 163, 131, 0.16)' : isRem ? 'rgba(229, 70, 102, 0.16)' : 'var(--gray-1)';
 
-  const lnColor = isAdd ? '#1d3b31' : isRem ? '#64172b' : 'var(--gray-9)';
+  const lnColor = isAdd ? 'var(--green-11)' : isRem ? 'var(--red-11)' : 'var(--gray-9)';
 
   // Sigil glyph color
   const sigilColor = isAdd ? 'var(--green-11)' : isRem ? 'var(--red-11)' : 'var(--fg-3)';

--- a/packages/web/src/components/CodeLine.tsx
+++ b/packages/web/src/components/CodeLine.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useResolvedTheme, useReviewStore } from '../state/review-store';
 import type { DiffLine } from '../state/types';
 import { highlightLine } from '../lib/shiki';
+import { useHighlighter } from '../hooks/useHighlighter';
 import { IconPlus } from './Icons';
 
 type Props = {
@@ -9,23 +10,19 @@ type Props = {
   lineKey: string;
   lang: string;
   dimmed?: boolean;
-  highlighterReady?: boolean;
 };
 
-export function CodeLine({ line, lineKey, lang, dimmed, highlighterReady }: Props) {
+export function CodeLine({ line, lineKey, lang, dimmed }: Props) {
   const setOpenLine = useReviewStore((s) => s.setOpenLine);
   const theme = useResolvedTheme();
+  const ready = useHighlighter();
 
   const isAdd = line.type === 'add';
   const isRem = line.type === 'remove';
 
   const sign = isAdd ? '+' : isRem ? '−' : '';
 
-  // Shiki output
-  const highlighted = useMemo(
-    () => highlightLine(line.content, lang, theme),
-    [line.content, lang, theme, highlighterReady],
-  );
+  const highlighted = useMemo(() => highlightLine(line.content, lang, theme), [line.content, lang, theme, ready]);
 
   // Row background tints (matching design CSS: rgba(41,163,131,0.08) / rgba(229,70,102,0.08))
   const rowBg = isAdd ? 'rgba(41, 163, 131, 0.08)' : isRem ? 'rgba(229, 70, 102, 0.08)' : 'var(--bg-panel)';

--- a/packages/web/src/components/DadMark.tsx
+++ b/packages/web/src/components/DadMark.tsx
@@ -1,0 +1,236 @@
+export type DadMarkShape = 'circle' | 'squircle' | 'none';
+export type DadMarkGlasses = 'round' | 'rect' | 'aviator-clear';
+
+export type DadMarkProps = {
+  size?: number;
+  bg?: string;
+  ink?: string;
+  skin?: string;
+  blush?: string;
+  shape?: DadMarkShape;
+  glasses?: DadMarkGlasses;
+  showBadge?: boolean;
+  showWink?: boolean;
+  strokeW?: number;
+  className?: string;
+};
+
+const DEFAULTS = {
+  size: 32,
+  bg: '#6565ec',
+  ink: '#15233F',
+  skin: '#FFF6E6',
+  blush: '#FFC2A0',
+  shape: 'circle' as DadMarkShape,
+  glasses: 'round' as DadMarkGlasses,
+  showBadge: false,
+  showWink: false,
+  strokeW: 8,
+};
+
+/**
+ * Builds the inner SVG markup string for the DadMark.
+ *
+ * Shared between the React component (`DadMark`) and the pure
+ * `renderDadMarkSVG` helper used to build a data URI for the dynamic
+ * favicon.
+ */
+function dadMarkPaths(opts: Required<Omit<DadMarkProps, 'size' | 'className'>>): string {
+  const { bg, ink, skin, blush, shape, glasses, showBadge, showWink, strokeW } = opts;
+  const S = 320;
+  const cx = 160;
+  const cy = 168;
+  const glassY = cy + 4;
+  const glassDX = 38;
+  const lensW = glasses === 'rect' ? 56 : 52;
+  const lensH = glasses === 'rect' ? 38 : 40;
+  const lensR = glasses === 'rect' ? 8 : 22;
+
+  const parts: string[] = [];
+
+  // Badge shape
+  if (shape === 'circle') {
+    parts.push(`<circle cx="${S / 2}" cy="${S / 2}" r="150" fill="${bg}"/>`);
+  } else if (shape === 'squircle') {
+    parts.push(`<rect x="10" y="10" width="300" height="300" rx="68" ry="68" fill="${bg}"/>`);
+  }
+
+  parts.push('<g>');
+
+  // Hair (under face)
+  const hairPath = `M ${cx - 78} ${cy - 36} C ${cx - 88} ${cy - 92}, ${cx - 30} ${cy - 118}, ${cx + 10} ${cy - 110} C ${cx + 70} ${cy - 102}, ${cx + 92} ${cy - 70}, ${cx + 86} ${cy - 36} C ${cx + 70} ${cy - 70}, ${cx + 30} ${cy - 78}, ${cx - 10} ${cy - 58} C ${cx - 30} ${cy - 48}, ${cx - 50} ${cy - 50}, ${cx - 78} ${cy - 36} Z`;
+  parts.push(`<path d="${hairPath}" fill="${ink}"/>`);
+
+  // Face
+  parts.push(
+    `<circle cx="${cx}" cy="${cy}" r="94" fill="${skin}" stroke="${ink}" stroke-width="${strokeW}"/>`,
+  );
+
+  // Hair re-clip on top of stroked face
+  parts.push(`<path d="${hairPath}" fill="${ink}"/>`);
+
+  // Ears
+  parts.push(
+    `<ellipse cx="${cx - 92}" cy="${cy + 8}" rx="9" ry="14" fill="${skin}" stroke="${ink}" stroke-width="${strokeW}"/>`,
+  );
+  parts.push(
+    `<ellipse cx="${cx + 92}" cy="${cy + 8}" rx="9" ry="14" fill="${skin}" stroke="${ink}" stroke-width="${strokeW}"/>`,
+  );
+
+  // Cheeks
+  parts.push(`<circle cx="${cx - 56}" cy="${cy + 28}" r="11" fill="${blush}" opacity="0.7"/>`);
+  parts.push(`<circle cx="${cx + 56}" cy="${cy + 28}" r="11" fill="${blush}" opacity="0.7"/>`);
+
+  // Eyebrows
+  parts.push(
+    `<path d="M ${cx - 52} ${glassY - 26} Q ${cx - 38} ${glassY - 34} ${cx - 22} ${glassY - 26}" stroke="${ink}" stroke-width="6" stroke-linecap="round" fill="none"/>`,
+  );
+  parts.push(
+    `<path d="M ${cx + 22} ${glassY - 26} Q ${cx + 38} ${glassY - 34} ${cx + 52} ${glassY - 26}" stroke="${ink}" stroke-width="6" stroke-linecap="round" fill="none"/>`,
+  );
+
+  // Glasses group
+  parts.push('<g>');
+
+  // Bridge
+  parts.push(
+    `<line x1="${cx - (glassDX - lensW / 2)}" y1="${glassY}" x2="${cx + (glassDX - lensW / 2)}" y2="${glassY}" stroke="${ink}" stroke-width="6" stroke-linecap="round"/>`,
+  );
+
+  // Left lens
+  if (glasses === 'round') {
+    parts.push(
+      `<circle cx="${cx - glassDX}" cy="${glassY}" r="26" fill="white" stroke="${ink}" stroke-width="6"/>`,
+    );
+  } else if (glasses === 'rect') {
+    parts.push(
+      `<rect x="${cx - glassDX - lensW / 2}" y="${glassY - lensH / 2}" width="${lensW}" height="${lensH}" rx="${lensR}" fill="white" stroke="${ink}" stroke-width="6"/>`,
+    );
+  } else if (glasses === 'aviator-clear') {
+    parts.push(
+      `<path d="M ${cx - glassDX - 28} ${glassY - 16} Q ${cx - glassDX - 30} ${glassY + 22} ${cx - glassDX} ${glassY + 22} Q ${cx - glassDX + 28} ${glassY + 22} ${cx - glassDX + 26} ${glassY - 18} Z" fill="white" stroke="${ink}" stroke-width="6"/>`,
+    );
+  }
+
+  // Right lens
+  if (glasses === 'round') {
+    parts.push(
+      `<circle cx="${cx + glassDX}" cy="${glassY}" r="26" fill="white" stroke="${ink}" stroke-width="6"/>`,
+    );
+  } else if (glasses === 'rect') {
+    parts.push(
+      `<rect x="${cx + glassDX - lensW / 2}" y="${glassY - lensH / 2}" width="${lensW}" height="${lensH}" rx="${lensR}" fill="white" stroke="${ink}" stroke-width="6"/>`,
+    );
+  } else if (glasses === 'aviator-clear') {
+    parts.push(
+      `<path d="M ${cx + glassDX - 26} ${glassY - 18} Q ${cx + glassDX - 28} ${glassY + 22} ${cx + glassDX} ${glassY + 22} Q ${cx + glassDX + 30} ${glassY + 22} ${cx + glassDX + 28} ${glassY - 16} Z" fill="white" stroke="${ink}" stroke-width="6"/>`,
+    );
+  }
+
+  // Pupils (or wink)
+  if (!showWink) {
+    parts.push(`<circle cx="${cx - glassDX + 2}" cy="${glassY + 2}" r="4" fill="${ink}"/>`);
+    parts.push(`<circle cx="${cx + glassDX + 2}" cy="${glassY + 2}" r="4" fill="${ink}"/>`);
+  } else {
+    parts.push(`<circle cx="${cx - glassDX + 2}" cy="${glassY + 2}" r="4" fill="${ink}"/>`);
+    parts.push(
+      `<path d="M ${cx + glassDX - 12} ${glassY + 2} Q ${cx + glassDX} ${glassY - 6} ${cx + glassDX + 12} ${glassY + 2}" stroke="${ink}" stroke-width="5" stroke-linecap="round" fill="none"/>`,
+    );
+  }
+
+  // Temple tips
+  const templeOffset = glasses === 'rect' ? lensW / 2 : 26;
+  parts.push(
+    `<line x1="${cx - glassDX - templeOffset}" y1="${glassY - 2}" x2="${cx - glassDX - templeOffset - 12}" y2="${glassY - 8}" stroke="${ink}" stroke-width="6" stroke-linecap="round"/>`,
+  );
+  parts.push(
+    `<line x1="${cx + glassDX + templeOffset}" y1="${glassY - 2}" x2="${cx + glassDX + templeOffset + 12}" y2="${glassY - 8}" stroke="${ink}" stroke-width="6" stroke-linecap="round"/>`,
+  );
+
+  parts.push('</g>'); // end glasses group
+
+  // Nose
+  parts.push(
+    `<path d="M ${cx - 6} ${cy + 30} Q ${cx} ${cy + 38} ${cx + 6} ${cy + 30}" stroke="${ink}" stroke-width="5" stroke-linecap="round" fill="none"/>`,
+  );
+
+  // Mustache
+  const mustachePath = `M ${cx} ${cy + 44} C ${cx - 14} ${cy + 40}, ${cx - 28} ${cy + 42}, ${cx - 44} ${cy + 52} C ${cx - 60} ${cy + 60}, ${cx - 76} ${cy + 64}, ${cx - 86} ${cy + 56} C ${cx - 78} ${cy + 76}, ${cx - 56} ${cy + 84}, ${cx - 38} ${cy + 78} C ${cx - 22} ${cy + 74}, ${cx - 10} ${cy + 68}, ${cx} ${cy + 64} C ${cx + 10} ${cy + 68}, ${cx + 22} ${cy + 74}, ${cx + 38} ${cy + 78} C ${cx + 56} ${cy + 84}, ${cx + 78} ${cy + 76}, ${cx + 86} ${cy + 56} C ${cx + 76} ${cy + 64}, ${cx + 60} ${cy + 60}, ${cx + 44} ${cy + 52} C ${cx + 28} ${cy + 42}, ${cx + 14} ${cy + 40}, ${cx} ${cy + 44} Z`;
+  parts.push(`<path d="${mustachePath}" fill="${ink}"/>`);
+
+  // Mustache highlight
+  parts.push(
+    `<path d="M ${cx} ${cy + 48} Q ${cx} ${cy + 60} ${cx - 2} ${cy + 66}" stroke="${skin}" stroke-width="2" stroke-linecap="round" fill="none" opacity="0.4"/>`,
+  );
+
+  // Chin tuft
+  parts.push(
+    `<path d="M ${cx - 14} ${cy + 80} Q ${cx} ${cy + 92} ${cx + 14} ${cy + 80}" stroke="${ink}" stroke-width="5" stroke-linecap="round" fill="none"/>`,
+  );
+
+  parts.push('</g>'); // end face group
+
+  // Diff badge
+  if (showBadge) {
+    parts.push(`<g transform="translate(${S - 78}, 36)">`);
+    parts.push(`<rect x="0" y="0" width="56" height="56" rx="14" fill="white" stroke="${ink}" stroke-width="5"/>`);
+    parts.push(`<line x1="10" y1="20" x2="18" y2="20" stroke="#1F9D55" stroke-width="5" stroke-linecap="round"/>`);
+    parts.push(`<line x1="14" y1="16" x2="14" y2="24" stroke="#1F9D55" stroke-width="5" stroke-linecap="round"/>`);
+    parts.push(`<line x1="24" y1="20" x2="46" y2="20" stroke="#1F9D55" stroke-width="5" stroke-linecap="round"/>`);
+    parts.push(`<line x1="10" y1="38" x2="18" y2="38" stroke="#D64545" stroke-width="5" stroke-linecap="round"/>`);
+    parts.push(`<line x1="24" y1="38" x2="42" y2="38" stroke="#D64545" stroke-width="5" stroke-linecap="round"/>`);
+    parts.push('</g>');
+  }
+
+  return parts.join('');
+}
+
+function resolveOpts(props: DadMarkProps): Required<Omit<DadMarkProps, 'size' | 'className'>> {
+  return {
+    bg: props.bg ?? DEFAULTS.bg,
+    ink: props.ink ?? DEFAULTS.ink,
+    skin: props.skin ?? DEFAULTS.skin,
+    blush: props.blush ?? DEFAULTS.blush,
+    shape: props.shape ?? DEFAULTS.shape,
+    glasses: props.glasses ?? DEFAULTS.glasses,
+    showBadge: props.showBadge ?? DEFAULTS.showBadge,
+    showWink: props.showWink ?? DEFAULTS.showWink,
+    strokeW: props.strokeW ?? DEFAULTS.strokeW,
+  };
+}
+
+/**
+ * Pure function returning a complete `<svg>...</svg>` markup string.
+ * Useful for building data URIs (favicons, og-images) outside of React.
+ */
+export function renderDadMarkSVG(props: Omit<DadMarkProps, 'className'> = {}): string {
+  const size = props.size ?? DEFAULTS.size;
+  const inner = dadMarkPaths(resolveOpts(props));
+  return `<svg viewBox="0 0 320 320" width="${size}" height="${size}" xmlns="http://www.w3.org/2000/svg">${inner}</svg>`;
+}
+
+/**
+ * React component rendering the DadMark inline.
+ *
+ * Shares geometry with `renderDadMarkSVG`. All content is generated from
+ * hardcoded geometry plus numeric/color props — no user input flows in,
+ * so injecting the inner markup is safe.
+ */
+export function DadMark(props: DadMarkProps) {
+  const size = props.size ?? DEFAULTS.size;
+  const inner = dadMarkPaths(resolveOpts(props));
+  return (
+    <svg
+      viewBox="0 0 320 320"
+      width={size}
+      height={size}
+      xmlns="http://www.w3.org/2000/svg"
+      className={props.className}
+      aria-hidden="true"
+      // SAFE: `inner` is built only from hardcoded geometry and the typed
+      // numeric/color props above — no untrusted strings reach this point.
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: inner }}
+    />
+  );
+}

--- a/packages/web/src/components/DadMark.tsx
+++ b/packages/web/src/components/DadMark.tsx
@@ -62,9 +62,7 @@ function dadMarkPaths(opts: Required<Omit<DadMarkProps, 'size' | 'className'>>):
   parts.push(`<path d="${hairPath}" fill="${ink}"/>`);
 
   // Face
-  parts.push(
-    `<circle cx="${cx}" cy="${cy}" r="94" fill="${skin}" stroke="${ink}" stroke-width="${strokeW}"/>`,
-  );
+  parts.push(`<circle cx="${cx}" cy="${cy}" r="94" fill="${skin}" stroke="${ink}" stroke-width="${strokeW}"/>`);
 
   // Hair re-clip on top of stroked face
   parts.push(`<path d="${hairPath}" fill="${ink}"/>`);
@@ -99,9 +97,7 @@ function dadMarkPaths(opts: Required<Omit<DadMarkProps, 'size' | 'className'>>):
 
   // Left lens
   if (glasses === 'round') {
-    parts.push(
-      `<circle cx="${cx - glassDX}" cy="${glassY}" r="26" fill="white" stroke="${ink}" stroke-width="6"/>`,
-    );
+    parts.push(`<circle cx="${cx - glassDX}" cy="${glassY}" r="26" fill="white" stroke="${ink}" stroke-width="6"/>`);
   } else if (glasses === 'rect') {
     parts.push(
       `<rect x="${cx - glassDX - lensW / 2}" y="${glassY - lensH / 2}" width="${lensW}" height="${lensH}" rx="${lensR}" fill="white" stroke="${ink}" stroke-width="6"/>`,
@@ -114,9 +110,7 @@ function dadMarkPaths(opts: Required<Omit<DadMarkProps, 'size' | 'className'>>):
 
   // Right lens
   if (glasses === 'round') {
-    parts.push(
-      `<circle cx="${cx + glassDX}" cy="${glassY}" r="26" fill="white" stroke="${ink}" stroke-width="6"/>`,
-    );
+    parts.push(`<circle cx="${cx + glassDX}" cy="${glassY}" r="26" fill="white" stroke="${ink}" stroke-width="6"/>`);
   } else if (glasses === 'rect') {
     parts.push(
       `<rect x="${cx + glassDX - lensW / 2}" y="${glassY - lensH / 2}" width="${lensW}" height="${lensH}" rx="${lensR}" fill="white" stroke="${ink}" stroke-width="6"/>`,

--- a/packages/web/src/components/GeneratingScreen.tsx
+++ b/packages/web/src/components/GeneratingScreen.tsx
@@ -1,4 +1,6 @@
 import { useReviewStore } from '../state/review-store';
+import { DadMark } from './DadMark';
+import { getAccentMeta } from '../lib/accents';
 
 type Props = {
   message: string;
@@ -7,16 +9,15 @@ type Props = {
 export function GeneratingScreen({ message }: Props) {
   const pr = useReviewStore((s) => s.pr);
   const files = useReviewStore((s) => s.files);
+  const accent = useReviewStore((s) => s.accent);
+  const { markBg } = getAccentMeta(accent);
 
   return (
     <main className="flex min-h-screen flex-col items-center justify-center bg-[var(--bg-page)] px-6">
       <div className="flex flex-col items-center gap-6 text-center">
-        <img
-          src="/diff-dad-mark.svg"
-          alt="Diff Dad"
-          className="h-16 w-16"
-          style={{ animation: 'generating-bob 2s ease-in-out infinite' }}
-        />
+        <div style={{ animation: 'generating-bob 2s ease-in-out infinite' }}>
+          <DadMark size={64} bg={markBg} shape="circle" showBadge={false} showWink />
+        </div>
 
         {pr && (
           <div className="space-y-1">

--- a/packages/web/src/components/Hunk.tsx
+++ b/packages/web/src/components/Hunk.tsx
@@ -329,7 +329,7 @@ function HunkLines({
       const hasThread = openLine === lineKey || lineComments.length > 0;
       return (
         <div key={lineKey}>
-          <CodeLine line={line} lineKey={lineKey} lang={lang} dimmed={dimmed} />
+          <CodeLine line={line} lineKey={lineKey} lang={lang} dimmed={dimmed} highlighterReady={highlighterReady} />
           {hasThread && (
             <CollapsibleThread
               comments={lineComments}
@@ -342,7 +342,7 @@ function HunkLines({
         </div>
       );
     },
-    [hunk.lines, file, hunkIndex, comments, normFile, clusterBots, openLine, setOpenLine, lang],
+    [hunk.lines, file, hunkIndex, comments, normFile, clusterBots, openLine, setOpenLine, lang, highlighterReady],
   );
 
   return (
@@ -367,7 +367,7 @@ export function Hunk({ file, hunk, isNewFile, hunkIndex, highlight }: Props) {
   const repoUrl = useReviewStore((s) => s.repoUrl);
   const headSha = useReviewStore((s) => s.pr?.headSha ?? null);
   const clusterBots = useReviewStore((s) => s.clusterBots);
-  useHighlighter();
+  const highlighterReady = useHighlighter();
   const lang = guessLang(file);
 
   const rangeStart = hunk.oldStart;

--- a/packages/web/src/components/Hunk.tsx
+++ b/packages/web/src/components/Hunk.tsx
@@ -43,7 +43,7 @@ function CollapsibleThread({
           boxShadow: 'inset 0 1px 0 var(--gray-a4), inset 0 -1px 0 var(--gray-a4)',
         }}
       >
-        <IconChat className="h-3.5 w-3.5" style={{ color: 'var(--purple-11)' }} />
+        <IconChat className="h-3.5 w-3.5 text-[var(--purple-11)]" />
         {count} {count === 1 ? 'comment' : 'comments'} — click to expand
       </button>
     );

--- a/packages/web/src/components/Hunk.tsx
+++ b/packages/web/src/components/Hunk.tsx
@@ -4,7 +4,6 @@ import type { DiffHunk, PRComment } from '../state/types';
 import { CodeLine } from './CodeLine';
 import { CommentThread } from './CommentThread';
 import { Comment } from './Comment';
-import { useHighlighter } from '../hooks/useHighlighter';
 import { guessLang } from '../lib/shiki';
 import { getAuthorInfo } from '../lib/authors';
 import { normalizePath } from '../lib/paths';
@@ -329,7 +328,7 @@ function HunkLines({
       const hasThread = openLine === lineKey || lineComments.length > 0;
       return (
         <div key={lineKey}>
-          <CodeLine line={line} lineKey={lineKey} lang={lang} dimmed={dimmed} highlighterReady={highlighterReady} />
+          <CodeLine line={line} lineKey={lineKey} lang={lang} dimmed={dimmed} />
           {hasThread && (
             <CollapsibleThread
               comments={lineComments}
@@ -342,7 +341,7 @@ function HunkLines({
         </div>
       );
     },
-    [hunk.lines, file, hunkIndex, comments, normFile, clusterBots, openLine, setOpenLine, lang, highlighterReady],
+    [hunk.lines, file, hunkIndex, comments, normFile, clusterBots, openLine, setOpenLine, lang],
   );
 
   return (
@@ -367,7 +366,6 @@ export function Hunk({ file, hunk, isNewFile, hunkIndex, highlight }: Props) {
   const repoUrl = useReviewStore((s) => s.repoUrl);
   const headSha = useReviewStore((s) => s.pr?.headSha ?? null);
   const clusterBots = useReviewStore((s) => s.clusterBots);
-  const highlighterReady = useHighlighter();
   const lang = guessLang(file);
 
   const rangeStart = hunk.oldStart;

--- a/packages/web/src/components/Splash.tsx
+++ b/packages/web/src/components/Splash.tsx
@@ -1,5 +1,8 @@
 import { useState } from 'react';
 import { copy } from '../lib/microcopy';
+import { DadMark } from './DadMark';
+import { getAccentMeta } from '../lib/accents';
+import { useReviewStore } from '../state/review-store';
 import { IconArrowRight } from './Icons';
 
 type Props = {
@@ -25,6 +28,8 @@ const STEPS: { num: number; text: string; code?: string }[] = [
 const CLI_COMMAND = 'dad review <pr-number>';
 
 export function Splash({ onContinue }: Props) {
+  const accent = useReviewStore((s) => s.accent);
+  const { markBg } = getAccentMeta(accent);
   const [copied, setCopied] = useState(false);
 
   async function handleCopy() {
@@ -57,16 +62,7 @@ export function Splash({ onContinue }: Props) {
           boxShadow: '0 1px 0 var(--gray-a4), 0 30px 80px -20px rgba(0,0,0,0.18)',
         }}
       >
-        <div
-          className="grid h-12 w-12 place-items-center rounded-[12px] text-white"
-          style={{
-            background: 'var(--purple-9)',
-            font: '800 22px var(--font-sans)',
-            marginBottom: 18,
-          }}
-        >
-          D
-        </div>
+        <DadMark size={48} bg={markBg} shape="circle" showBadge={false} />
         <div id="splash-title" className="text-[28px] font-bold tracking-[-0.02em] text-[var(--fg-1)]">
           Diff Dad
         </div>

--- a/packages/web/src/hooks/useNarrative.ts
+++ b/packages/web/src/hooks/useNarrative.ts
@@ -48,8 +48,7 @@ export function useNarrative() {
             const next: Partial<typeof useReviewStore extends { getState: () => infer S } ? S : never> = {};
             if (data.config.theme && !localStorage.getItem('diffdad.theme'))
               next.theme = data.config.theme as 'light' | 'dark' | 'auto';
-            if (data.config.accent && !localStorage.getItem('diffdad.accent'))
-              next.accent = data.config.accent as any;
+            if (data.config.accent && !localStorage.getItem('diffdad.accent')) next.accent = data.config.accent as any;
             if (data.config.storyStructure) next.storyStructure = data.config.storyStructure as any;
             if (data.config.layoutMode) next.layoutMode = data.config.layoutMode as any;
             if (data.config.displayDensity) next.displayDensity = data.config.displayDensity as any;

--- a/packages/web/src/hooks/useNarrative.ts
+++ b/packages/web/src/hooks/useNarrative.ts
@@ -46,7 +46,10 @@ export function useNarrative() {
           });
           if (data.config) {
             const next: Partial<typeof useReviewStore extends { getState: () => infer S } ? S : never> = {};
-            if (data.config.theme) next.theme = data.config.theme as 'light' | 'dark' | 'auto';
+            if (data.config.theme && !localStorage.getItem('diffdad.theme'))
+              next.theme = data.config.theme as 'light' | 'dark' | 'auto';
+            if (data.config.accent && !localStorage.getItem('diffdad.accent'))
+              next.accent = data.config.accent as any;
             if (data.config.storyStructure) next.storyStructure = data.config.storyStructure as any;
             if (data.config.layoutMode) next.layoutMode = data.config.layoutMode as any;
             if (data.config.displayDensity) next.displayDensity = data.config.displayDensity as any;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -161,6 +161,256 @@
   --blue-11: #95b3ee;
 }
 
+/* ── Accent themes ── */
+
+[data-accent='paprika'] {
+  --brand: #FF7A45;
+  --brand-hover: #E56A35;
+  --brand-soft: rgba(255, 122, 69, 0.1);
+  --purple-2: #fff5f0;
+  --purple-3: #ffe8dd;
+  --purple-4: #ffd9c7;
+  --purple-9: #FF7A45;
+  --purple-10: #E56A35;
+  --purple-11: #D65A25;
+  --purple-12: #7a2e0e;
+  --purple-a3: rgba(255, 122, 69, 0.12);
+  --purple-a4: rgba(255, 122, 69, 0.2);
+  --purple-a5: rgba(255, 122, 69, 0.28);
+  --purple-a8: rgba(255, 122, 69, 0.55);
+}
+
+.dark[data-accent='paprika'] {
+  --brand: #FF8A5C;
+  --brand-hover: #FFA07A;
+  --brand-soft: rgba(255, 138, 92, 0.14);
+  --purple-2: rgba(255, 138, 92, 0.1);
+  --purple-3: rgba(255, 138, 92, 0.18);
+  --purple-4: rgba(255, 138, 92, 0.26);
+  --purple-9: #FF8A5C;
+  --purple-10: #FFA07A;
+  --purple-11: #FFB899;
+  --purple-12: #ffe0d0;
+  --purple-a3: rgba(255, 138, 92, 0.18);
+  --purple-a4: rgba(255, 138, 92, 0.28);
+  --purple-a5: rgba(255, 138, 92, 0.36);
+  --purple-a8: rgba(255, 138, 92, 0.65);
+}
+
+[data-accent='tomato'] {
+  --brand: #E05E4B;
+  --brand-hover: #C94A38;
+  --brand-soft: rgba(224, 94, 75, 0.1);
+  --purple-2: #fff3f1;
+  --purple-3: #ffe3de;
+  --purple-4: #ffd2ca;
+  --purple-9: #E05E4B;
+  --purple-10: #C94A38;
+  --purple-11: #B8382A;
+  --purple-12: #6e1f14;
+  --purple-a3: rgba(224, 94, 75, 0.12);
+  --purple-a4: rgba(224, 94, 75, 0.2);
+  --purple-a5: rgba(224, 94, 75, 0.28);
+  --purple-a8: rgba(224, 94, 75, 0.55);
+}
+
+.dark[data-accent='tomato'] {
+  --brand: #EC6F5E;
+  --brand-hover: #F08878;
+  --brand-soft: rgba(236, 111, 94, 0.14);
+  --purple-2: rgba(236, 111, 94, 0.1);
+  --purple-3: rgba(236, 111, 94, 0.18);
+  --purple-4: rgba(236, 111, 94, 0.26);
+  --purple-9: #EC6F5E;
+  --purple-10: #F08878;
+  --purple-11: #F4A99E;
+  --purple-12: #fde0db;
+  --purple-a3: rgba(236, 111, 94, 0.18);
+  --purple-a4: rgba(236, 111, 94, 0.28);
+  --purple-a5: rgba(236, 111, 94, 0.36);
+  --purple-a8: rgba(236, 111, 94, 0.65);
+}
+
+[data-accent='forest'] {
+  --brand: #3F7D5C;
+  --brand-hover: #2E6A49;
+  --brand-soft: rgba(63, 125, 92, 0.1);
+  --purple-2: #edfaf3;
+  --purple-3: #d4f0e1;
+  --purple-4: #bee8d2;
+  --purple-9: #3F7D5C;
+  --purple-10: #2E6A49;
+  --purple-11: #256B42;
+  --purple-12: #143826;
+  --purple-a3: rgba(63, 125, 92, 0.12);
+  --purple-a4: rgba(63, 125, 92, 0.2);
+  --purple-a5: rgba(63, 125, 92, 0.28);
+  --purple-a8: rgba(63, 125, 92, 0.55);
+}
+
+.dark[data-accent='forest'] {
+  --brand: #4A9B70;
+  --brand-hover: #5DB882;
+  --brand-soft: rgba(74, 155, 112, 0.14);
+  --purple-2: rgba(74, 155, 112, 0.1);
+  --purple-3: rgba(74, 155, 112, 0.18);
+  --purple-4: rgba(74, 155, 112, 0.26);
+  --purple-9: #4A9B70;
+  --purple-10: #5DB882;
+  --purple-11: #7ECDA0;
+  --purple-12: #c8f0d8;
+  --purple-a3: rgba(74, 155, 112, 0.18);
+  --purple-a4: rgba(74, 155, 112, 0.28);
+  --purple-a5: rgba(74, 155, 112, 0.36);
+  --purple-a8: rgba(74, 155, 112, 0.65);
+}
+
+[data-accent='plum'] {
+  --brand: #7C5BA0;
+  --brand-hover: #6A4A8E;
+  --brand-soft: rgba(124, 91, 160, 0.1);
+  --purple-2: #f8f4fc;
+  --purple-3: #ede5f5;
+  --purple-4: #e0d4ee;
+  --purple-9: #7C5BA0;
+  --purple-10: #6A4A8E;
+  --purple-11: #5E3D82;
+  --purple-12: #321f48;
+  --purple-a3: rgba(124, 91, 160, 0.12);
+  --purple-a4: rgba(124, 91, 160, 0.2);
+  --purple-a5: rgba(124, 91, 160, 0.28);
+  --purple-a8: rgba(124, 91, 160, 0.55);
+}
+
+.dark[data-accent='plum'] {
+  --brand: #9474B8;
+  --brand-hover: #A88FCA;
+  --brand-soft: rgba(148, 116, 184, 0.14);
+  --purple-2: rgba(148, 116, 184, 0.1);
+  --purple-3: rgba(148, 116, 184, 0.18);
+  --purple-4: rgba(148, 116, 184, 0.26);
+  --purple-9: #9474B8;
+  --purple-10: #A88FCA;
+  --purple-11: #C4B0D9;
+  --purple-12: #ece4f5;
+  --purple-a3: rgba(148, 116, 184, 0.18);
+  --purple-a4: rgba(148, 116, 184, 0.28);
+  --purple-a5: rgba(148, 116, 184, 0.36);
+  --purple-a8: rgba(148, 116, 184, 0.65);
+}
+
+[data-accent='sky'] {
+  --brand: #4A8EC2;
+  --brand-hover: #3A7BAD;
+  --brand-soft: rgba(74, 142, 194, 0.1);
+  --purple-2: #eff6fc;
+  --purple-3: #d6e8f7;
+  --purple-4: #bddaf0;
+  --purple-9: #4A8EC2;
+  --purple-10: #3A7BAD;
+  --purple-11: #2D6B9A;
+  --purple-12: #173a56;
+  --purple-a3: rgba(74, 142, 194, 0.12);
+  --purple-a4: rgba(74, 142, 194, 0.2);
+  --purple-a5: rgba(74, 142, 194, 0.28);
+  --purple-a8: rgba(74, 142, 194, 0.55);
+}
+
+.dark[data-accent='sky'] {
+  --brand: #6AAAD6;
+  --brand-hover: #84BDE2;
+  --brand-soft: rgba(106, 170, 214, 0.14);
+  --purple-2: rgba(106, 170, 214, 0.1);
+  --purple-3: rgba(106, 170, 214, 0.18);
+  --purple-4: rgba(106, 170, 214, 0.26);
+  --purple-9: #6AAAD6;
+  --purple-10: #84BDE2;
+  --purple-11: #9DD0EE;
+  --purple-12: #d6ecf8;
+  --purple-a3: rgba(106, 170, 214, 0.18);
+  --purple-a4: rgba(106, 170, 214, 0.28);
+  --purple-a5: rgba(106, 170, 214, 0.36);
+  --purple-a8: rgba(106, 170, 214, 0.65);
+}
+
+[data-accent='dadcore'] {
+  --brand: #FF7A45;
+  --brand-hover: #E56A35;
+  --brand-soft: rgba(255, 122, 69, 0.1);
+  --purple-2: #fff5f0;
+  --purple-3: #ffe8dd;
+  --purple-4: #ffd9c7;
+  --purple-9: #FF7A45;
+  --purple-10: #E56A35;
+  --purple-11: #D65A25;
+  --purple-12: #7a2e0e;
+  --purple-a3: rgba(255, 122, 69, 0.12);
+  --purple-a4: rgba(255, 122, 69, 0.2);
+  --purple-a5: rgba(255, 122, 69, 0.28);
+  --purple-a8: rgba(255, 122, 69, 0.55);
+
+  --bg-page: #F4EFE6;
+  --bg-panel: #FFF6E6;
+  --bg-subtle: #FBF7EE;
+  --fg-1: #15233F;
+  --fg-2: #2D3A55;
+  --fg-3: #8A8579;
+  --border: rgba(21, 35, 63, 0.08);
+  --border-strong: rgba(21, 35, 63, 0.12);
+  --shadow-card: 0 1px 2px rgba(21, 35, 63, 0.06), 0 3px 6px -1px rgba(21, 35, 63, 0.1);
+  --shadow-elevated: 0 12px 24px -4px rgba(21, 35, 63, 0.18), 0 4px 8px -2px rgba(21, 35, 63, 0.1);
+  --gray-1: #faf8f4;
+  --gray-2: #f5f1ea;
+  --gray-3: #ece7dd;
+  --gray-4: #e3ddd2;
+  --gray-9: #8A8579;
+  --gray-11: #5c5649;
+  --gray-12: #15233F;
+  --gray-a3: rgba(21, 35, 63, 0.06);
+  --gray-a4: rgba(21, 35, 63, 0.09);
+  --gray-a5: rgba(21, 35, 63, 0.13);
+  --gray-a6: rgba(21, 35, 63, 0.16);
+}
+
+.dark[data-accent='dadcore'] {
+  --brand: #FF8A5C;
+  --brand-hover: #FFA07A;
+  --brand-soft: rgba(255, 138, 92, 0.14);
+  --purple-2: rgba(255, 138, 92, 0.1);
+  --purple-3: rgba(255, 138, 92, 0.18);
+  --purple-4: rgba(255, 138, 92, 0.26);
+  --purple-9: #FF8A5C;
+  --purple-10: #FFA07A;
+  --purple-11: #FFB899;
+  --purple-12: #ffe0d0;
+  --purple-a3: rgba(255, 138, 92, 0.18);
+  --purple-a4: rgba(255, 138, 92, 0.28);
+  --purple-a5: rgba(255, 138, 92, 0.36);
+  --purple-a8: rgba(255, 138, 92, 0.65);
+
+  --bg-page: #14202E;
+  --bg-panel: #1B2A3D;
+  --bg-subtle: #243549;
+  --fg-1: #FFF6E6;
+  --fg-2: #C9D2DF;
+  --fg-3: #8794A8;
+  --border: rgba(255, 246, 230, 0.08);
+  --border-strong: rgba(255, 246, 230, 0.12);
+  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.3), 0 3px 6px -1px rgba(0, 0, 0, 0.4);
+  --shadow-elevated: 0 12px 24px -4px rgba(0, 0, 0, 0.5), 0 4px 8px -2px rgba(0, 0, 0, 0.3);
+  --gray-1: #162030;
+  --gray-2: #1a2638;
+  --gray-3: #213040;
+  --gray-4: #283a4c;
+  --gray-9: #6b7b90;
+  --gray-11: #9baab8;
+  --gray-12: #FFF6E6;
+  --gray-a3: rgba(255, 246, 230, 0.06);
+  --gray-a4: rgba(255, 246, 230, 0.09);
+  --gray-a5: rgba(255, 246, 230, 0.13);
+  --gray-a6: rgba(255, 246, 230, 0.18);
+}
+
 html {
   font-size: 16px;
   -webkit-font-smoothing: antialiased;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -164,15 +164,15 @@
 /* ── Accent themes ── */
 
 [data-accent='paprika'] {
-  --brand: #FF7A45;
-  --brand-hover: #E56A35;
+  --brand: #ff7a45;
+  --brand-hover: #e56a35;
   --brand-soft: rgba(255, 122, 69, 0.1);
   --purple-2: #fff5f0;
   --purple-3: #ffe8dd;
   --purple-4: #ffd9c7;
-  --purple-9: #FF7A45;
-  --purple-10: #E56A35;
-  --purple-11: #D65A25;
+  --purple-9: #ff7a45;
+  --purple-10: #e56a35;
+  --purple-11: #d65a25;
   --purple-12: #7a2e0e;
   --purple-a3: rgba(255, 122, 69, 0.12);
   --purple-a4: rgba(255, 122, 69, 0.2);
@@ -181,15 +181,15 @@
 }
 
 .dark[data-accent='paprika'] {
-  --brand: #FF8A5C;
-  --brand-hover: #FFA07A;
+  --brand: #ff8a5c;
+  --brand-hover: #ffa07a;
   --brand-soft: rgba(255, 138, 92, 0.14);
   --purple-2: rgba(255, 138, 92, 0.1);
   --purple-3: rgba(255, 138, 92, 0.18);
   --purple-4: rgba(255, 138, 92, 0.26);
-  --purple-9: #FF8A5C;
-  --purple-10: #FFA07A;
-  --purple-11: #FFB899;
+  --purple-9: #ff8a5c;
+  --purple-10: #ffa07a;
+  --purple-11: #ffb899;
   --purple-12: #ffe0d0;
   --purple-a3: rgba(255, 138, 92, 0.18);
   --purple-a4: rgba(255, 138, 92, 0.28);
@@ -198,15 +198,15 @@
 }
 
 [data-accent='tomato'] {
-  --brand: #E05E4B;
-  --brand-hover: #C94A38;
+  --brand: #e05e4b;
+  --brand-hover: #c94a38;
   --brand-soft: rgba(224, 94, 75, 0.1);
   --purple-2: #fff3f1;
   --purple-3: #ffe3de;
   --purple-4: #ffd2ca;
-  --purple-9: #E05E4B;
-  --purple-10: #C94A38;
-  --purple-11: #B8382A;
+  --purple-9: #e05e4b;
+  --purple-10: #c94a38;
+  --purple-11: #b8382a;
   --purple-12: #6e1f14;
   --purple-a3: rgba(224, 94, 75, 0.12);
   --purple-a4: rgba(224, 94, 75, 0.2);
@@ -215,15 +215,15 @@
 }
 
 .dark[data-accent='tomato'] {
-  --brand: #EC6F5E;
-  --brand-hover: #F08878;
+  --brand: #ec6f5e;
+  --brand-hover: #f08878;
   --brand-soft: rgba(236, 111, 94, 0.14);
   --purple-2: rgba(236, 111, 94, 0.1);
   --purple-3: rgba(236, 111, 94, 0.18);
   --purple-4: rgba(236, 111, 94, 0.26);
-  --purple-9: #EC6F5E;
-  --purple-10: #F08878;
-  --purple-11: #F4A99E;
+  --purple-9: #ec6f5e;
+  --purple-10: #f08878;
+  --purple-11: #f4a99e;
   --purple-12: #fde0db;
   --purple-a3: rgba(236, 111, 94, 0.18);
   --purple-a4: rgba(236, 111, 94, 0.28);
@@ -232,15 +232,15 @@
 }
 
 [data-accent='forest'] {
-  --brand: #3F7D5C;
-  --brand-hover: #2E6A49;
+  --brand: #3f7d5c;
+  --brand-hover: #2e6a49;
   --brand-soft: rgba(63, 125, 92, 0.1);
   --purple-2: #edfaf3;
   --purple-3: #d4f0e1;
   --purple-4: #bee8d2;
-  --purple-9: #3F7D5C;
-  --purple-10: #2E6A49;
-  --purple-11: #256B42;
+  --purple-9: #3f7d5c;
+  --purple-10: #2e6a49;
+  --purple-11: #256b42;
   --purple-12: #143826;
   --purple-a3: rgba(63, 125, 92, 0.12);
   --purple-a4: rgba(63, 125, 92, 0.2);
@@ -249,15 +249,15 @@
 }
 
 .dark[data-accent='forest'] {
-  --brand: #4A9B70;
-  --brand-hover: #5DB882;
+  --brand: #4a9b70;
+  --brand-hover: #5db882;
   --brand-soft: rgba(74, 155, 112, 0.14);
   --purple-2: rgba(74, 155, 112, 0.1);
   --purple-3: rgba(74, 155, 112, 0.18);
   --purple-4: rgba(74, 155, 112, 0.26);
-  --purple-9: #4A9B70;
-  --purple-10: #5DB882;
-  --purple-11: #7ECDA0;
+  --purple-9: #4a9b70;
+  --purple-10: #5db882;
+  --purple-11: #7ecda0;
   --purple-12: #c8f0d8;
   --purple-a3: rgba(74, 155, 112, 0.18);
   --purple-a4: rgba(74, 155, 112, 0.28);
@@ -266,15 +266,15 @@
 }
 
 [data-accent='plum'] {
-  --brand: #7C5BA0;
-  --brand-hover: #6A4A8E;
+  --brand: #7c5ba0;
+  --brand-hover: #6a4a8e;
   --brand-soft: rgba(124, 91, 160, 0.1);
   --purple-2: #f8f4fc;
   --purple-3: #ede5f5;
   --purple-4: #e0d4ee;
-  --purple-9: #7C5BA0;
-  --purple-10: #6A4A8E;
-  --purple-11: #5E3D82;
+  --purple-9: #7c5ba0;
+  --purple-10: #6a4a8e;
+  --purple-11: #5e3d82;
   --purple-12: #321f48;
   --purple-a3: rgba(124, 91, 160, 0.12);
   --purple-a4: rgba(124, 91, 160, 0.2);
@@ -283,15 +283,15 @@
 }
 
 .dark[data-accent='plum'] {
-  --brand: #9474B8;
-  --brand-hover: #A88FCA;
+  --brand: #9474b8;
+  --brand-hover: #a88fca;
   --brand-soft: rgba(148, 116, 184, 0.14);
   --purple-2: rgba(148, 116, 184, 0.1);
   --purple-3: rgba(148, 116, 184, 0.18);
   --purple-4: rgba(148, 116, 184, 0.26);
-  --purple-9: #9474B8;
-  --purple-10: #A88FCA;
-  --purple-11: #C4B0D9;
+  --purple-9: #9474b8;
+  --purple-10: #a88fca;
+  --purple-11: #c4b0d9;
   --purple-12: #ece4f5;
   --purple-a3: rgba(148, 116, 184, 0.18);
   --purple-a4: rgba(148, 116, 184, 0.28);
@@ -300,15 +300,15 @@
 }
 
 [data-accent='sky'] {
-  --brand: #4A8EC2;
-  --brand-hover: #3A7BAD;
+  --brand: #4a8ec2;
+  --brand-hover: #3a7bad;
   --brand-soft: rgba(74, 142, 194, 0.1);
   --purple-2: #eff6fc;
   --purple-3: #d6e8f7;
   --purple-4: #bddaf0;
-  --purple-9: #4A8EC2;
-  --purple-10: #3A7BAD;
-  --purple-11: #2D6B9A;
+  --purple-9: #4a8ec2;
+  --purple-10: #3a7bad;
+  --purple-11: #2d6b9a;
   --purple-12: #173a56;
   --purple-a3: rgba(74, 142, 194, 0.12);
   --purple-a4: rgba(74, 142, 194, 0.2);
@@ -317,15 +317,15 @@
 }
 
 .dark[data-accent='sky'] {
-  --brand: #6AAAD6;
-  --brand-hover: #84BDE2;
+  --brand: #6aaad6;
+  --brand-hover: #84bde2;
   --brand-soft: rgba(106, 170, 214, 0.14);
   --purple-2: rgba(106, 170, 214, 0.1);
   --purple-3: rgba(106, 170, 214, 0.18);
   --purple-4: rgba(106, 170, 214, 0.26);
-  --purple-9: #6AAAD6;
-  --purple-10: #84BDE2;
-  --purple-11: #9DD0EE;
+  --purple-9: #6aaad6;
+  --purple-10: #84bde2;
+  --purple-11: #9dd0ee;
   --purple-12: #d6ecf8;
   --purple-a3: rgba(106, 170, 214, 0.18);
   --purple-a4: rgba(106, 170, 214, 0.28);
@@ -334,27 +334,27 @@
 }
 
 [data-accent='dadcore'] {
-  --brand: #FF7A45;
-  --brand-hover: #E56A35;
+  --brand: #ff7a45;
+  --brand-hover: #e56a35;
   --brand-soft: rgba(255, 122, 69, 0.1);
   --purple-2: #fff5f0;
   --purple-3: #ffe8dd;
   --purple-4: #ffd9c7;
-  --purple-9: #FF7A45;
-  --purple-10: #E56A35;
-  --purple-11: #D65A25;
+  --purple-9: #ff7a45;
+  --purple-10: #e56a35;
+  --purple-11: #d65a25;
   --purple-12: #7a2e0e;
   --purple-a3: rgba(255, 122, 69, 0.12);
   --purple-a4: rgba(255, 122, 69, 0.2);
   --purple-a5: rgba(255, 122, 69, 0.28);
   --purple-a8: rgba(255, 122, 69, 0.55);
 
-  --bg-page: #F4EFE6;
-  --bg-panel: #FFF6E6;
-  --bg-subtle: #FBF7EE;
-  --fg-1: #15233F;
-  --fg-2: #2D3A55;
-  --fg-3: #8A8579;
+  --bg-page: #f4efe6;
+  --bg-panel: #fff6e6;
+  --bg-subtle: #fbf7ee;
+  --fg-1: #15233f;
+  --fg-2: #2d3a55;
+  --fg-3: #8a8579;
   --border: rgba(21, 35, 63, 0.08);
   --border-strong: rgba(21, 35, 63, 0.12);
   --shadow-card: 0 1px 2px rgba(21, 35, 63, 0.06), 0 3px 6px -1px rgba(21, 35, 63, 0.1);
@@ -363,9 +363,9 @@
   --gray-2: #f5f1ea;
   --gray-3: #ece7dd;
   --gray-4: #e3ddd2;
-  --gray-9: #8A8579;
+  --gray-9: #8a8579;
   --gray-11: #5c5649;
-  --gray-12: #15233F;
+  --gray-12: #15233f;
   --gray-a3: rgba(21, 35, 63, 0.06);
   --gray-a4: rgba(21, 35, 63, 0.09);
   --gray-a5: rgba(21, 35, 63, 0.13);
@@ -373,27 +373,27 @@
 }
 
 .dark[data-accent='dadcore'] {
-  --brand: #FF8A5C;
-  --brand-hover: #FFA07A;
+  --brand: #ff8a5c;
+  --brand-hover: #ffa07a;
   --brand-soft: rgba(255, 138, 92, 0.14);
   --purple-2: rgba(255, 138, 92, 0.1);
   --purple-3: rgba(255, 138, 92, 0.18);
   --purple-4: rgba(255, 138, 92, 0.26);
-  --purple-9: #FF8A5C;
-  --purple-10: #FFA07A;
-  --purple-11: #FFB899;
+  --purple-9: #ff8a5c;
+  --purple-10: #ffa07a;
+  --purple-11: #ffb899;
   --purple-12: #ffe0d0;
   --purple-a3: rgba(255, 138, 92, 0.18);
   --purple-a4: rgba(255, 138, 92, 0.28);
   --purple-a5: rgba(255, 138, 92, 0.36);
   --purple-a8: rgba(255, 138, 92, 0.65);
 
-  --bg-page: #14202E;
-  --bg-panel: #1B2A3D;
+  --bg-page: #14202e;
+  --bg-panel: #1b2a3d;
   --bg-subtle: #243549;
-  --fg-1: #FFF6E6;
-  --fg-2: #C9D2DF;
-  --fg-3: #8794A8;
+  --fg-1: #fff6e6;
+  --fg-2: #c9d2df;
+  --fg-3: #8794a8;
   --border: rgba(255, 246, 230, 0.08);
   --border-strong: rgba(255, 246, 230, 0.12);
   --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.3), 0 3px 6px -1px rgba(0, 0, 0, 0.4);
@@ -404,7 +404,7 @@
   --gray-4: #283a4c;
   --gray-9: #6b7b90;
   --gray-11: #9baab8;
-  --gray-12: #FFF6E6;
+  --gray-12: #fff6e6;
   --gray-a3: rgba(255, 246, 230, 0.06);
   --gray-a4: rgba(255, 246, 230, 0.09);
   --gray-a5: rgba(255, 246, 230, 0.13);

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -5,8 +5,8 @@
   --color-brand: #6565ec;
   --color-brand-hover: #5151cd;
   --font-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
-  --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, monospace;
-  --font-serif: 'Source Serif 4', ui-serif, Georgia, serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
+  --font-serif: 'Fraunces', ui-serif, Georgia, serif;
 }
 
 :root {
@@ -183,12 +183,12 @@ body {
 .font-mono,
 pre,
 code {
-  font-family: 'IBM Plex Mono', ui-monospace, SFMono-Regular, monospace;
+  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
 }
 
 .font-serif,
 .font-em {
-  font-family: 'Source Serif 4', ui-serif, Georgia, serif;
+  font-family: 'Fraunces', ui-serif, Georgia, serif;
 }
 
 /* Animations */
@@ -330,7 +330,7 @@ code {
 
 /* Narration prose: serif italic em, bold b, mono code on gray chip */
 .narration-prose em {
-  font-family: 'Source Serif 4', ui-serif, Georgia, serif;
+  font-family: 'Fraunces', ui-serif, Georgia, serif;
   font-style: italic;
   font-size: 1.05em;
 }
@@ -340,7 +340,7 @@ code {
 }
 .narration-prose code {
   font:
-    400 0.9em 'IBM Plex Mono',
+    400 0.9em 'JetBrains Mono',
     ui-monospace,
     monospace;
   background: var(--gray-a3);

--- a/packages/web/src/lib/accents.ts
+++ b/packages/web/src/lib/accents.ts
@@ -1,0 +1,22 @@
+export type AccentId = 'classic' | 'paprika' | 'tomato' | 'forest' | 'plum' | 'sky' | 'dadcore';
+
+export type AccentMeta = {
+  id: AccentId;
+  name: string;
+  dot: string;
+  markBg: string;
+};
+
+export const ACCENTS: AccentMeta[] = [
+  { id: 'classic', name: 'Classic', dot: '#6565ec', markBg: '#6565ec' },
+  { id: 'paprika', name: 'Paprika', dot: '#FF7A45', markBg: '#FF7A45' },
+  { id: 'tomato', name: 'Tomato', dot: '#E05E4B', markBg: '#E05E4B' },
+  { id: 'forest', name: 'Forest', dot: '#3F7D5C', markBg: '#3F7D5C' },
+  { id: 'plum', name: 'Plum', dot: '#7C5BA0', markBg: '#7C5BA0' },
+  { id: 'sky', name: 'Sky', dot: '#4A8EC2', markBg: '#4A8EC2' },
+  { id: 'dadcore', name: 'Dadcore', dot: '#FF7A45', markBg: '#FF7A45' },
+];
+
+export function getAccentMeta(id: AccentId): AccentMeta {
+  return ACCENTS.find((a) => a.id === id) ?? ACCENTS[0];
+}

--- a/packages/web/src/state/review-store.ts
+++ b/packages/web/src/state/review-store.ts
@@ -11,6 +11,7 @@ import type {
   PRData,
   PRReview,
 } from './types';
+import type { AccentId } from '../lib/accents';
 
 type Theme = 'light' | 'dark' | 'auto';
 type Density = 'terse' | 'normal' | 'verbose';
@@ -22,6 +23,7 @@ type DisplayDensity = 'comfortable' | 'compact';
 
 export type BackendConfig = {
   theme?: Theme;
+  accent?: AccentId;
   storyStructure?: StoryStructure;
   layoutMode?: LayoutMode;
   displayDensity?: DisplayDensity;
@@ -42,6 +44,7 @@ type ReviewState = {
   drafts: DraftComment[];
   openLine: string | null;
   theme: Theme;
+  accent: AccentId;
   density: Density;
   chapterDensity: Record<string, Density>;
   view: View;
@@ -76,6 +79,7 @@ type ReviewState = {
   removeDraft: (id: string) => void;
   clearDrafts: () => void;
   setTheme: (theme: Theme) => void;
+  setAccent: (accent: AccentId) => void;
   setDensity: (d: Density) => void;
   setChapterDensity: (chapterKey: string, density: Density) => void;
   setView: (view: View) => void;
@@ -146,6 +150,7 @@ export const useReviewStore = create<ReviewState>((set) => ({
   drafts: [],
   openLine: null,
   theme: (localStorage.getItem('diffdad.theme') as Theme) || 'auto',
+  accent: (localStorage.getItem('diffdad.accent') as AccentId) || 'classic',
   density: 'normal',
   chapterDensity: {},
   view: 'story',
@@ -189,6 +194,7 @@ export const useReviewStore = create<ReviewState>((set) => ({
     };
     if (config) {
       if (config.theme && !localStorage.getItem('diffdad.theme')) next.theme = config.theme;
+      if (config.accent && !localStorage.getItem('diffdad.accent')) next.accent = config.accent;
       if (config.storyStructure) next.storyStructure = config.storyStructure;
       if (config.layoutMode) next.layoutMode = config.layoutMode;
       if (config.displayDensity) next.displayDensity = config.displayDensity;
@@ -251,6 +257,11 @@ export const useReviewStore = create<ReviewState>((set) => ({
   setTheme: (theme) => {
     localStorage.setItem('diffdad.theme', theme);
     set({ theme });
+  },
+
+  setAccent: (accent) => {
+    localStorage.setItem('diffdad.accent', accent);
+    set({ accent });
   },
 
   setDensity: (density) => set({ density }),


### PR DESCRIPTION
## Summary

- **7 accent themes**: Classic (default purple), Paprika, Tomato, Forest, Plum, Sky, and Dadcore (paprika + warm sand/cream foundation)
- **DadMark SVG component**: Dad face logo that adapts its color to the selected accent. Winking variant for positive moments (loading, approval celebration)
- **Dynamic favicon**: Renders the DadMark as a data-URI SVG favicon, updates live when accent changes
- **Font upgrade**: JetBrains Mono (code) and Fraunces (narrative prose) replace IBM Plex Mono and Source Serif 4
- **CLI config**: `dad config` now includes an accent picker, persisted and sent to the frontend

## Architecture

Theme system is two-dimensional — accent color × light/dark mode compose independently via `data-accent` attribute and `.dark` class on `<html>`. CSS custom property overrides handle the cascading. Dadcore accent additionally overrides foundation tokens (backgrounds, text, borders) for the full warm palette experience.

## Test plan

- [ ] `bun run build` succeeds
- [ ] `bun run test` — all 11 tests pass
- [ ] `bun run lint` — 0 warnings, 0 errors
- [ ] Open the app in browser, verify AppBar shows DadMark logo and accent picker dots
- [ ] Click each accent dot — brand colors, logo, and favicon update across the app
- [ ] Toggle light/dark/auto — each accent works in both modes
- [ ] Select Dadcore — backgrounds shift to warm sand/cream (light) or midnight navy (dark)
- [ ] Verify DadMark appears in GeneratingScreen (winking), ApprovalCelebration (winking), and Splash (regular)
- [ ] Run `dad config` — accent picker appears in Display section
- [ ] Verify JetBrains Mono loads for code, Fraunces loads for serif/narrative text