### PR TITLE
feat(cli): configurable default CLI and per-CLI model

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -261,7 +261,7 @@ async function reviewCommand(prArg: string | undefined): Promise<number> {
 
   if (!cached) {
     const withCli = Bun.argv.find((f) => f.startsWith('--with='))?.split('=')[1];
-    const providerHint = withCli ?? config.aiProvider ?? 'claude';
+    const providerHint = withCli ?? config.aiProvider ?? config.defaultCli ?? 'claude';
     const waitJoke = DAD_JOKES[Math.floor(Math.random() * DAD_JOKES.length)];
     console.log(
       `  ${a.yellow}Generating narrative${a.reset} ${a.gray}via${a.reset} ${a.cyan}${providerHint}${a.reset}`,

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -6,6 +6,15 @@ import { resolveGitHubToken } from './auth';
 
 export type AiProvider = 'anthropic' | 'openai' | 'openai-compatible' | 'ollama';
 
+export type LocalCli = 'claude' | 'codex' | 'pi';
+export const LOCAL_CLIS: readonly LocalCli[] = ['claude', 'codex', 'pi'] as const;
+
+export const DEFAULT_CLI_MODELS: Readonly<Record<LocalCli, string>> = {
+  claude: 'sonnet',
+  codex: '',
+  pi: '',
+};
+
 export type StoryStructure = 'chapters' | 'linear' | 'outline';
 export type LayoutMode = 'toc' | 'linear';
 export type DisplayDensity = 'comfortable' | 'compact';
@@ -19,6 +28,8 @@ export interface DiffDadConfig {
   aiApiKey?: string;
   aiModel?: string;
   aiBaseUrl?: string;
+  defaultCli?: LocalCli;
+  cliModels?: Partial<Record<LocalCli, string>>;
   storyStructure?: StoryStructure;
   layoutMode?: LayoutMode;
   displayDensity?: DisplayDensity;
@@ -170,12 +181,42 @@ export async function runConfig(): Promise<number> {
     let aiApiKey: string | undefined = existing.aiApiKey;
     let aiBaseUrl: string | undefined = existing.aiBaseUrl;
     let aiModel: string | undefined = existing.aiModel;
+    let defaultCli: LocalCli | undefined = existing.defaultCli;
+    let cliModels: Partial<Record<LocalCli, string>> | undefined = existing.cliModels;
 
     if (useClaudeCli) {
-      process.stdout.write(`\n  ${c.green}✓${c.reset} Using local CLI ${c.dim}(claude → codex → pi)${c.reset}\n`);
+      process.stdout.write(`\n  ${c.green}✓${c.reset} Using local CLI\n`);
       aiApiKey = undefined;
       aiBaseUrl = undefined;
       aiModel = undefined;
+
+      defaultCli = await pickOne(
+        ask,
+        'preferred CLI',
+        [
+          { value: 'claude' as LocalCli, display: 'claude' },
+          { value: 'codex' as LocalCli, display: 'codex' },
+          { value: 'pi' as LocalCli, display: 'pi' },
+        ],
+        existing.defaultCli ?? 'claude',
+      );
+
+      const updatedModels: Partial<Record<LocalCli, string>> = { ...existing.cliModels };
+      for (const cli of LOCAL_CLIS) {
+        const fallback = DEFAULT_CLI_MODELS[cli];
+        const currentModel = existing.cliModels?.[cli] ?? fallback;
+        const display = currentModel.length > 0 ? currentModel : `${cli} default`;
+        const answer = await ask(`  ${c.dim}${cli} model${c.reset} ${c.gray}(${display})${c.reset}: `);
+        if (answer.length === 0) {
+          if (currentModel.length > 0) updatedModels[cli] = currentModel;
+          else delete updatedModels[cli];
+        } else if (answer === '-' || answer.toLowerCase() === 'default') {
+          delete updatedModels[cli];
+        } else {
+          updatedModels[cli] = answer;
+        }
+      }
+      cliModels = Object.keys(updatedModels).length > 0 ? updatedModels : undefined;
     } else if (provider) {
       const defaults = PROVIDER_DEFAULTS[provider];
       process.stdout.write('\n');
@@ -303,6 +344,10 @@ export async function runConfig(): Promise<number> {
       delete next.aiApiKey;
       delete next.aiBaseUrl;
       delete next.aiModel;
+      if (defaultCli) next.defaultCli = defaultCli;
+      else delete next.defaultCli;
+      if (cliModels) next.cliModels = cliModels;
+      else delete next.cliModels;
     } else {
       if (aiApiKey !== undefined) next.aiApiKey = aiApiKey;
       else delete next.aiApiKey;

--- a/packages/cli/src/narrative/engine.ts
+++ b/packages/cli/src/narrative/engine.ts
@@ -3,7 +3,7 @@ import { generateText } from 'ai';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
 import type { LanguageModelV1 } from 'ai';
-import type { DiffDadConfig } from '../config';
+import { DEFAULT_CLI_MODELS, LOCAL_CLIS, type DiffDadConfig, type LocalCli } from '../config';
 import type { DiffFile, PRMetadata } from '../github/types';
 import { buildNarrativePrompt, type PreviousNarrativeContext } from './prompt';
 import type { NarrativeResponse } from './types';
@@ -88,51 +88,73 @@ export function setCliOverride(cli: string) {
   cliOverride = cli;
 }
 
-async function callCodex(system: string, user: string): Promise<AiResult> {
+function resolveCliModel(cli: LocalCli, config: DiffDadConfig): string | undefined {
+  const envOverride = process.env[`DIFFDAD_${cli.toUpperCase()}_MODEL`];
+  if (envOverride && envOverride.length > 0) return envOverride;
+  const fromConfig = config.cliModels?.[cli];
+  if (fromConfig && fromConfig.length > 0) return fromConfig;
+  const fallback = DEFAULT_CLI_MODELS[cli];
+  return fallback.length > 0 ? fallback : undefined;
+}
+
+async function callClaude(system: string, user: string, config: DiffDadConfig): Promise<AiResult> {
+  const prompt = `${system}\n\n---\n\n${user}`;
+  const args = ['claude', '-p', '--output-format', 'text'];
+  const model = resolveCliModel('claude', config);
+  if (model) args.push('--model', model);
+  const r = await spawnCli(args, prompt);
+  return { ...r, provider: model ? `claude (${model})` : 'claude' };
+}
+
+async function callPi(system: string, user: string, config: DiffDadConfig): Promise<AiResult> {
+  const args = ['pi', '-p', '--system-prompt', system, '--no-tools'];
+  const model = resolveCliModel('pi', config);
+  if (model) args.push('--model', model);
+  const r = await spawnCli(args, user);
+  return { ...r, provider: model ? `pi (${model})` : 'pi' };
+}
+
+async function callCodex(system: string, user: string, config: DiffDadConfig): Promise<AiResult> {
   const prompt = `${system}\n\n---\n\n${user}`;
   const tmpFile = `/tmp/diffdad-codex-${Date.now()}.txt`;
+  const args = ['codex', 'exec', '--skip-git-repo-check', '--ignore-rules', '-o', tmpFile];
+  const model = resolveCliModel('codex', config);
+  if (model) args.push('--model', model);
   try {
-    const r = await spawnCli(['codex', 'exec', '--skip-git-repo-check', '--ignore-rules', '-o', tmpFile], prompt);
+    const r = await spawnCli(args, prompt);
     const output = await Bun.file(tmpFile)
       .text()
       .catch(() => r.text);
-    return { text: output, truncated: false, provider: 'codex' };
+    return { text: output, truncated: false, provider: model ? `codex (${model})` : 'codex' };
   } finally {
     rm(tmpFile, { force: true }).catch(() => {});
   }
 }
 
-async function callLocalCli(system: string, user: string): Promise<AiResult> {
-  const prompt = `${system}\n\n---\n\n${user}`;
+async function callByCli(cli: LocalCli, system: string, user: string, config: DiffDadConfig): Promise<AiResult> {
+  if (cli === 'claude') return callClaude(system, user, config);
+  if (cli === 'pi') return callPi(system, user, config);
+  return callCodex(system, user, config);
+}
+
+async function callLocalCli(system: string, user: string, config: DiffDadConfig): Promise<AiResult> {
   const forced = cliOverride ?? process.env.DIFFDAD_CLI;
 
   if (forced) {
-    if (forced === 'pi') {
-      const r = await spawnCli(['pi', '-p', '--system-prompt', system, '--no-tools'], user);
-      return { ...r, provider: 'pi' };
+    if (!LOCAL_CLIS.includes(forced as LocalCli)) {
+      throw new Error(`Unknown --with value: "${forced}". Use "claude", "codex", or "pi".`);
     }
-    if (forced === 'claude') {
-      const r = await spawnCli(['claude', '-p', '--output-format', 'text'], prompt);
-      return { ...r, provider: 'claude' };
-    }
-    if (forced === 'codex') {
-      return callCodex(system, user);
-    }
-    throw new Error(`Unknown --with value: "${forced}". Use "claude", "codex", or "pi".`);
+    return callByCli(forced as LocalCli, system, user, config);
   }
 
-  if (await whichExists('claude')) {
-    const r = await spawnCli(['claude', '-p', '--output-format', 'text'], prompt);
-    return { ...r, provider: 'claude' };
-  }
+  const order: LocalCli[] = config.defaultCli
+    ? [config.defaultCli, ...LOCAL_CLIS.filter((c) => c !== config.defaultCli)]
+    : [...LOCAL_CLIS];
 
-  if (await whichExists('codex')) {
-    return callCodex(system, user);
-  }
-
-  if (await whichExists('pi')) {
-    const r = await spawnCli(['pi', '-p', '--system-prompt', system, '--no-tools'], user);
-    return { ...r, provider: 'pi' };
+  for (const cli of order) {
+    if (await whichExists(cli)) {
+      return callByCli(cli, system, user, config);
+    }
   }
 
   throw new Error(
@@ -147,11 +169,11 @@ export async function callAi(
   maxTokens?: number,
 ): Promise<AiResult> {
   if (cliOverride) {
-    return callLocalCli(system, user);
+    return callLocalCli(system, user, config);
   }
 
   if (!hasConfiguredProvider(config)) {
-    return callLocalCli(system, user);
+    return callLocalCli(system, user, config);
   }
 
   const provider = config.aiProvider ?? 'anthropic';


### PR DESCRIPTION
## Summary
- Adds `defaultCli` (`claude` | `codex` | `pi`) to `DiffDadConfig` to override the auto-detect order.
- Adds `cliModels` for per-CLI model overrides; defaults `claude` to `sonnet` so out-of-the-box narrative generation is ~2-3× faster than Opus with negligible quality loss for this structured-output task.
- Each CLI invocation now passes `--model` when a model is resolved. Resolution order: `DIFFDAD_<CLI>_MODEL` env > `config.cliModels.<cli>` > built-in default.
- `dad config` prompts for preferred CLI + each CLI's model when local-CLI mode is selected; entering `-` or `default` clears an override.

## Test plan
- [ ] `bun run test` passes (11/11 locally)
- [ ] `bun run lint` clean
- [ ] `bun run build` succeeds
- [ ] `dad config` round-trips defaultCli + cliModels correctly
- [ ] `dad <pr>` with no config uses claude+sonnet
- [ ] `dad --with=codex <pr>` still forces codex regardless of config
- [ ] `DIFFDAD_CLAUDE_MODEL=opus dad <pr>` overrides config model