### PR TITLE
fix: enable horizontal scroll for long diff lines

### DIFF
--- a/packages/web/src/components/CodeLine.tsx
+++ b/packages/web/src/components/CodeLine.tsx
@@ -44,6 +44,7 @@ export function CodeLine({ line, lineKey, lang, dimmed }: Props) {
         gridTemplateColumns: '36px 36px 14px 1fr',
         background: rowBg,
         color: 'var(--gray-12)',
+        minWidth: 'max-content',
       }}
     >
       <span
@@ -73,12 +74,12 @@ export function CodeLine({ line, lineKey, lang, dimmed }: Props) {
       </span>
       {highlighted ? (
         <pre
-          className="m-0 overflow-x-hidden whitespace-pre px-3"
+          className="m-0 whitespace-pre px-3"
           style={{ lineHeight: '19px' }}
           dangerouslySetInnerHTML={{ __html: highlighted }}
         />
       ) : (
-        <pre className="m-0 overflow-x-hidden whitespace-pre px-3" style={{ lineHeight: '19px' }}>
+        <pre className="m-0 whitespace-pre px-3" style={{ lineHeight: '19px' }}>
           {line.content}
         </pre>
       )}

--- a/packages/web/src/components/Hunk.tsx
+++ b/packages/web/src/components/Hunk.tsx
@@ -330,13 +330,15 @@ function HunkLines({
         <div key={lineKey}>
           <CodeLine line={line} lineKey={lineKey} lang={lang} dimmed={dimmed} />
           {hasThread && (
-            <CollapsibleThread
-              comments={lineComments}
-              file={file}
-              lineNumber={line.lineNumber.new}
-              isNewThread={openLine === lineKey && lineComments.length === 0}
-              onClose={() => (openLine === lineKey ? setOpenLine(null) : undefined)}
-            />
+            <div className="sticky left-0" style={{ width: '100cqw' }}>
+              <CollapsibleThread
+                comments={lineComments}
+                file={file}
+                lineNumber={line.lineNumber.new}
+                isNewThread={openLine === lineKey && lineComments.length === 0}
+                onClose={() => (openLine === lineKey ? setOpenLine(null) : undefined)}
+              />
+            </div>
           )}
         </div>
       );
@@ -345,7 +347,7 @@ function HunkLines({
   );
 
   return (
-    <div>
+    <div style={{ minWidth: 'max-content' }}>
       {initialGroups.map((group, gi) => {
         if (group.kind === 'lines') {
           return group.indices.map((i) => renderLine(i, false));
@@ -353,7 +355,11 @@ function HunkLines({
         if (expandedFolds.has(gi)) {
           return group.indices.map((i) => renderLine(i, true));
         }
-        return <FoldedLines key={`fold-${gi}`} count={group.count} onExpand={() => expandFold(gi)} />;
+        return (
+          <div key={`fold-${gi}`} className="sticky left-0" style={{ width: '100cqw' }}>
+            <FoldedLines count={group.count} onExpand={() => expandFold(gi)} />
+          </div>
+        );
       })}
     </div>
   );
@@ -451,17 +457,19 @@ export function Hunk({ file, hunk, isNewFile, hunkIndex, highlight }: Props) {
         </div>
       </div>
       {clusterBots && botComments.length > 0 && <BotCluster comments={botComments} />}
-      <HunkLines
-        file={file}
-        hunk={hunk}
-        hunkIndex={hunkIndex}
-        lang={lang}
-        highlight={highlight}
-        comments={comments}
-        openLine={openLine}
-        setOpenLine={setOpenLine}
-        clusterBots={clusterBots}
-      />
+      <div className="overflow-x-auto" style={{ containerType: 'inline-size' }}>
+        <HunkLines
+          file={file}
+          hunk={hunk}
+          hunkIndex={hunkIndex}
+          lang={lang}
+          highlight={highlight}
+          comments={comments}
+          openLine={openLine}
+          setOpenLine={setOpenLine}
+          clusterBots={clusterBots}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Fixes #6

## Summary
- Long lines in diff hunks were clipped with no way to side-scroll. The `<pre>` had `overflow-x-hidden` and the hunk wrapper had `overflow-hidden`, leaving nowhere for horizontal scroll to live.
- Scoped a horizontal scroll container to the hunk's code area only — file header and bot cluster stay anchored.
- Code rows get `min-width: max-content` so they extend to fit content; comment threads and fold buttons use `position: sticky; left: 0` with `width: 100cqw` (via `container-type: inline-size` on the scroll container) so they stay pinned to the viewport's left edge during horizontal scroll instead of sliding off.

## Test plan
- [ ] Open a PR with long lines, confirm horizontal scrollbar appears on the hunk's code area
- [ ] Scroll right — verify file header and bot cluster stay put
- [ ] Scroll right on a hunk with inline comments — verify the comment thread stays pinned to the left edge
- [ ] Scroll right on a hunk with folded lines — verify the "X lines hidden" button stays pinned
- [ ] Verify short lines still render normally (no scrollbar, no layout shift)