### PR TITLE
fix: allow commenting on removed lines (closes #7)

### DIFF
--- a/packages/cli/src/github/client.ts
+++ b/packages/cli/src/github/client.ts
@@ -284,7 +284,7 @@ export class GitHubClient {
     number: number,
     event: 'COMMENT' | 'APPROVE' | 'REQUEST_CHANGES',
     body?: string,
-    comments?: { path: string; line: number; body: string }[],
+    comments?: { path: string; line: number; body: string; side?: 'LEFT' | 'RIGHT' }[],
   ): Promise<void> {
     await this.fetch(`/repos/${owner}/${repo}/pulls/${number}/reviews`, {
       method: 'POST',

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -399,7 +399,11 @@ export function createServer(ctx: ServerContext) {
   });
 
   app.post('/api/review', async (c) => {
-    let payload: { event?: string; body?: string; comments?: { path: string; line: number; body: string }[] };
+    let payload: {
+      event?: string;
+      body?: string;
+      comments?: { path: string; line: number; body: string; side?: 'LEFT' | 'RIGHT' }[];
+    };
     try {
       payload = (await c.req.json()) as typeof payload;
     } catch {

--- a/packages/web/src/components/CodeLine.tsx
+++ b/packages/web/src/components/CodeLine.tsx
@@ -83,7 +83,7 @@ export function CodeLine({ line, lineKey, lang, dimmed }: Props) {
           {line.content}
         </pre>
       )}
-      {line.lineNumber.new !== undefined && (
+      {(line.lineNumber.new !== undefined || line.lineNumber.old !== undefined) && (
         <button
           type="button"
           aria-label="Comment on line"

--- a/packages/web/src/components/CommentThread.tsx
+++ b/packages/web/src/components/CommentThread.tsx
@@ -9,6 +9,7 @@ type Props = {
   comments: PRComment[];
   path?: string;
   line?: number;
+  side?: 'LEFT' | 'RIGHT';
   chapterIndex?: number;
   inReplyToId?: number;
   onClose?: () => void;
@@ -58,7 +59,7 @@ function draftKeyFor(path?: string, line?: number, chapterIndex?: number): strin
   return null;
 }
 
-export function CommentThread({ comments, path, line, chapterIndex, inReplyToId, onClose, autoFocus }: Props) {
+export function CommentThread({ comments, path, line, side, chapterIndex, inReplyToId, onClose, autoFocus }: Props) {
   const { postComment } = useComments();
   const drafts = useReviewStore((s) => s.drafts);
   const addDraft = useReviewStore((s) => s.addDraft);
@@ -133,6 +134,7 @@ export function CommentThread({ comments, path, line, chapterIndex, inReplyToId,
       body: trimmed,
       path,
       line,
+      side,
       chapterIndex,
     });
     setDraftSavedAt(Date.now());
@@ -153,7 +155,7 @@ export function CommentThread({ comments, path, line, chapterIndex, inReplyToId,
     setSubmitting(true);
     setError(null);
     try {
-      await postComment(trimmed, { path, line, inReplyToId: replyTarget });
+      await postComment(trimmed, { path, line, side, inReplyToId: replyTarget });
       setBody('');
       clearDraftForKey();
       onClose?.();

--- a/packages/web/src/components/Hunk.tsx
+++ b/packages/web/src/components/Hunk.tsx
@@ -21,12 +21,14 @@ function CollapsibleThread({
   comments,
   file,
   lineNumber,
+  side,
   isNewThread,
   onClose,
 }: {
   comments: PRComment[];
   file: string;
   lineNumber: number | undefined;
+  side: 'LEFT' | 'RIGHT';
   isNewThread: boolean;
   onClose: () => void;
 }) {
@@ -65,7 +67,14 @@ function CollapsibleThread({
           Collapse {count} {count === 1 ? 'comment' : 'comments'}
         </button>
       )}
-      <CommentThread comments={comments} path={file} line={lineNumber} onClose={onClose} autoFocus={isNewThread} />
+      <CommentThread
+        comments={comments}
+        path={file}
+        line={lineNumber}
+        side={side}
+        onClose={onClose}
+        autoFocus={isNewThread}
+      />
     </div>
   );
 }
@@ -342,7 +351,8 @@ function HunkLines({
               <CollapsibleThread
                 comments={lineComments}
                 file={file}
-                lineNumber={line.lineNumber.new}
+                lineNumber={line.type === 'remove' ? line.lineNumber.old : line.lineNumber.new}
+                side={line.type === 'remove' ? 'LEFT' : 'RIGHT'}
                 isNewThread={openLine === lineKey && lineComments.length === 0}
                 onClose={() => (openLine === lineKey ? setOpenLine(null) : undefined)}
               />

--- a/packages/web/src/state/review-store.ts
+++ b/packages/web/src/state/review-store.ts
@@ -127,14 +127,16 @@ function loadDrafts(prNumber: number): DraftComment[] {
   return [];
 }
 
-type InlineComment = { path: string; line: number; body: string };
+type InlineComment = { path: string; line: number; body: string; side?: 'LEFT' | 'RIGHT' };
 
 function isSubmittableDraft(d: DraftComment): d is DraftComment & { path: string; line: number } {
   return !!d.path && d.line !== undefined;
 }
 
 export function pendingReviewComments(drafts: DraftComment[]): InlineComment[] {
-  return drafts.filter(isSubmittableDraft).map((d) => ({ path: d.path, line: d.line, body: d.body }));
+  return drafts
+    .filter(isSubmittableDraft)
+    .map((d) => ({ path: d.path, line: d.line, body: d.body, side: d.side }));
 }
 
 export const useReviewStore = create<ReviewState>((set) => ({

--- a/packages/web/src/state/types.ts
+++ b/packages/web/src/state/types.ts
@@ -100,6 +100,7 @@ export type DraftComment = {
   body: string;
   path?: string;
   line?: number;
+  side?: 'LEFT' | 'RIGHT';
   chapterIndex?: number;
 };
 


### PR DESCRIPTION
## Summary
- Removed lines were uncommentable because the inline "+" button gated on `line.lineNumber.new !== undefined` — removed lines only carry `old`. Not an API limitation: GitHub's review-comments API supports this via `side: 'LEFT'`, and the backend already wired `side` end-to-end.
- Gate the button on either `old` or `new` being present, and thread `side: 'LEFT'` (with the old-side line number) through `CommentThread` → `useComments` → `/api/comments`, plus through drafts and the batched `/api/review` submit path.
- Display-side handling for incoming `LEFT` comments was already correct (`Hunk.tsx` resolves comments via `ln.old === c.line` when `side === 'LEFT'`).

## Test plan
- [ ] `bun run build && bun packages/cli/src/cli.ts review <owner>/<repo>#<n>` on a PR with deletions
- [ ] Click "+" on a `−` line, post a comment, confirm it appears on GitHub anchored to the deleted line
- [ ] Save a draft on a removed line, submit a batched review, confirm `side: LEFT` round-trips
- [ ] Existing context/added-line commenting still defaults to `RIGHT`