### PR TITLE
feat: `dad watch` — narrate your branch as you go

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <h1 align="center">Diff Dad</h1>
 
 <p align="center">
-  GitHub PRs as narrated stories.<br/>
-  <code>dad 139</code> turns a file-by-file diff into a semantic walkthrough with AI-generated chapters, inline comments, and live sync.
+  GitHub PRs as narrated stories. Your local branch as a live one.<br/>
+  <code>dad 139</code> turns a PR diff into a semantic walkthrough with AI-generated chapters, inline comments, and live sync. <code>dad watch</code> does the same for the branch you're working on, before you ever open a PR.
 </p>
 
 ## Install
@@ -39,6 +39,7 @@ Requires [Bun](https://bun.sh) when building from source. The Homebrew install i
 ```sh
 dad <pr>                     # Open a PR as a narrated story
 dad review <pr>              # Same as above (explicit subcommand)
+dad watch [branch]           # Narrate your in-progress branch (no GitHub required)
 dad config                   # Configure AI provider, GitHub token, display settings
 dad cache clear              # Clear cached narratives
 dad --version                # Print version
@@ -48,6 +49,7 @@ Flags (can go in any position):
 
 ```sh
 --with=claude|pi             # Force a specific AI CLI
+--base <ref>                 # Watch mode: override base ref (default: origin/HEAD)
 --no-cache                   # Regenerate narrative even if cached
 --no-open                    # Don't auto-open the browser
 --port=3000                  # Use a specific port
@@ -61,7 +63,23 @@ owner/repo#123
 139                          # bare number — infers repo from git remote
 ```
 
-The CLI fetches the PR diff, generates a semantic narrative, and opens a local web UI in your browser.
+The CLI fetches the PR diff (or local branch diff in watch mode), generates a semantic narrative, and opens a local web UI in your browser.
+
+### Watch your branch
+
+`dad watch` is the local-branch counterpart to `dad <pr>`. It's built for the awkward modern workflow where an agent produced a lot of the code and you need to catch up on what was built before peer review.
+
+```sh
+dad watch                    # narrate the current branch vs origin/HEAD (or main)
+dad watch some-branch        # watch a different branch
+dad watch --base develop     # override the base ref
+```
+
+When you run it, you immediately see a **branch skeleton** — no LLM wait — with totals, touched directories, file categorization (tests / config / schema / migration / docs / public-api / source), and the most-changed files. In the background, Dad generates a **whole-branch narrative** that explains what the branch *does* — the feature it now describes, not just the sequence of edits.
+
+Click a commit chip in the timeline to drill into a single commit. New commit lands? The skeleton refreshes and the whole-branch story regenerates. Rebase or amend? Orphaned narratives drop out automatically.
+
+Watch mode is read-only and offline — no GitHub API calls, no comments posted, nothing written back to the repo. Cached at `~/.cache/diffdad/watch/`, keyed by `(baseSha, headSha)` for the whole-branch view.
 
 ## How It Works
 
@@ -96,7 +114,7 @@ Diff Dad needs a GitHub token to fetch PR data and post comments. It checks, in 
 
 ### Caching
 
-Narratives are cached at `~/.cache/diffdad/` keyed by `{owner}-{repo}-{number}-{sha}`. Same commit = instant reload. Use `--no-cache` to regenerate, or `dad cache clear` to wipe all cached narratives.
+PR-mode narratives are cached at `~/.cache/diffdad/` keyed by `{owner}-{repo}-{number}-{sha}`. Watch-mode narratives live under `~/.cache/diffdad/watch/`, keyed by repo fingerprint plus `(baseSha, headSha)` for the whole-branch view and per-SHA for individual commits. Same SHA = instant reload. Use `--no-cache` to regenerate (PR mode), or `dad cache clear` to wipe everything.
 
 ## Features
 
@@ -111,6 +129,12 @@ Review comments from GitHub appear inline next to the relevant code lines. Comme
 ### Live Sync
 
 An SSE connection polls GitHub every 10 seconds. New comments, CI status changes, and check runs appear in real time. Comments you post are broadcast instantly via the server — no waiting for the next poll.
+
+In watch mode, SSE pushes branch updates instead — new commits, regenerated whole-branch narratives, freshly-narrated commits — driven by a 2-second poll of `git rev-parse <branch>` instead of the GitHub API.
+
+### Branch Skeleton (Watch Mode)
+
+Before any model call returns, watch mode renders a local skeleton: totals, by-category file counts (tests / config / schema / migration / docs / public-api / source), top touched directories, and most-changed files. It's the cheap-and-immediate context layer — useful while the LLM is still thinking, and a sanity check that you're looking at the right diff.
 
 ### Story Controls
 

--- a/docs/dad-watch.md
+++ b/docs/dad-watch.md
@@ -4,15 +4,20 @@
 
 Diff Dad already does a good job turning *other people's* PRs into narrated stories. The problem this PR addresses is the symmetric one: **reviewing your own in-progress work**, especially when most of that work was written by an AI agent.
 
-The honest observation that motivated this PR was that reviewing your own agent's code is a tenuous activity. When Claude (or Cursor, or Codex) writes 80% of a feature, the human's review pass tends to skim — the code "looks right," it compiles, the tests pass, and confirmation bias does the rest. Bugs slip through that a fresh reviewer would catch in five seconds. By the time the PR opens, the author is no longer a fresh reviewer of their own work, and the actual reviewer is now the second person to nod at the same code instead of the first to scrutinize it.
+The honest observation that motivated this PR was that reviewing your own agent's code is a tenuous activity. When Claude (or Cursor, or Codex) writes 80% of a feature, the human's review pass tends to skim — the code "looks right," it compiles, the tests pass, and confirmation bias does the rest. Bugs slip through that a fresh reviewer would catch in five seconds. Worse, in a long agent-driven session, the human often *doesn't actually know* what the agent built in detail: they prompted, the agent worked, they nodded at the result. By the time the PR opens, the author is no longer a fresh reviewer of their own work — they're a half-informed observer of work that was mostly done without them.
 
-The pitch for `dad watch` is simple: **be the fresh reviewer your agent's work needs, before the PR opens.** As you commit, Dad narrates each commit through a "scrutinize" lens — not "here's what you did, great job" but "here's what you did, and here's what a senior reviewer would push back on, what tests are missing, what error paths aren't handled, what looks subtle and risky." Optionally, on demand, you can fold the whole branch into a single coherent story to see how the feature reads end-to-end.
+`dad watch` is meant to address both halves of that:
+
+1. **Help you understand what's being built.** As each commit lands, Dad narrates it in plain prose: what changed at the behavioral level, what consequences that has, what subtle assumptions are baked in. This is the *comprehension* layer — you stop being a half-informed observer and become someone who actually knows what's in their feature. You can't review what you can't articulate; this gets you to the point where you could.
+2. **Scrutinize what was built.** On top of the comprehension, the scrutinize lens explicitly asks "what would a senior reviewer push back on, what tests are missing, what error paths aren't handled, what looks subtle and risky." This is the *review* layer — and it works precisely because the comprehension layer made the change legible enough to actually critique.
+
+These aren't separate features; they're sequential outputs of the same narration. The narrative section of each chapter explains the change (understand); the callouts and missing-items list flag what to question (scrutinize). Optionally, on demand, you can fold the whole branch into a single coherent story to see how the feature reads end-to-end — same two layers, applied to the unified diff.
 
 The framing the user landed on during design — and the one that should guide future iteration — is:
 
 > Dad helps me practice for the real world of code reviews.
 
-That phrasing matters. It's not about generating PR descriptions, not about replacing review, not about making you feel good. It's about training your own attention so the eventual human review (yours, your teammates') has a better chance of catching what matters.
+That phrasing matters. It's not about generating PR descriptions, not about replacing review, not about making you feel good. It's about (a) catching you up on what your agent actually did, then (b) training your own attention so the eventual human review (yours, your teammates') has a better chance of catching what matters.
 
 ## What's in scope for this PR
 
@@ -211,9 +216,9 @@ Things that are more likely to bite than the obvious bugs:
 
 ## Success looks like
 
-- You finish a feature with the help of an agent.
+- You finish a feature with the help of an agent and you can actually *describe* what it built — not just "it works", but the behavioral changes, the assumptions made, the moving parts. The narration filled in the gap between "I prompted" and "I understand."
 - For each commit, Dad's narration surfaced at least one absence, callout, or "verify that…" note that you actually acted on.
-- When you open the PR, your description is informed by Dad's unified view — you didn't have to write it from scratch.
+- When you open the PR, your description is informed by Dad's unified view — you didn't have to write it from scratch, and the things you say in it match what's actually in the diff because you read the story before posting.
 - Your teammates' reviews catch fewer things you should have caught yourself.
 - You trust Dad more when it flags concerns than when it's quiet — i.e., it's calibrated, not just verbose.
 

--- a/docs/dad-watch.md
+++ b/docs/dad-watch.md
@@ -1,0 +1,227 @@
+# `dad watch` — narrating your branch as you go
+
+## Thesis
+
+Diff Dad already does a good job turning *other people's* PRs into narrated stories. The problem this PR addresses is the symmetric one: **reviewing your own in-progress work**, especially when most of that work was written by an AI agent.
+
+The honest observation that motivated this PR was that reviewing your own agent's code is a tenuous activity. When Claude (or Cursor, or Codex) writes 80% of a feature, the human's review pass tends to skim — the code "looks right," it compiles, the tests pass, and confirmation bias does the rest. Bugs slip through that a fresh reviewer would catch in five seconds. By the time the PR opens, the author is no longer a fresh reviewer of their own work, and the actual reviewer is now the second person to nod at the same code instead of the first to scrutinize it.
+
+The pitch for `dad watch` is simple: **be the fresh reviewer your agent's work needs, before the PR opens.** As you commit, Dad narrates each commit through a "scrutinize" lens — not "here's what you did, great job" but "here's what you did, and here's what a senior reviewer would push back on, what tests are missing, what error paths aren't handled, what looks subtle and risky." Optionally, on demand, you can fold the whole branch into a single coherent story to see how the feature reads end-to-end.
+
+The framing the user landed on during design — and the one that should guide future iteration — is:
+
+> Dad helps me practice for the real world of code reviews.
+
+That phrasing matters. It's not about generating PR descriptions, not about replacing review, not about making you feel good. It's about training your own attention so the eventual human review (yours, your teammates') has a better chance of catching what matters.
+
+## What's in scope for this PR
+
+A new top-level CLI command — `dad watch [branch] [--base <ref>]` — that:
+
+1. Detects the current branch (or accepts one as an argument), auto-detects the base via `origin/HEAD` → `main` → `master` (with `--base` override), and computes the merge-base.
+2. Lists the commits in `base..head` (oldest first, skipping merge commits).
+3. Generates one narrative per commit using a **scrutinize-mode** system prompt that explicitly emphasizes absences, pushback, and honest "I can't verify this from the diff alone" notes.
+4. Caches narratives by `(repoFingerprint, sha)` so stable SHAs are never re-narrated. Rebased / squashed / amended SHAs disappear cleanly from the timeline; we don't try to carry chapters forward across history rewrites.
+5. Polls `git rev-parse <branch>` every 2 seconds. New commits trigger background narration; rewritten history triggers a refresh that drops orphaned chapters and narrates the new SHAs.
+6. Serves a local web UI (Hono + React) showing a horizontal commit timeline. Click any commit chip to switch the narrative pane to that commit. Click "Whole branch" to lazily generate a fresh narration of `base..HEAD` as one story.
+7. Sends live updates over the existing SSE channel — `commit-narrating`, `commit-narrative`, `unified-narrating`, `unified-narrative`, `watch-update` events let the UI react in real time.
+
+It is, deliberately, **read-only**. Watch mode never writes to the repo, never posts to GitHub, never sends data anywhere except your local LLM call. The only persistent artifact is the narrative cache at `~/.cache/diffdad/watch/`, which is yours to delete with `dad cache clear`.
+
+## What's deliberately NOT in scope, and why
+
+This is the long version. Each of these came up during design, and each one is shippable on its own merits — but shipping them all together would have produced a feature too brittle to trust.
+
+### 1. The feedback loop (commenting → agent → code change)
+
+This is the deferred prize, and the most important thing to be honest about.
+
+**The vision (eventually).** You read Dad's narrative of a commit, leave a comment on a specific line ("this should handle the empty case", "rename `foo` to `userId`", "extract this into a helper"), and that comment is fed back to your coding agent — Claude, Cursor, Codex, whatever — which makes the change, commits, and Dad re-narrates. A closed loop where the human stays in review-and-direct mode and the agent stays in code-mode.
+
+**Why it's not in this PR.** Every piece of it has at least one hard, unsolved problem:
+
+- **Anchor stability across history rewrites.** AI workflows rebase, squash, and `--amend` constantly. Comments anchored by `(file, line, sha)` orphan themselves the moment the agent rewrites a commit. The fix is content-based fuzzy anchoring (store the original lines + 3–5 lines of context, search HEAD for the snippet on each rebase) — but that's a heuristic. When it gets the anchor wrong, the agent acts on bad context, and the failure is silent: the user nods at code that "addressed" their comment but actually missed the point.
+
+- **Chapter identity drift across re-narrations.** Comments anchored to "Chapter 2" lose meaning when the next commit re-narrates and Chapter 2 becomes Chapter 3 or merges into Chapter 1. The fix is fingerprinting chapters by their hunk set and matching by Jaccard overlap. Another heuristic. Stacks on top of the previous one.
+
+- **Closing the loop is the part that quietly doesn't work.** Writing a `feedback.jsonl` is trivial. Getting the coding agent to actually read it at the right moment, and only at the right moment, is the whole game. Skill that the user has to remember to invoke? Often forgotten. Hook that fires automatically? Wrong moments. Polling MCP? Race conditions. Without an integration tight enough that comments feel like talking *to* the agent, the file becomes notes that never get acted on.
+
+- **Schema design under churn.** Comments need types (line, range, chapter, global), threading (replies), edit semantics, dismissal/resolve states, an outdated detector. JSONL event-log replay is the right model — but every one of those concerns has subtle edge cases (what if a comment is edited then resolved? what if a thread reply lands on an outdated parent?) that compound when implemented speculatively.
+
+- **Failure modes are silent and trust-eroding.** A normal bug crashes or shows a wrong number. Anchor-drift bugs cause an agent to "address" feedback in subtly wrong code locations, which a tired user nods at. That's worse than a crash, because it makes the tool *feel* useful while making review *worse*.
+
+The decision was: **defer until real usage of watch mode shows what hurts.** Watch-and-narrate is genuinely solid by itself — no anchoring problem because there's no persistent state across rewrites — and shipping just that gives us a real artifact to use day-to-day. The shape of the feedback loop will be much clearer after a few weeks of "I keep wanting to do X with this commit's narrative" observations than from a whiteboard.
+
+When it does land, it'll be its own feature with its own design conversation, its own scope, its own thesis. Likely components: a JSONL event log at `~/.cache/diffdad/watch/<repoFp>-<branch>-feedback.jsonl`, content+context-based anchoring with the SHA as a hint, an MCP server exposing read-only feedback queries to coding agents, and a hydration step that turns raw events into agent-ready briefs (chapter context + hunk + comment body in one prompt-shaped blob).
+
+For now, the comment-adding UI surfaces leftover from PR mode are visible in watch mode but nonfunctional — drafts go to localStorage with no destination. A follow-up will hide those affordances until the feedback loop ships, so the UI matches reality.
+
+### 2. Watching the working tree (uncommitted changes)
+
+**Tempting because:** it would feel even more "live" — narration as you literally type, before any commit.
+
+**Why it's not in this PR.**
+
+- Working-tree state changes on every file save. Without aggressive debouncing, an active agent session triggers an LLM call every few seconds. With aggressive debouncing, the narrative lags behind reality and feels stale.
+- Half-edited code is the worst possible narration target. "I see you're in the middle of a function" is not useful prose, and the LLM will produce *something* — usually a confused or cautiously hedged paragraph — rather than admit it can't tell what's going on.
+- There is no SHA to anchor against, so caching has no key. Every regeneration is a fresh full-cost call.
+- Commits are the natural "I want a story now" moment. They're already explicit checkpoints that the user (or the agent) chose to mark.
+
+**Future path.** If real usage of watch mode shows people genuinely miss the working-tree view, an on-demand "preview uncommitted" button — fires once, doesn't auto-update, narrates `git diff HEAD` — solves the use case without the auto-update mess.
+
+### 3. MCP server for feeding data back to the model
+
+**The vision.** A Model Context Protocol server (`dad mcp serve` or similar) that exposes Dad's narratives, comments, and chapter context to any MCP-aware coding agent. The agent can query `dad_list_open_feedback`, `dad_get_chapter_context(commitSha, chapterIndex)`, `dad_resolve_feedback(id)` — pulling the right context at the right moment without the user having to copy-paste anything.
+
+**Why it's not in this PR.**
+
+- The MCP is the *data plane* for the feedback loop. Without comments to query, there's nothing meaningful to expose. The narrative itself is already accessible via the local web API; an MCP wrapper without the feedback layer would just be a second access path to the same data.
+- Multiple agents speak MCP differently in practice (some auto-discover servers, some need explicit registration, some have rate limits we'd need to design around). Building this once we know which agents users are pairing with watch mode is a much better-informed design than building it speculatively.
+- The MCP will be the right shape *if and when* the feedback loop is built. Building it before the feedback loop has a defined schema would lock us into a wire format we'd likely want to change.
+
+**Future path.** When the feedback loop lands, the MCP comes with it as the canonical access surface. Likely shape:
+```
+tools:
+  dad_list_open_feedback(branch?) -> Feedback[]
+  dad_get_feedback(id) -> Feedback (hydrated with chapter + hunk context)
+  dad_get_chapter(commitSha, chapterIndex) -> Chapter
+  dad_resolve_feedback(id, note?) -> void
+  dad_get_branch_summary() -> { commits, narrativeSummaries }
+```
+Plus a `SessionStart` hook in the user's coding-agent config that nudges "you have N open Dad comments — want me to check them?"
+
+### 4. Auto-posting per-commit narratives as GitHub commit comments
+
+**The vision.** Each per-commit narrative gets pushed up to GitHub as a commit comment. When the PR eventually opens, those comments are already there as context for human reviewers.
+
+**Why it's not in this PR.**
+
+- GitHub commit comments are a UI backwater. They appear in the Commits tab but are invisible from the Files-changed tab where most review actually happens. They have no threading, no resolve state, no good interaction with PR review comments.
+- WIP narratives baked into permanent commit history is the wrong default. If your feature has 30 commits and 20 of them are "fix typo" / "address feedback" / "wip", you don't want 30 narratives smeared across the public commit log.
+- Force-push or rebase orphans every commit comment ever made.
+- Most importantly, this conflates two distinct phases: the **personal review** phase (where Dad helps the author scrutinize their own work, ideally privately and rough-around-the-edges) and the **published artifact** phase (where the author has consolidated the story and wants to surface it for others).
+
+**Future path.** When `dad watch` matures, an explicit `dad publish` (or similar) action could consolidate per-commit narratives into a single PR description draft, or a single top-level PR review comment, that the user sees and approves before posting. That respects both phases. The existing PR-with-commit-comments work can be revisited under that frame, but the current default of "auto-post each commit narrative" should not ship.
+
+### 5. Comment anchoring across history rewrites
+
+**The problem.** If watch mode had comments, those comments would need to survive `git rebase`, `git commit --amend`, `git reset`, and squash-on-merge — all of which AI agents do constantly during a normal feature.
+
+**The candidate solutions, all heuristic.**
+
+- **Content + context anchoring.** Store `(file, originalLines, contextBefore[3..5], contextAfter[3..5], originalSha)`. On read, fuzzy-search HEAD for the original snippet. SHA is a hint, not a requirement. Survives most rewrites.
+- **AST/symbolic anchoring** (tree-sitter). Anchor to "function `foo` in `bar.ts`, statement N." Survives more aggressive refactors but requires per-language grammar maintenance.
+- **Three-state result.** Found exactly → anchor refreshed. Found with edits → outdated badge with original-vs-current view. Not found → orphaned tray with original code preserved.
+
+**Why it's not in this PR.** Watch mode has no comments to anchor. Without comments, there's nothing for the anchor algorithm to do. When the feedback loop arrives, this becomes the load-bearing algorithm and deserves its own pressure-testing pass — including a deliberate effort to make the failure modes *loud*, not silent.
+
+### 6. Outdated comment detection
+
+**The vision.** When code under a comment changes in subsequent commits, the comment is auto-tagged "outdated", shown dimmed with a badge, and the original-vs-current code can be expanded inline. Dismiss appends a `{kind:"resolve"}` event to the JSONL log; pin marks the comment so it's not re-flagged.
+
+**Why it's not in this PR.** Same reason as anchoring — no comments to flag.
+
+**Note for future design.** The critical rule is **detect-and-surface, never auto-resolve.** A code change can make a comment *more* relevant, not less; silently dropping it is the worst possible behavior.
+
+### 7. Cross-model recommendation (codex narrating, claude coding)
+
+**The risk.** Same-family LLMs share blind spots. If Claude writes the code and Claude narrates it, the things one model missed in writing tend to be the things the other misses in scrutinizing. That partially defeats the "fresh reviewer" purpose.
+
+**Why it's not enforced in this PR.** The infrastructure is already there — `--with=codex`, `--with=claude`, `--with=pi` flags exist on the existing `dad review` flow and work for `dad watch` too. Enforcing or recommending a different model than the user's agent uses would require knowing what their agent uses, which we don't.
+
+**Future path.** README and the `dad watch` first-run prompt should explicitly recommend cross-family narration: "Tip: if Claude wrote the code, run `dad watch --with=codex` (or similar) for a more independent read." Not gating the PR, but worth landing before any public release.
+
+### 8. UI affordances for comments in watch mode
+
+The current state is a small honesty bug: the existing line-comment and chapter-comment UI from PR mode is still rendered in watch mode (it's the same `Chapter` component), but watch mode's server has no `/api/comments` or `/api/review` endpoints. Drafts get saved to `localStorage` and never go anywhere.
+
+**Resolution.** Follow-up commit will hide the comment-add affordances entirely in watch mode. When the feedback loop ships, those affordances come back with a real destination — and that's a more satisfying landing than "incrementally less broken drafts."
+
+### 9. Working with non-git VCSes
+
+Mercurial, jj, sapling, etc. are all out of scope. Watch mode shells out to `git` directly via `Bun.spawn`. Adding VCS abstraction is far ahead of where the user-facing feature is in maturity.
+
+### 10. Multi-branch / multi-repo watching
+
+`dad watch` watches one branch in one repo. Not a "dashboard of all my in-flight work." That's a real product surface but a different one — likely better as a separate `dad dashboard` command that aggregates results from many `dad watch` runs.
+
+---
+
+## Architectural decisions worth flagging for future maintainers
+
+These are the choices that shaped the PR's structure. Calling them out here so they're easy to revisit if assumptions change.
+
+### Per-commit as the narration unit, not the rolling story
+
+The first instinct was "narrate `base..HEAD` as one story, regenerate on every commit." That has two failure modes:
+- **Cost.** You re-narrate the entire branch on every commit. 30 commits = 30 full-branch narrations.
+- **Narrative collage drift.** Each regeneration is a fresh take — chapter structure shifts, tone shifts, callouts move. The user's mental model of "the story so far" gets perturbed every commit.
+
+Per-commit narration gives:
+- **Cheap incrementals.** Each commit's narrative is small and cached forever once generated.
+- **Honest unit boundaries.** Each chapter set corresponds to one commit. Easier for the user to reason about "what did this commit do."
+- **Stable cache keying.** SHA in, narrative out. Stable.
+
+The unified view is offered as an explicit, on-demand, **separate** narration of `base..HEAD` — not stitched from the per-commit ones. Stitching produces incoherence; a fresh full-branch narration produces a real story. The cost of one occasional unified call is justified by the quality difference.
+
+### Watch mode is a separate server, not a retrofit of `dad review`
+
+`packages/cli/src/server.ts` is built around PR mode: GitHub client, comment posting, review submission, check-run polling, comment-to-chapter mapping. Trying to graft "no GitHub, no comments, no PR" onto that produced a tangle of `if (mode === 'watch')` branches. A parallel `watch-server.ts` is cleaner and cheaper to maintain.
+
+The frontend, in contrast, *is* a retrofit — same Zustand store, same `Chapter`/`StoryView` components, just gated by a `mode: 'pr' | 'watch'` flag and a watch slice. That's because the *display* of a narrative is genuinely the same operation regardless of where the narrative came from. The data path is the part that diverges.
+
+### Polling vs file-watching for new commits
+
+`fs.watch` on `.git/refs/heads/<branch>` doesn't work reliably:
+- Packed refs (`git pack-refs`, common after `git gc`) move ref contents into a single file; per-branch files cease to exist.
+- `fs.watch` on Linux uses inotify and silently misses events on some FS types and over network mounts.
+
+A 2-second poll of `git rev-parse <branch>` is universally reliable, costs ~30 cheap subprocess calls per minute, and avoids the entire reliability matrix above. The simplicity-vs-latency tradeoff is favorable: 2 seconds is well below human perception for "did my commit register?" and far below the LLM call latency that dominates the actual narration timing.
+
+### Scrutinize prompt as an addendum, not a separate prompt
+
+The narrative engine (chapters, sections, callouts, missing array, verdict) is the same in both modes — what changes is the *framing*. Modeling that as a system-prompt addendum keeps:
+- One JSON schema for both modes.
+- One frontend rendering pipeline.
+- One place to evolve narrative quality (changes to the base prompt benefit both modes; changes to the addendum only affect scrutinize).
+
+The addendum explicitly asks for: *what's questionable, what's missing, what would a senior reviewer push back on*; prefers concern/warning callouts over nits; defaults verdict to "caution"; tells the model to be honest about what it can't verify from the diff alone.
+
+### Synthetic PR metadata
+
+The frontend was designed around `PRMetadata`. Rather than fork the components, watch mode constructs PR-shaped objects from local commit data — `number: 0` as a sentinel for "no PR yet", `state: 'open'`, `branch`/`base` from the branch and base ref, `additions`/`deletions`/`changedFiles` from `git diff --numstat`. The UI components don't have to know they're showing a watch-mode artifact; they just render a PR-shaped object the same way they always do.
+
+The only frontend change is a `mode === 'watch'` branch in `App.tsx` that swaps `PRHeader` (PR-specific chrome: GitHub link, checks, reviews, submit-review button) for `WatchHeader` + `CommitTimeline`.
+
+---
+
+## Risks and what to watch for in real use
+
+Things that are more likely to bite than the obvious bugs:
+
+1. **Trust amplification.** The whole risk this PR addresses is "you don't scrutinize your agent's code carefully enough." The risk this PR *introduces* is "the narrator describes the code so well that you trust it more, not less." If the scrutinize prompt produces compelling but vague pushback, the user may nod along to the *narration* the way they were nodding along to the code. Watch for: do you act on the missing-items list? Do callouts make you change anything? If the answer is "rarely" after a few weeks, the prompt needs sharper teeth.
+
+2. **Same-family blind spots.** If you let it default to `claude` and your agent is also Claude, you're checking Claude's work with Claude. Consider a docs nudge toward `--with=codex` or similar.
+
+3. **Narrative cost on large branches.** A 50-commit feature is 50 narrations. Caching helps, but the first-time generation isn't free. If this becomes a pain point, the levers are: tier models (cheap/fast for incremental, expensive/good for unified), debounce harder (only narrate on push, not commit), or skip-narrate noisy commits (configurable patterns: "ignore commits matching ^fixup!", etc.).
+
+4. **The feature hits its own ceiling.** If you find yourself wanting to talk back — "yes Dad, but this hunk is fine because..." — that's the signal that the feedback loop is actually needed. Note when and why you wanted that, and feed it into the eventual feedback-loop design conversation. The wishlist of "things I wanted to say to a commit's narrative" is the highest-value design input we could collect right now.
+
+---
+
+## Success looks like
+
+- You finish a feature with the help of an agent.
+- For each commit, Dad's narration surfaced at least one absence, callout, or "verify that…" note that you actually acted on.
+- When you open the PR, your description is informed by Dad's unified view — you didn't have to write it from scratch.
+- Your teammates' reviews catch fewer things you should have caught yourself.
+- You trust Dad more when it flags concerns than when it's quiet — i.e., it's calibrated, not just verbose.
+
+## Failure looks like
+
+- Narratives feel triumphant. You read them, nod, ship. Bugs make it through anyway.
+- Cost runs up faster than expected and you stop running watch mode on long branches.
+- You keep reaching for affordances that don't exist (comments, agent direction, etc.) and feel limited.
+- Narrative drift across a long branch makes the unified view feel disconnected from the per-commit ones.
+
+Each of those is actionable, and each tells us something specific about what to build next. The point of shipping the read-only half first is to *earn* that signal.

--- a/docs/dad-watch.md
+++ b/docs/dad-watch.md
@@ -4,6 +4,10 @@
 
 Diff Dad does a good job turning *other people's* PRs into narrated stories. The symmetric problem — and the one this design addresses — is **reviewing your own in-progress work**, especially when most of that work was written by an AI agent.
 
+The core value proposition:
+
+> Dad is a guardrail for the awkward modern workflow where an agent produced a lot of the code and the human author is no longer a fully informed reviewer.
+
 The honest observation that motivates this design: reviewing your own agent's code is a tenuous activity. When Claude (or Cursor, or Codex) writes 80% of a feature, the human's review pass tends to skim — the code "looks right," it compiles, the tests pass, and confirmation bias does the rest. Bugs slip through that a fresh reviewer would catch in five seconds. Worse, in a long agent-driven session, the human often *doesn't actually know* what the agent built in detail: they prompted, the agent worked, they nodded at the result. By the time the PR opens, the author is no longer a fresh reviewer of their own work — they're a half-informed observer of work that was mostly done without them.
 
 `dad watch` should address both halves of that:

--- a/docs/dad-watch.md
+++ b/docs/dad-watch.md
@@ -2,48 +2,223 @@
 
 ## Thesis
 
-Diff Dad already does a good job turning *other people's* PRs into narrated stories. The problem this PR addresses is the symmetric one: **reviewing your own in-progress work**, especially when most of that work was written by an AI agent.
+Diff Dad does a good job turning *other people's* PRs into narrated stories. The symmetric problem — and the one this design addresses — is **reviewing your own in-progress work**, especially when most of that work was written by an AI agent.
 
-The honest observation that motivated this PR was that reviewing your own agent's code is a tenuous activity. When Claude (or Cursor, or Codex) writes 80% of a feature, the human's review pass tends to skim — the code "looks right," it compiles, the tests pass, and confirmation bias does the rest. Bugs slip through that a fresh reviewer would catch in five seconds. Worse, in a long agent-driven session, the human often *doesn't actually know* what the agent built in detail: they prompted, the agent worked, they nodded at the result. By the time the PR opens, the author is no longer a fresh reviewer of their own work — they're a half-informed observer of work that was mostly done without them.
+The honest observation that motivates this design: reviewing your own agent's code is a tenuous activity. When Claude (or Cursor, or Codex) writes 80% of a feature, the human's review pass tends to skim — the code "looks right," it compiles, the tests pass, and confirmation bias does the rest. Bugs slip through that a fresh reviewer would catch in five seconds. Worse, in a long agent-driven session, the human often *doesn't actually know* what the agent built in detail: they prompted, the agent worked, they nodded at the result. By the time the PR opens, the author is no longer a fresh reviewer of their own work — they're a half-informed observer of work that was mostly done without them.
 
-`dad watch` is meant to address both halves of that:
+`dad watch` should address both halves of that:
 
-1. **Help you understand what's being built.** As each commit lands, Dad narrates it in plain prose: what changed at the behavioral level, what consequences that has, what subtle assumptions are baked in. This is the *comprehension* layer — you stop being a half-informed observer and become someone who actually knows what's in their feature. You can't review what you can't articulate; this gets you to the point where you could.
+1. **Help you understand what's being built.** As each commit lands (or when you ask), Dad narrates it in plain prose: what changed at the behavioral level, what consequences that has, what subtle assumptions are baked in. This is the *comprehension* layer — you stop being a half-informed observer and become someone who actually knows what's in their feature. You can't review what you can't articulate; this gets you to the point where you could.
 2. **Scrutinize what was built.** On top of the comprehension, the scrutinize lens explicitly asks "what would a senior reviewer push back on, what tests are missing, what error paths aren't handled, what looks subtle and risky." This is the *review* layer — and it works precisely because the comprehension layer made the change legible enough to actually critique.
 
-These aren't separate features; they're sequential outputs of the same narration. The narrative section of each chapter explains the change (understand); the callouts and missing-items list flag what to question (scrutinize). Optionally, on demand, you can fold the whole branch into a single coherent story to see how the feature reads end-to-end — same two layers, applied to the unified diff.
+These aren't separate features; they should be sequential outputs of the same narration. The narrative section of each chapter explains the change (understand); the callouts and missing-items list flag what to question (scrutinize). On demand, the user can also fold the whole branch into a single coherent story — same two layers, applied to the unified diff.
 
-The framing the user landed on during design — and the one that should guide future iteration — is:
+The framing that should guide future iteration:
 
 > Dad helps me practice for the real world of code reviews.
 
 That phrasing matters. It's not about generating PR descriptions, not about replacing review, not about making you feel good. It's about (a) catching you up on what your agent actually did, then (b) training your own attention so the eventual human review (yours, your teammates') has a better chance of catching what matters.
 
-## What's in scope for this PR
+## Scope
 
 A new top-level CLI command — `dad watch [branch] [--base <ref>]` — that:
 
 1. Detects the current branch (or accepts one as an argument), auto-detects the base via `origin/HEAD` → `main` → `master` (with `--base` override), and computes the merge-base.
 2. Lists the commits in `base..head` (oldest first, skipping merge commits).
-3. Generates one narrative per commit using a **scrutinize-mode** system prompt that explicitly emphasizes absences, pushback, and honest "I can't verify this from the diff alone" notes.
-4. Caches narratives by `(repoFingerprint, sha)` so stable SHAs are never re-narrated. Rebased / squashed / amended SHAs disappear cleanly from the timeline; we don't try to carry chapters forward across history rewrites.
-5. Polls `git rev-parse <branch>` every 2 seconds. New commits trigger background narration; rewritten history triggers a refresh that drops orphaned chapters and narrates the new SHAs.
-6. Serves a local web UI (Hono + React) showing a horizontal commit timeline. Click any commit chip to switch the narrative pane to that commit. Click "Whole branch" to lazily generate a fresh narration of `base..HEAD` as one story.
-7. Sends live updates over the existing SSE channel — `commit-narrating`, `commit-narrative`, `unified-narrating`, `unified-narrative`, `watch-update` events let the UI react in real time.
+3. Narrates commits using a **comprehension-first, scrutinize-second** system prompt (see [Prompt design](#prompt-design)).
+4. Triggers narration **on demand by default**, with the latest commit auto-narrated when it lands (see [Narration triggering](#narration-triggering)).
+5. Caches narratives by `(repoFingerprint, sha)` so stable SHAs are never re-narrated. Rebased / squashed / amended SHAs disappear cleanly from the timeline; we don't try to carry chapters forward across history rewrites.
+6. Polls `git rev-parse <branch>` every 2 seconds. New commits update the timeline (and trigger narration of the latest); rewritten history triggers a refresh that drops orphaned chapters.
+7. Serves a local web UI (Hono + React) showing a **vertical commit sidebar** (see [UI](#ui)) that scales to branches with dozens of commits. Click any commit to switch the narrative pane (or trigger its narration if it hasn't been narrated yet). Click "Whole branch" to lazily generate a fresh narration of `base..HEAD` as one story.
+8. Sends live updates over the existing SSE channel — `commit-narrating`, `commit-narrative`, `unified-narrating`, `unified-narrative`, `watch-update` events let the UI react in real time.
 
 It is, deliberately, **read-only**. Watch mode never writes to the repo, never posts to GitHub, never sends data anywhere except your local LLM call. The only persistent artifact is the narrative cache at `~/.cache/diffdad/watch/`, which is yours to delete with `dad cache clear`.
 
-## What's deliberately NOT in scope, and why
+## Prompt design
 
-This is the long version. Each of these came up during design, and each one is shippable on its own merits — but shipping them all together would have produced a feature too brittle to trust.
+The prompt is the load-bearing piece of this entire feature. If it doesn't deliver both layers (comprehension + scrutiny), the rest of the architecture is just plumbing for an unhelpful output.
+
+The narrative engine and JSON schema (chapters, sections, callouts, missing array, verdict) are shared with `dad review`. What changes for watch mode is the *framing* — implemented as a system-prompt **addendum**, not a separate prompt. This keeps:
+
+- One JSON schema for both modes.
+- One frontend rendering pipeline.
+- One place to evolve narrative quality (changes to the base prompt benefit both modes; changes to the addendum only affect scrutinize).
+
+### The two-layer instruction
+
+The addendum must structure the model's output as a **deliberate sequence**: comprehend first, then question. Without explicit sequencing, scrutiny-leaning instructions push the model to skip past the explanation and dive into criticism, which is exactly the failure mode the comprehension layer was supposed to prevent. The addendum should look like:
+
+> You are narrating a commit on a developer's own in-progress branch. Most of this code was written by an AI agent; the developer has prompted but not necessarily *read* it. Each chapter must do two things, in this order:
+>
+> 1. **Comprehension first.** State what this change does at the behavioral level, in plain language. Assume the reader didn't write this code and may not even know it was written. Lead with "before this commit, X. After this commit, Y." Surface the consequence — "this means Z now happens / no longer happens." If a hunk is mechanical (rename, format), say so plainly and move on.
+> 2. **Scrutiny second.** Once the change is legible, surface what's worth questioning: implicit assumptions, hidden coupling, ordering dependencies, error paths that aren't handled, edge cases that aren't covered, validation that was skipped, race conditions, off-by-ones. Be specific enough that the reader can verify each concern in under a minute.
+>
+> Other rules:
+> - **Hunt for absences in the `missing` array.** Missing tests for new behavior, missing error handling, missing input validation, missing cleanup on failure paths, missing docs for public surface changes, missing migrations. Be specific — "no test for the empty-input case in foo()" beats "needs more tests."
+> - **Treat callouts as the real product.** Prefer "concern" and "warning" callouts over "nit". Each callout should be specific enough that the reader can verify it in under a minute. If you can't be specific, don't write the callout.
+> - **Be honest about what you can't tell from the diff alone.** "Verify that X actually fires when Y" is better than guessing. Confidence you can't justify is worse than admitting uncertainty.
+> - **Default verdict to caution.** Reserve "safe" for genuinely mechanical changes. If you flagged a single warning callout or a non-trivial absence, the verdict is "caution" or "risky".
+>
+> The reviewer trusts you more when you (a) make them feel they understand the change and (b) flag real problems they wouldn't have caught. Earn both halves of that trust.
+
+### Why this matters
+
+A scrutinize-only prompt produces narrations that *look* useful but don't scaffold the user's understanding. They jump to "here's what's wrong" before the user has internalized "here's what it does," and the user ends up nodding at warnings the same way they were nodding at code. The two-layer structure is what makes scrutiny *land* — pushback on something you understand is actionable; pushback on something you didn't understand to begin with is just noise.
+
+### Validating the prompt
+
+The prompt should be evaluated against real branches by reading outputs and asking, per chapter:
+
+- Could a reader who didn't write this code, after reading the narrative section alone, accurately describe what changed?
+- Could that same reader, after reading the callouts, point at a specific line or hunk and say "that's the thing to check"?
+- Are the absences in `missing` things the reader would actually want flagged, or generic checklist items?
+
+If any of those is "no" consistently, the addendum needs another pass. Treat the prompt as a living artifact, not a one-shot.
+
+## Narration triggering
+
+When narration fires matters as much as what it says.
+
+### On-demand by default
+
+Narrating every commit eagerly doesn't scale, for three compounding reasons:
+
+1. **Cost.** A 50-commit feature is 50 LLM calls. Caching helps for stable SHAs, but the first time around is full price. Most users have a budget — implicit or explicit — and shouldn't have to choose between "use Dad" and "use it cheaply."
+2. **Time.** At ~15 seconds per narration, 50 commits is ~12 minutes of background work. Even if it's truly background, it's a lot of fan noise for outputs you may never look at.
+3. **Signal.** Most commits in a real feature branch are noise: "fix typo", "wip", "address feedback", "rebase", small fixups. They don't deserve their own story. Narrating them dilutes the timeline with mediocre chapters and trains the user to scroll past.
+
+The default is therefore: **the timeline shows every commit, but narration fires only when the user clicks (or when the latest commit lands).** Most commits live in the sidebar as clickable rows in an "unnarrated" state. Clicking generates the narrative on demand, with the loading state shown in the main pane while it runs.
+
+### Latest-commit auto-narration
+
+The dominant flow in practice is: "I just committed something, let me see what Dad thinks." Forcing the user to click for that case adds friction with no benefit. So when a new commit arrives via the polling watcher, the latest commit is auto-narrated — but only the latest one, not every newly-arrived commit if multiple landed at once.
+
+This collapses cost from O(commits) to O(commits-the-user-actually-clicked), typically 1–3 per session, regardless of branch length. It also makes the sidebar genuinely scalable: each row is first-class whether narrated or not.
+
+### Optional eager mode
+
+For short branches or users who want the "everything ready instantly" experience, an explicit `--eager` flag on `dad watch` should opt into narrate-all-on-arrival behavior. Off by default; documented as the option for "I'm okay paying for narration on all 8 commits in my small branch."
+
+### Unified view
+
+Always on-demand. The user clicks "Whole branch" in the sidebar; the server generates a fresh `base..HEAD` narration (not stitched from per-commit ones — see [Architectural decisions](#architectural-decisions)). Cached by `(baseSha, headSha)` so it's not re-generated until the branch moves.
+
+## UI
+
+The UI must scale to branches with dozens of commits without losing legibility. Three structural decisions follow from that:
+
+### Vertical commit sidebar
+
+Commits live in a **vertical sidebar** on the left of the main content area, not a horizontal strip across the top. Vertical scales naturally to many rows; horizontal runs out of width and forces awkward overflow scroll for anything beyond ~10 commits.
+
+Each row shows:
+- A status indicator: ✓ narrated, ⏳ narrating, ○ unnarrated.
+- The short SHA (monospace).
+- The commit subject (truncated with ellipsis if needed).
+- Optional: relative date, author (when not the user themselves), `+N/-M` size.
+
+The "Whole branch" toggle lives at the top of the sidebar, above the commit list. Selected commit (or "Whole branch" if active) is highlighted.
+
+The sidebar is sticky to the viewport top (below the header) and scrolls internally if the commit count exceeds available height. Width: ~260px.
+
+### Layout
+
+```
++------------------------------------------------+
+| AppBar (sticky)                                |
++------------------------------------------------+
+| WatchHeader (sticky): branch, base, +N -M, etc. |
++----------+-------------------------------------+
+| Sidebar  | Main pane                           |
+|          |                                     |
+| Whole br |   StoryView for selected commit     |
+|          |   (existing chapters, callouts,     |
+| ✓ a1b2   |    missing items, verdict)          |
+| ✓ c3d4   |                                     |
+| ⏳ e5f6   |   — or, if narrating —              |
+| ○ g7h8   |   Compact GeneratingScreen          |
+|          |                                     |
++----------+-------------------------------------+
+```
+
+### Loading state
+
+When a commit's narrative isn't ready (whether because the user just clicked an unnarrated commit, or because narration was kicked off by the latest-commit auto-trigger and hasn't completed), the main pane shows the **whimsical loading screen** — bobbing Dad mark, animated dots, cycling messages — not a plain "narration in progress…" text. The sidebar stays interactive so the user can switch commits while waiting.
+
+### No comment UI in watch mode
+
+The PR-mode UI has affordances for line comments, chapter comments, and review submission. None of those have a destination in watch mode (there's no GitHub PR; there's no feedback loop yet). Those affordances should be **hidden** in watch mode — drafts that go nowhere are an honesty bug, not a feature. They come back when the feedback loop ships.
+
+## Caching
+
+Narratives cached at `~/.cache/diffdad/watch/`:
+- Per-commit: `<repoFingerprint>-commit-<sha>.json`.
+- Unified: `<repoFingerprint>-unified-<baseSha>-<headSha>.json`.
+
+`repoFingerprint` is a stable short hash of the absolute repo path, so two checkouts of the same repo don't collide.
+
+Stable SHAs are never re-narrated. When a SHA disappears from the branch (rebase, squash, amend), its narrative stays on disk but the in-memory state and timeline drop it — no attempt to "carry forward" a chapter to the rewritten commit, because the underlying assumption ("this narrative is about *this* commit") no longer holds.
+
+`dad cache clear` wipes both PR-mode and watch-mode caches.
+
+## Architectural decisions
+
+These are the design choices that will shape the implementation. Calling them out so they're easy to revisit if assumptions change.
+
+### Per-commit as the narration unit, not the rolling story
+
+The first instinct is "narrate `base..HEAD` as one story, regenerate on every commit." That has two failure modes:
+- **Cost.** Re-narrating the entire branch on every commit is expensive.
+- **Narrative collage drift.** Each regeneration is a fresh take — chapter structure shifts, tone shifts, callouts move. The user's mental model of "the story so far" gets perturbed every commit.
+
+Per-commit narration gives:
+- **Cheap incrementals.** Each commit's narrative is small and cached forever once generated.
+- **Honest unit boundaries.** Each chapter set corresponds to one commit. Easier for the user to reason about "what did this commit do."
+- **Stable cache keying.** SHA in, narrative out.
+
+The unified view is offered as an explicit, on-demand, **separate** narration of `base..HEAD` — not stitched from the per-commit ones. Stitching produces incoherence; a fresh full-branch narration produces a real story. The cost of one occasional unified call is justified by the quality difference.
+
+### Watch mode is a separate server, not a retrofit of `dad review`
+
+`packages/cli/src/server.ts` is built around PR mode: GitHub client, comment posting, review submission, check-run polling, comment-to-chapter mapping. Trying to graft "no GitHub, no comments, no PR" onto that produces a tangle of `if (mode === 'watch')` branches. A parallel `watch-server.ts` is cleaner and cheaper to maintain.
+
+The frontend, in contrast, *should* be a retrofit — same Zustand store, same `Chapter`/`StoryView` components, gated by a `mode: 'pr' | 'watch'` flag and a watch slice. The *display* of a narrative is genuinely the same operation regardless of where the narrative came from; the data path is the part that diverges.
+
+### Polling vs file-watching for new commits
+
+`fs.watch` on `.git/refs/heads/<branch>` is unreliable:
+- Packed refs (`git pack-refs`, common after `git gc`) move ref contents into a single file; per-branch files cease to exist.
+- `fs.watch` on Linux uses inotify and silently misses events on some FS types and over network mounts.
+
+A 2-second poll of `git rev-parse <branch>` is universally reliable, costs ~30 cheap subprocess calls per minute, and avoids the entire reliability matrix above. The simplicity-vs-latency tradeoff is favorable: 2 seconds is well below human perception for "did my commit register?" and far below the LLM call latency that dominates actual narration timing.
+
+### Scrutinize prompt as an addendum, not a separate prompt
+
+Already covered in [Prompt design](#prompt-design). The key invariant: comprehension and scrutiny share a JSON schema and a rendering pipeline; the addendum only changes the framing instructions, never the output structure.
+
+### Synthetic PR metadata
+
+The frontend was designed around `PRMetadata`. Rather than fork the components, watch mode constructs PR-shaped objects from local commit data — `number: 0` as a sentinel for "no PR yet", `state: 'open'`, `branch`/`base` from the branch and base ref, `additions`/`deletions`/`changedFiles` from `git diff --numstat`. The UI components don't have to know they're showing a watch-mode artifact; they just render a PR-shaped object the same way they always do.
+
+The only frontend swap is `mode === 'watch'` in `App.tsx` rendering `WatchHeader` + commit sidebar instead of `PRHeader` + (PR-specific chrome: GitHub link, checks, reviews, submit-review button).
+
+### AppBar reads watch state directly
+
+The top-level "$ dad <command> → <target>" framing in the AppBar reads `mode` and the `watch` slice (not `pr.number`) when in watch mode, so it shows `dad watch <branch>` and links to the branch on GitHub instead of generating a bogus `#0` PR link. This is a small thing but matters for the read-out feel of the UI — "dad review 0" is a tell that the tool got into a state it doesn't understand.
+
+---
+
+## Out of scope
+
+Each of these came up during design, and each is shippable on its own merits — but lumping them in produces a feature too brittle to trust. Defer until the read-only half is in real use and tells us what to build next.
 
 ### 1. The feedback loop (commenting → agent → code change)
 
 This is the deferred prize, and the most important thing to be honest about.
 
-**The vision (eventually).** You read Dad's narrative of a commit, leave a comment on a specific line ("this should handle the empty case", "rename `foo` to `userId`", "extract this into a helper"), and that comment is fed back to your coding agent — Claude, Cursor, Codex, whatever — which makes the change, commits, and Dad re-narrates. A closed loop where the human stays in review-and-direct mode and the agent stays in code-mode.
+**The vision.** You read Dad's narrative of a commit, leave a comment on a specific line ("this should handle the empty case", "rename `foo` to `userId`", "extract this into a helper"), and that comment is fed back to your coding agent — Claude, Cursor, Codex, whatever — which makes the change, commits, and Dad re-narrates. A closed loop where the human stays in review-and-direct mode and the agent stays in code-mode.
 
-**Why it's not in this PR.** Every piece of it has at least one hard, unsolved problem:
+**Why it's deferred.** Every piece has at least one hard, unsolved problem:
 
 - **Anchor stability across history rewrites.** AI workflows rebase, squash, and `--amend` constantly. Comments anchored by `(file, line, sha)` orphan themselves the moment the agent rewrites a commit. The fix is content-based fuzzy anchoring (store the original lines + 3–5 lines of context, search HEAD for the snippet on each rebase) — but that's a heuristic. When it gets the anchor wrong, the agent acts on bad context, and the failure is silent: the user nods at code that "addressed" their comment but actually missed the point.
 
@@ -55,30 +230,28 @@ This is the deferred prize, and the most important thing to be honest about.
 
 - **Failure modes are silent and trust-eroding.** A normal bug crashes or shows a wrong number. Anchor-drift bugs cause an agent to "address" feedback in subtly wrong code locations, which a tired user nods at. That's worse than a crash, because it makes the tool *feel* useful while making review *worse*.
 
-The decision was: **defer until real usage of watch mode shows what hurts.** Watch-and-narrate is genuinely solid by itself — no anchoring problem because there's no persistent state across rewrites — and shipping just that gives us a real artifact to use day-to-day. The shape of the feedback loop will be much clearer after a few weeks of "I keep wanting to do X with this commit's narrative" observations than from a whiteboard.
+The decision: **defer until real usage of watch mode shows what hurts.** Watch-and-narrate is solid by itself — no anchoring problem because there's no persistent state across rewrites — and shipping just that gives a real artifact to use day-to-day. The shape of the feedback loop will be much clearer after a few weeks of "I keep wanting to do X with this commit's narrative" observations than from a whiteboard.
 
 When it does land, it'll be its own feature with its own design conversation, its own scope, its own thesis. Likely components: a JSONL event log at `~/.cache/diffdad/watch/<repoFp>-<branch>-feedback.jsonl`, content+context-based anchoring with the SHA as a hint, an MCP server exposing read-only feedback queries to coding agents, and a hydration step that turns raw events into agent-ready briefs (chapter context + hunk + comment body in one prompt-shaped blob).
-
-For now, the comment-adding UI surfaces leftover from PR mode are visible in watch mode but nonfunctional — drafts go to localStorage with no destination. A follow-up will hide those affordances until the feedback loop ships, so the UI matches reality.
 
 ### 2. Watching the working tree (uncommitted changes)
 
 **Tempting because:** it would feel even more "live" — narration as you literally type, before any commit.
 
-**Why it's not in this PR.**
+**Why it's deferred.**
 
 - Working-tree state changes on every file save. Without aggressive debouncing, an active agent session triggers an LLM call every few seconds. With aggressive debouncing, the narrative lags behind reality and feels stale.
 - Half-edited code is the worst possible narration target. "I see you're in the middle of a function" is not useful prose, and the LLM will produce *something* — usually a confused or cautiously hedged paragraph — rather than admit it can't tell what's going on.
 - There is no SHA to anchor against, so caching has no key. Every regeneration is a fresh full-cost call.
 - Commits are the natural "I want a story now" moment. They're already explicit checkpoints that the user (or the agent) chose to mark.
 
-**Future path.** If real usage of watch mode shows people genuinely miss the working-tree view, an on-demand "preview uncommitted" button — fires once, doesn't auto-update, narrates `git diff HEAD` — solves the use case without the auto-update mess.
+**Future path.** If real usage shows people genuinely miss the working-tree view, an on-demand "preview uncommitted" button — fires once, doesn't auto-update, narrates `git diff HEAD` — solves the use case without the auto-update mess.
 
 ### 3. MCP server for feeding data back to the model
 
 **The vision.** A Model Context Protocol server (`dad mcp serve` or similar) that exposes Dad's narratives, comments, and chapter context to any MCP-aware coding agent. The agent can query `dad_list_open_feedback`, `dad_get_chapter_context(commitSha, chapterIndex)`, `dad_resolve_feedback(id)` — pulling the right context at the right moment without the user having to copy-paste anything.
 
-**Why it's not in this PR.**
+**Why it's deferred.**
 
 - The MCP is the *data plane* for the feedback loop. Without comments to query, there's nothing meaningful to expose. The narrative itself is already accessible via the local web API; an MCP wrapper without the feedback layer would just be a second access path to the same data.
 - Multiple agents speak MCP differently in practice (some auto-discover servers, some need explicit registration, some have rate limits we'd need to design around). Building this once we know which agents users are pairing with watch mode is a much better-informed design than building it speculatively.
@@ -99,14 +272,14 @@ Plus a `SessionStart` hook in the user's coding-agent config that nudges "you ha
 
 **The vision.** Each per-commit narrative gets pushed up to GitHub as a commit comment. When the PR eventually opens, those comments are already there as context for human reviewers.
 
-**Why it's not in this PR.**
+**Why it's deferred.**
 
 - GitHub commit comments are a UI backwater. They appear in the Commits tab but are invisible from the Files-changed tab where most review actually happens. They have no threading, no resolve state, no good interaction with PR review comments.
 - WIP narratives baked into permanent commit history is the wrong default. If your feature has 30 commits and 20 of them are "fix typo" / "address feedback" / "wip", you don't want 30 narratives smeared across the public commit log.
 - Force-push or rebase orphans every commit comment ever made.
 - Most importantly, this conflates two distinct phases: the **personal review** phase (where Dad helps the author scrutinize their own work, ideally privately and rough-around-the-edges) and the **published artifact** phase (where the author has consolidated the story and wants to surface it for others).
 
-**Future path.** When `dad watch` matures, an explicit `dad publish` (or similar) action could consolidate per-commit narratives into a single PR description draft, or a single top-level PR review comment, that the user sees and approves before posting. That respects both phases. The existing PR-with-commit-comments work can be revisited under that frame, but the current default of "auto-post each commit narrative" should not ship.
+**Future path.** When `dad watch` matures, an explicit `dad publish` (or similar) action could consolidate per-commit narratives into a single PR description draft, or a single top-level PR review comment, that the user sees and approves before posting. That respects both phases.
 
 ### 5. Comment anchoring across history rewrites
 
@@ -118,13 +291,13 @@ Plus a `SessionStart` hook in the user's coding-agent config that nudges "you ha
 - **AST/symbolic anchoring** (tree-sitter). Anchor to "function `foo` in `bar.ts`, statement N." Survives more aggressive refactors but requires per-language grammar maintenance.
 - **Three-state result.** Found exactly → anchor refreshed. Found with edits → outdated badge with original-vs-current view. Not found → orphaned tray with original code preserved.
 
-**Why it's not in this PR.** Watch mode has no comments to anchor. Without comments, there's nothing for the anchor algorithm to do. When the feedback loop arrives, this becomes the load-bearing algorithm and deserves its own pressure-testing pass — including a deliberate effort to make the failure modes *loud*, not silent.
+**Why it's deferred.** Watch mode has no comments to anchor. Without comments, there's nothing for the anchor algorithm to do. When the feedback loop arrives, this becomes the load-bearing algorithm and deserves its own pressure-testing pass — including a deliberate effort to make the failure modes *loud*, not silent.
 
 ### 6. Outdated comment detection
 
 **The vision.** When code under a comment changes in subsequent commits, the comment is auto-tagged "outdated", shown dimmed with a badge, and the original-vs-current code can be expanded inline. Dismiss appends a `{kind:"resolve"}` event to the JSONL log; pin marks the comment so it's not re-flagged.
 
-**Why it's not in this PR.** Same reason as anchoring — no comments to flag.
+**Why it's deferred.** Same reason as anchoring — no comments to flag.
 
 **Note for future design.** The critical rule is **detect-and-surface, never auto-resolve.** A code change can make a comment *more* relevant, not less; silently dropping it is the worst possible behavior.
 
@@ -132,101 +305,52 @@ Plus a `SessionStart` hook in the user's coding-agent config that nudges "you ha
 
 **The risk.** Same-family LLMs share blind spots. If Claude writes the code and Claude narrates it, the things one model missed in writing tend to be the things the other misses in scrutinizing. That partially defeats the "fresh reviewer" purpose.
 
-**Why it's not enforced in this PR.** The infrastructure is already there — `--with=codex`, `--with=claude`, `--with=pi` flags exist on the existing `dad review` flow and work for `dad watch` too. Enforcing or recommending a different model than the user's agent uses would require knowing what their agent uses, which we don't.
+**Why it's not enforced.** The infrastructure is already there — `--with=codex`, `--with=claude`, `--with=pi` flags exist on the existing `dad review` flow and work for `dad watch` too. Enforcing or recommending a different model than the user's agent uses would require knowing what their agent uses, which we don't.
 
-**Future path.** README and the `dad watch` first-run prompt should explicitly recommend cross-family narration: "Tip: if Claude wrote the code, run `dad watch --with=codex` (or similar) for a more independent read." Not gating the PR, but worth landing before any public release.
+**Future path.** README and the `dad watch` first-run prompt should explicitly recommend cross-family narration: "Tip: if Claude wrote the code, run `dad watch --with=codex` (or similar) for a more independent read." Worth landing before any public release.
 
-### 8. UI affordances for comments in watch mode
+### 8. Working with non-git VCSes
 
-The current state is a small honesty bug: the existing line-comment and chapter-comment UI from PR mode is still rendered in watch mode (it's the same `Chapter` component), but watch mode's server has no `/api/comments` or `/api/review` endpoints. Drafts get saved to `localStorage` and never go anywhere.
+Mercurial, jj, sapling, etc. are all out of scope. Watch mode shells out to `git` directly. Adding VCS abstraction is far ahead of where the user-facing feature is in maturity.
 
-**Resolution.** Follow-up commit will hide the comment-add affordances entirely in watch mode. When the feedback loop ships, those affordances come back with a real destination — and that's a more satisfying landing than "incrementally less broken drafts."
-
-### 9. Working with non-git VCSes
-
-Mercurial, jj, sapling, etc. are all out of scope. Watch mode shells out to `git` directly via `Bun.spawn`. Adding VCS abstraction is far ahead of where the user-facing feature is in maturity.
-
-### 10. Multi-branch / multi-repo watching
+### 9. Multi-branch / multi-repo watching
 
 `dad watch` watches one branch in one repo. Not a "dashboard of all my in-flight work." That's a real product surface but a different one — likely better as a separate `dad dashboard` command that aggregates results from many `dad watch` runs.
 
 ---
 
-## Architectural decisions worth flagging for future maintainers
-
-These are the choices that shaped the PR's structure. Calling them out here so they're easy to revisit if assumptions change.
-
-### Per-commit as the narration unit, not the rolling story
-
-The first instinct was "narrate `base..HEAD` as one story, regenerate on every commit." That has two failure modes:
-- **Cost.** You re-narrate the entire branch on every commit. 30 commits = 30 full-branch narrations.
-- **Narrative collage drift.** Each regeneration is a fresh take — chapter structure shifts, tone shifts, callouts move. The user's mental model of "the story so far" gets perturbed every commit.
-
-Per-commit narration gives:
-- **Cheap incrementals.** Each commit's narrative is small and cached forever once generated.
-- **Honest unit boundaries.** Each chapter set corresponds to one commit. Easier for the user to reason about "what did this commit do."
-- **Stable cache keying.** SHA in, narrative out. Stable.
-
-The unified view is offered as an explicit, on-demand, **separate** narration of `base..HEAD` — not stitched from the per-commit ones. Stitching produces incoherence; a fresh full-branch narration produces a real story. The cost of one occasional unified call is justified by the quality difference.
-
-### Watch mode is a separate server, not a retrofit of `dad review`
-
-`packages/cli/src/server.ts` is built around PR mode: GitHub client, comment posting, review submission, check-run polling, comment-to-chapter mapping. Trying to graft "no GitHub, no comments, no PR" onto that produced a tangle of `if (mode === 'watch')` branches. A parallel `watch-server.ts` is cleaner and cheaper to maintain.
-
-The frontend, in contrast, *is* a retrofit — same Zustand store, same `Chapter`/`StoryView` components, just gated by a `mode: 'pr' | 'watch'` flag and a watch slice. That's because the *display* of a narrative is genuinely the same operation regardless of where the narrative came from. The data path is the part that diverges.
-
-### Polling vs file-watching for new commits
-
-`fs.watch` on `.git/refs/heads/<branch>` doesn't work reliably:
-- Packed refs (`git pack-refs`, common after `git gc`) move ref contents into a single file; per-branch files cease to exist.
-- `fs.watch` on Linux uses inotify and silently misses events on some FS types and over network mounts.
-
-A 2-second poll of `git rev-parse <branch>` is universally reliable, costs ~30 cheap subprocess calls per minute, and avoids the entire reliability matrix above. The simplicity-vs-latency tradeoff is favorable: 2 seconds is well below human perception for "did my commit register?" and far below the LLM call latency that dominates the actual narration timing.
-
-### Scrutinize prompt as an addendum, not a separate prompt
-
-The narrative engine (chapters, sections, callouts, missing array, verdict) is the same in both modes — what changes is the *framing*. Modeling that as a system-prompt addendum keeps:
-- One JSON schema for both modes.
-- One frontend rendering pipeline.
-- One place to evolve narrative quality (changes to the base prompt benefit both modes; changes to the addendum only affect scrutinize).
-
-The addendum explicitly asks for: *what's questionable, what's missing, what would a senior reviewer push back on*; prefers concern/warning callouts over nits; defaults verdict to "caution"; tells the model to be honest about what it can't verify from the diff alone.
-
-### Synthetic PR metadata
-
-The frontend was designed around `PRMetadata`. Rather than fork the components, watch mode constructs PR-shaped objects from local commit data — `number: 0` as a sentinel for "no PR yet", `state: 'open'`, `branch`/`base` from the branch and base ref, `additions`/`deletions`/`changedFiles` from `git diff --numstat`. The UI components don't have to know they're showing a watch-mode artifact; they just render a PR-shaped object the same way they always do.
-
-The only frontend change is a `mode === 'watch'` branch in `App.tsx` that swaps `PRHeader` (PR-specific chrome: GitHub link, checks, reviews, submit-review button) for `WatchHeader` + `CommitTimeline`.
-
----
-
 ## Risks and what to watch for in real use
 
-Things that are more likely to bite than the obvious bugs:
+Things more likely to bite than the obvious bugs:
 
-1. **Trust amplification.** The whole risk this PR addresses is "you don't scrutinize your agent's code carefully enough." The risk this PR *introduces* is "the narrator describes the code so well that you trust it more, not less." If the scrutinize prompt produces compelling but vague pushback, the user may nod along to the *narration* the way they were nodding along to the code. Watch for: do you act on the missing-items list? Do callouts make you change anything? If the answer is "rarely" after a few weeks, the prompt needs sharper teeth.
+1. **Trust amplification.** The whole risk this design addresses is "you don't scrutinize your agent's code carefully enough." The risk it *introduces* is "the narrator describes the code so well that you trust it more, not less." If the scrutinize prompt produces compelling but vague pushback, the user may nod along to the *narration* the way they were nodding along to the code. Watch for: do you act on the missing-items list? Do callouts make you change anything? If the answer is "rarely" after a few weeks, the prompt needs sharper teeth — likely starting with the "be specific enough that the reader can verify in under a minute" rule and tightening it further.
 
-2. **Same-family blind spots.** If you let it default to `claude` and your agent is also Claude, you're checking Claude's work with Claude. Consider a docs nudge toward `--with=codex` or similar.
+2. **Comprehension layer that's too long, scrutiny layer that's too short.** The two-layer prompt structure is a balance. If chapters become reading-comprehension exercises and the callouts feel tacked on, the reader skims the prose and never reaches the questions. Prefer concise comprehension ("before X, after Y, consequence Z") over expansive prose. The scrutiny layer should usually be at least as long as the comprehension layer.
 
-3. **Narrative cost on large branches.** A 50-commit feature is 50 narrations. Caching helps, but the first-time generation isn't free. If this becomes a pain point, the levers are: tier models (cheap/fast for incremental, expensive/good for unified), debounce harder (only narrate on push, not commit), or skip-narrate noisy commits (configurable patterns: "ignore commits matching ^fixup!", etc.).
+3. **Same-family blind spots.** If you let it default to `claude` and your agent is also Claude, you're checking Claude's work with Claude. Docs nudge toward `--with=codex` or similar.
 
-4. **The feature hits its own ceiling.** If you find yourself wanting to talk back — "yes Dad, but this hunk is fine because..." — that's the signal that the feedback loop is actually needed. Note when and why you wanted that, and feed it into the eventual feedback-loop design conversation. The wishlist of "things I wanted to say to a commit's narrative" is the highest-value design input we could collect right now.
+4. **Narrative cost on long-running branches.** Even with on-demand-by-default, if the user clicks every commit out of curiosity, costs add up. Levers: tier models (cheap/fast for incremental, expensive/good for unified), debounce harder (e.g., narrate on push rather than every commit), or skip-narrate noisy commits (configurable patterns: "ignore commits matching ^fixup!", etc.).
+
+5. **The feature hits its own ceiling.** If you find yourself wanting to talk back — "yes Dad, but this hunk is fine because..." — that's the signal that the feedback loop is actually needed. Note when and why you wanted that, and feed it into the eventual feedback-loop design conversation. The wishlist of "things I wanted to say to a commit's narrative" is the highest-value design input we could collect right now.
+
+6. **Unnarrated commits feeling like dead weight.** With on-demand-by-default, the sidebar will mostly show ○ (unnarrated) rows. If the user scrolls past them and forgets they're clickable, the timeline becomes vestigial. Watch for: do unnarrated rows actually get clicked? If "Whole branch" wins every time, maybe per-commit narration isn't the value driver and we should rethink the unit.
 
 ---
 
 ## Success looks like
 
 - You finish a feature with the help of an agent and you can actually *describe* what it built — not just "it works", but the behavioral changes, the assumptions made, the moving parts. The narration filled in the gap between "I prompted" and "I understand."
-- For each commit, Dad's narration surfaced at least one absence, callout, or "verify that…" note that you actually acted on.
+- For each commit you bothered to narrate, Dad's output surfaced at least one absence, callout, or "verify that…" note that you actually acted on.
 - When you open the PR, your description is informed by Dad's unified view — you didn't have to write it from scratch, and the things you say in it match what's actually in the diff because you read the story before posting.
 - Your teammates' reviews catch fewer things you should have caught yourself.
 - You trust Dad more when it flags concerns than when it's quiet — i.e., it's calibrated, not just verbose.
 
 ## Failure looks like
 
-- Narratives feel triumphant. You read them, nod, ship. Bugs make it through anyway.
-- Cost runs up faster than expected and you stop running watch mode on long branches.
-- You keep reaching for affordances that don't exist (comments, agent direction, etc.) and feel limited.
-- Narrative drift across a long branch makes the unified view feel disconnected from the per-commit ones.
+- Narratives feel triumphant. You read them, nod, ship. Bugs make it through anyway. → Sharpen the scrutinize layer of the prompt.
+- Narratives are pure pushback with no scaffolding. You bounce off them because they assume understanding you don't have. → Strengthen the comprehension layer; check the two-layer sequencing isn't being collapsed by the model.
+- Cost runs up faster than expected and you stop running watch mode on long branches. → Tier models, debounce harder, or revisit auto-narrate-latest.
+- You keep reaching for affordances that don't exist (comments, agent direction, etc.) and feel limited. → That's the signal; design the feedback loop next, informed by your specific reach-for moments.
+- Narrative drift across a long branch makes the unified view feel disconnected from the per-commit ones. → The unified view is a separate fresh narration by design, but if the inconsistency is jarring, consider sharing context (previous unified summary) on regeneration.
 
 Each of those is actionable, and each tells us something specific about what to build next. The point of shipping the read-only half first is to *earn* that signal.

--- a/docs/superpowers/plans/2026-05-03-dad-watch-walking-skeleton.md
+++ b/docs/superpowers/plans/2026-05-03-dad-watch-walking-skeleton.md
@@ -1,0 +1,1127 @@
+# Dad Watch — Walking Skeleton Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Realign the existing `dad watch` plumbing with the spec's branch-first vision: whole-branch story becomes the primary view, an immediate local skeleton renders before any model call, and per-commit narration drops back to on-demand only.
+
+**Architecture:** Most scaffolding (CLI command, watch-server, polling, unified-cache, commit-cache, web mode) already exists at `packages/cli/src/{cli.ts,watch-server.ts,git/local.ts}` and `packages/web/src/...`. This plan does not rebuild it; it (a) makes whole-branch the default selection and auto-fires it on startup, (b) removes the eager per-commit narration loop, (c) adds a local skeleton (touched directories, file categorization, notable files) that renders without the LLM, and (d) wires that skeleton into the UI before the narrative arrives. A retrospective spike confirms whether the parallel server split deserves any consolidation.
+
+**Tech Stack:** Bun + TypeScript + Hono (CLI), React 19 + Zustand + Tailwind v4 (web), vitest for tests.
+
+**Spec reference:** `docs/dad-watch.md` — "Build now" items 1, 2, 3.
+
+---
+
+## What already exists (do NOT rebuild)
+
+- `dad watch [branch] [--base <ref>]` CLI flow — `packages/cli/src/cli.ts:314-480`
+- Watch server with SSE, synthetic PR, commit + unified narration, cache hits — `packages/cli/src/watch-server.ts`
+- Local git helpers: `findRepoRoot`, `detectBaseBranch`, `mergeBase`, `listCommits`, `getDiffForRange`, `getDiffForCommit`, `getRangeStats`, `getCommitStats`, `repoFingerprint`, `getRemoteSlug` — `packages/cli/src/git/local.ts`
+- Unified cache by `(repoFp, baseSha, headSha)` — `packages/cli/src/narrative/cache.ts:89-110`
+- 2-second poll for new commits, refresh + drop orphaned narratives — `cli.ts:418-470`
+- Web mode = 'watch' with `WatchHeader`, `CommitTimeline`, `StoryView` rendering — `App.tsx:125-148`
+- "Whole branch" toggle pill in commit timeline (currently opt-in) — `CommitTimeline.tsx:70-87`
+
+The plan modifies these files; it does not duplicate the work.
+
+---
+
+## File Structure
+
+**Create:**
+- `packages/cli/src/watch/skeleton.ts` — file categorization + skeleton builder (pure functions, no I/O)
+- `packages/cli/src/__tests__/watch-skeleton.test.ts` — vitest tests for the classifier and aggregator
+- `packages/web/src/components/BranchSkeletonView.tsx` — pre-narrative view that renders local facts immediately
+
+**Modify:**
+- `packages/cli/src/watch-server.ts` — wire skeleton into `/api/narrative` payload; default `selectionFromQuery` to unified
+- `packages/cli/src/cli.ts` — auto-fire `narrateUnified` on startup; remove eager per-commit narration loop; keep on-new-commit refresh but stop auto-narrating each new commit
+- `packages/web/src/state/types.ts` — add `BranchSkeleton`, extend `WatchData`
+- `packages/web/src/state/review-store.ts` — store skeleton (keep changes minimal: skeleton lives inside `watch`)
+- `packages/web/src/App.tsx` — render `BranchSkeletonView` in watch mode when narrative is missing instead of `GeneratingScreen`
+- `packages/web/src/components/CommitTimeline.tsx` — make "Whole branch" the visually-active default when `selection.kind === 'unified'` (already true; verify) and surface a pending-narrative pill
+- `packages/web/src/components/WatchHeader.tsx` — no behavior change required (it already adapts to `selection.kind`); verify "Whole branch" default copy reads sensibly
+
+**Spike note (Task 0):** the spec asserts a parallel `watch-server.ts` is "cleaner" than grafting watch onto `server.ts`. That split already exists; the spike's job is retrospective — confirm the split was warranted and decide on optional small extractions.
+
+---
+
+## Task 0: Retrospective spike — server-split audit
+
+**Files:**
+- Read: `packages/cli/src/server.ts`, `packages/cli/src/watch-server.ts`
+- Output: `docs/superpowers/plans/2026-05-03-dad-watch-walking-skeleton.md` (append "Spike findings" section)
+
+This task produces a written decision, not code (unless a trivial extraction is obvious).
+
+- [ ] **Step 1: Diff the surfaces**
+
+List the routes each server defines and note which are unique vs shared. Append to this plan under a "Spike findings" heading. Expected list:
+
+```
+server.ts (PR mode):
+  GET  /api/narrative         (PR data + cached/generating narrative)
+  POST /api/ai                (ask, renarrate)
+  GET  /api/checks            (GitHub check-runs refresh)
+  GET  /api/comments          (GitHub review comments refresh)
+  GET  /api/events            (SSE: pr, comments, checks, reviews, narrative)
+  POST /api/comments          (post a GitHub comment)
+  POST /api/review            (submit a GitHub review)
+  GET  /*                     (static)
+
+watch-server.ts (watch mode):
+  GET  /api/narrative         (watch payload + selection-driven narrative)
+  POST /api/narrative/unified (kick off unified narration)
+  POST /api/narrative/commit  (kick off commit narration)
+  GET  /api/events            (SSE: watch-update, commit-narrating, commit-narrative, unified-narrating, unified-narrative, *-error)
+  GET  /*                     (static)
+```
+
+- [ ] **Step 2: Identify duplicated plumbing**
+
+The genuinely duplicated blocks are SSE writer setup and the `webDist` resolution + serveStatic mount. Confirm by reading both files. Document the count of duplicated lines (rough order: ~40 lines combined).
+
+- [ ] **Step 3: Decide and document**
+
+Write a 6-10 line "Spike findings" section to this plan with:
+- Verdict (keep split / collapse / extract helpers)
+- Reasoning (API surfaces actually diverge: watch has no GitHub I/O, no comments/reviews/checks; PR mode polls GitHub on a 10s interval, watch is driven by cli polling)
+- Optional follow-up (small `server-utils.ts` with `attachStaticAssets(app)` and `makeSseHandler()` — out of scope for this plan, but worth noting)
+
+Default verdict: keep the split, defer extraction. The split is justified by surface divergence; extraction is a cosmetic win that doesn't unlock any spec item.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/plans/2026-05-03-dad-watch-walking-skeleton.md
+git commit -m "docs(plan): spike findings on watch/PR server split"
+```
+
+---
+
+## Task 1: Skeleton module — classifier + aggregator (TDD)
+
+**Files:**
+- Create: `packages/cli/src/watch/skeleton.ts`
+- Test: `packages/cli/src/__tests__/watch-skeleton.test.ts`
+
+The skeleton is the cheap-local-facts surface. It must run synchronously off `DiffFile[]` returned by `parseDiff(getDiffForRange(...))` — no I/O, no model calls. The watch-server already loads `DiffFile[]` for the unified range; the skeleton consumes that list.
+
+### Types
+
+Define in `skeleton.ts`:
+
+```ts
+export type FileCategory = 'test' | 'config' | 'schema' | 'migration' | 'docs' | 'public-api' | 'source';
+
+export type SkeletonFile = {
+  path: string;
+  category: FileCategory;
+  additions: number;
+  deletions: number;
+  isNewFile: boolean;
+  isDeleted: boolean;
+};
+
+export type BranchSkeleton = {
+  totals: { additions: number; deletions: number; changedFiles: number };
+  byCategory: Record<FileCategory, number>;
+  touchedDirs: { dir: string; count: number }[]; // top 8, sorted by count desc
+  notable: SkeletonFile[]; // top 5 by (additions + deletions), excluding pure deletions of small files
+  files: SkeletonFile[];   // every file, in insertion order
+};
+```
+
+- [ ] **Step 1: Write failing tests**
+
+Create `packages/cli/src/__tests__/watch-skeleton.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import type { DiffFile } from '../github/types';
+import { buildBranchSkeleton, classifyFile } from '../watch/skeleton';
+
+function file(path: string, opts: Partial<{ additions: number; deletions: number; isNewFile: boolean; isDeleted: boolean }> = {}): DiffFile {
+  const adds = opts.additions ?? 1;
+  const dels = opts.deletions ?? 0;
+  return {
+    file: path,
+    isNewFile: opts.isNewFile ?? false,
+    isDeleted: opts.isDeleted ?? false,
+    hunks: [
+      {
+        header: '@@ -1,1 +1,1 @@',
+        oldStart: 1,
+        oldCount: dels,
+        newStart: 1,
+        newCount: adds,
+        lines: [
+          ...Array.from({ length: adds }, (_, i) => ({ type: 'add' as const, content: `a${i}`, lineNumber: { new: i + 1 } })),
+          ...Array.from({ length: dels }, (_, i) => ({ type: 'remove' as const, content: `d${i}`, lineNumber: { old: i + 1 } })),
+        ],
+      },
+    ],
+  };
+}
+
+describe('classifyFile', () => {
+  it('detects tests by directory', () => {
+    expect(classifyFile('packages/cli/src/__tests__/foo.test.ts')).toBe('test');
+    expect(classifyFile('src/foo.spec.ts')).toBe('test');
+    expect(classifyFile('tests/integration/api.ts')).toBe('test');
+  });
+
+  it('detects migrations', () => {
+    expect(classifyFile('db/migrations/0001_init.sql')).toBe('migration');
+    expect(classifyFile('prisma/migrations/20240101_x/migration.sql')).toBe('migration');
+  });
+
+  it('detects schemas', () => {
+    expect(classifyFile('prisma/schema.prisma')).toBe('schema');
+    expect(classifyFile('src/db/schema.ts')).toBe('schema');
+    expect(classifyFile('src/types/schema.ts')).toBe('schema');
+  });
+
+  it('detects config', () => {
+    expect(classifyFile('vite.config.ts')).toBe('config');
+    expect(classifyFile('tailwind.config.js')).toBe('config');
+    expect(classifyFile('tsconfig.json')).toBe('config');
+    expect(classifyFile('.oxlintrc.json')).toBe('config');
+    expect(classifyFile('package.json')).toBe('config');
+    expect(classifyFile('bun.lock')).toBe('config');
+  });
+
+  it('detects docs', () => {
+    expect(classifyFile('README.md')).toBe('docs');
+    expect(classifyFile('docs/dad-watch.md')).toBe('docs');
+    expect(classifyFile('CHANGELOG.md')).toBe('docs');
+  });
+
+  it('detects public api', () => {
+    expect(classifyFile('packages/cli/src/index.ts')).toBe('public-api');
+    expect(classifyFile('src/types/public.d.ts')).toBe('public-api');
+  });
+
+  it('falls back to source', () => {
+    expect(classifyFile('src/lib/foo.ts')).toBe('source');
+    expect(classifyFile('packages/web/src/components/Hunk.tsx')).toBe('source');
+  });
+});
+
+describe('buildBranchSkeleton', () => {
+  const files: DiffFile[] = [
+    file('packages/cli/src/watch-server.ts', { additions: 80, deletions: 10 }),
+    file('packages/cli/src/__tests__/watch.test.ts', { additions: 40, deletions: 0, isNewFile: true }),
+    file('packages/web/src/components/Foo.tsx', { additions: 20, deletions: 5 }),
+    file('packages/web/src/components/Bar.tsx', { additions: 5, deletions: 1 }),
+    file('docs/dad-watch.md', { additions: 200, deletions: 0 }),
+    file('vite.config.ts', { additions: 2, deletions: 1 }),
+  ];
+
+  it('counts totals and category buckets', () => {
+    const s = buildBranchSkeleton(files);
+    expect(s.totals.changedFiles).toBe(6);
+    expect(s.totals.additions).toBe(347);
+    expect(s.totals.deletions).toBe(17);
+    expect(s.byCategory.test).toBe(1);
+    expect(s.byCategory.docs).toBe(1);
+    expect(s.byCategory.config).toBe(1);
+    expect(s.byCategory.source).toBe(3);
+  });
+
+  it('aggregates touched directories sorted by count', () => {
+    const s = buildBranchSkeleton(files);
+    const top = s.touchedDirs[0];
+    expect(top.dir).toBe('packages/web/src/components');
+    expect(top.count).toBe(2);
+  });
+
+  it('flags notable files by total change size', () => {
+    const s = buildBranchSkeleton(files);
+    expect(s.notable[0].path).toBe('docs/dad-watch.md');
+    expect(s.notable.length).toBeLessThanOrEqual(5);
+  });
+
+  it('records every file in files[] preserving order', () => {
+    const s = buildBranchSkeleton(files);
+    expect(s.files.map((f) => f.path)).toEqual(files.map((f) => f.file));
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+bun test packages/cli/src/__tests__/watch-skeleton.test.ts
+```
+
+Expected: FAIL — module `../watch/skeleton` does not exist.
+
+- [ ] **Step 3: Implement `skeleton.ts`**
+
+Create `packages/cli/src/watch/skeleton.ts`:
+
+```ts
+import type { DiffFile } from '../github/types';
+
+export type FileCategory = 'test' | 'config' | 'schema' | 'migration' | 'docs' | 'public-api' | 'source';
+
+export type SkeletonFile = {
+  path: string;
+  category: FileCategory;
+  additions: number;
+  deletions: number;
+  isNewFile: boolean;
+  isDeleted: boolean;
+};
+
+export type BranchSkeleton = {
+  totals: { additions: number; deletions: number; changedFiles: number };
+  byCategory: Record<FileCategory, number>;
+  touchedDirs: { dir: string; count: number }[];
+  notable: SkeletonFile[];
+  files: SkeletonFile[];
+};
+
+const TEST_RE = /(^|\/)(__tests__|tests?)\//i;
+const TEST_SUFFIX_RE = /\.(test|spec)\.[a-z0-9]+$/i;
+const MIGRATION_RE = /(^|\/)migrations?\//i;
+const SCHEMA_RE = /(^|\/)(schema)\.(ts|js|prisma|sql)$/i;
+const SCHEMA_PRISMA_RE = /(^|\/)prisma\/schema\.prisma$/i;
+const DOCS_RE = /(^|\/)docs?\//i;
+const MARKDOWN_RE = /\.(md|mdx)$/i;
+const PUBLIC_API_RE = /(^|\/)(src\/index|index)\.(ts|tsx|js)$/i;
+const DTS_RE = /\.d\.ts$/i;
+const CONFIG_FILES = new Set([
+  'package.json',
+  'bun.lock',
+  'package-lock.json',
+  'yarn.lock',
+  'tsconfig.json',
+  '.oxlintrc.json',
+  '.oxfmtrc.json',
+  '.gitignore',
+  '.npmrc',
+]);
+const CONFIG_PATTERNS = [
+  /\.config\.(ts|js|mjs|cjs|json)$/i,
+  /(^|\/)(vite|vitest|tailwind|eslint|prettier|postcss|babel|rollup|webpack)\.config\./i,
+  /(^|\/)\.[a-z0-9-]+rc(\.[a-z]+)?$/i, // .eslintrc, .prettierrc, .oxlintrc.json (also caught above)
+];
+
+export function classifyFile(path: string): FileCategory {
+  if (TEST_RE.test(path) || TEST_SUFFIX_RE.test(path)) return 'test';
+  if (MIGRATION_RE.test(path)) return 'migration';
+  if (SCHEMA_PRISMA_RE.test(path) || SCHEMA_RE.test(path)) return 'schema';
+  const basename = path.split('/').pop() ?? path;
+  if (CONFIG_FILES.has(basename)) return 'config';
+  if (CONFIG_PATTERNS.some((re) => re.test(path))) return 'config';
+  if (MARKDOWN_RE.test(path) || DOCS_RE.test(path)) return 'docs';
+  if (PUBLIC_API_RE.test(path) || DTS_RE.test(path)) return 'public-api';
+  return 'source';
+}
+
+function countLines(file: DiffFile): { additions: number; deletions: number } {
+  let additions = 0;
+  let deletions = 0;
+  for (const h of file.hunks) {
+    for (const l of h.lines) {
+      if (l.type === 'add') additions += 1;
+      else if (l.type === 'remove') deletions += 1;
+    }
+  }
+  return { additions, deletions };
+}
+
+function dirOf(path: string): string {
+  const i = path.lastIndexOf('/');
+  return i === -1 ? '' : path.slice(0, i);
+}
+
+export function buildBranchSkeleton(files: DiffFile[]): BranchSkeleton {
+  const skeletonFiles: SkeletonFile[] = files.map((f) => {
+    const { additions, deletions } = countLines(f);
+    return {
+      path: f.file,
+      category: classifyFile(f.file),
+      additions,
+      deletions,
+      isNewFile: f.isNewFile,
+      isDeleted: f.isDeleted,
+    };
+  });
+
+  const totals = skeletonFiles.reduce(
+    (acc, f) => ({
+      additions: acc.additions + f.additions,
+      deletions: acc.deletions + f.deletions,
+      changedFiles: acc.changedFiles + 1,
+    }),
+    { additions: 0, deletions: 0, changedFiles: 0 },
+  );
+
+  const byCategory: Record<FileCategory, number> = {
+    test: 0,
+    config: 0,
+    schema: 0,
+    migration: 0,
+    docs: 0,
+    'public-api': 0,
+    source: 0,
+  };
+  for (const f of skeletonFiles) byCategory[f.category] += 1;
+
+  const dirCounts = new Map<string, number>();
+  for (const f of skeletonFiles) {
+    const d = dirOf(f.path) || '.';
+    dirCounts.set(d, (dirCounts.get(d) ?? 0) + 1);
+  }
+  const touchedDirs = [...dirCounts.entries()]
+    .map(([dir, count]) => ({ dir, count }))
+    .sort((a, b) => b.count - a.count || a.dir.localeCompare(b.dir))
+    .slice(0, 8);
+
+  const notable = [...skeletonFiles]
+    .sort((a, b) => b.additions + b.deletions - (a.additions + a.deletions))
+    .slice(0, 5);
+
+  return { totals, byCategory, touchedDirs, notable, files: skeletonFiles };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+bun test packages/cli/src/__tests__/watch-skeleton.test.ts
+```
+
+Expected: PASS — all 8 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/watch/skeleton.ts packages/cli/src/__tests__/watch-skeleton.test.ts
+git commit -m "$(cat <<'EOF'
+feat(watch): add branch skeleton classifier and aggregator
+
+Pure functions that turn DiffFile[] into a BranchSkeleton: file
+category, touched directories, notable files. Renders before any
+LLM call returns.
+EOF
+)"
+```
+
+---
+
+## Task 2: Wire skeleton into `/api/narrative` payload
+
+**Files:**
+- Modify: `packages/cli/src/watch-server.ts:339-385` (the `/api/narrative` handler) and the `WatchPayload` type at `:51-59`
+
+The skeleton should be computed from the unified-range diff (`base...headSha`) and included in every `/api/narrative` response so the UI can render it without waiting for the model. Cache the computed skeleton in `WatchServerContext` keyed by `(baseSha, headSha)` to avoid recomputing on every request.
+
+- [ ] **Step 1: Extend `WatchPayload` and `WatchServerContext`**
+
+Add to `watch-server.ts`:
+
+```ts
+import { buildBranchSkeleton, type BranchSkeleton } from './watch/skeleton';
+```
+
+Update the `WatchPayload` type to include `skeleton: BranchSkeleton`:
+
+```ts
+type WatchPayload = {
+  branch: string;
+  base: string;
+  baseSha: string;
+  headSha: string;
+  commits: CommitSummary[];
+  selection: { kind: 'commit'; sha: string } | { kind: 'unified' } | { kind: 'pending' };
+  unifiedReady: boolean;
+  skeleton: BranchSkeleton;
+};
+```
+
+Add a cached skeleton field to `WatchServerContext` (also exported):
+
+```ts
+export type WatchServerContext = {
+  // ...existing fields...
+  skeleton: BranchSkeleton | null;
+  skeletonKey: string | null; // `${baseSha}:${headSha}`
+};
+```
+
+- [ ] **Step 2: Compute and cache skeleton inside the request**
+
+In `createWatchServer`, add a helper:
+
+```ts
+async function getSkeleton(): Promise<BranchSkeleton> {
+  const key = `${ctx.baseSha}:${ctx.headSha}`;
+  if (ctx.skeleton && ctx.skeletonKey === key) return ctx.skeleton;
+  const files = await loadFilesForRange(ctx.repoRoot, ctx.base, ctx.headSha);
+  const skeleton = buildBranchSkeleton(files);
+  ctx.skeleton = skeleton;
+  ctx.skeletonKey = key;
+  return skeleton;
+}
+```
+
+Invalidate it inside `refreshCommits`:
+
+```ts
+async function refreshCommits(newCommits: LocalCommit[], newHeadSha: string) {
+  // ...existing code...
+  ctx.skeleton = null;
+  ctx.skeletonKey = null;
+  // ...rest...
+}
+```
+
+- [ ] **Step 3: Include skeleton in `/api/narrative` response**
+
+Inside the handler, after `buildCommitSummaries()`:
+
+```ts
+const skeleton = await getSkeleton();
+
+const watch: WatchPayload = {
+  branch: ctx.branch,
+  base: ctx.base,
+  baseSha: ctx.baseSha,
+  headSha: ctx.headSha,
+  commits: summaries,
+  selection,
+  unifiedReady,
+  skeleton,
+};
+```
+
+- [ ] **Step 4: Update `cli.ts` initialization to set the new context fields**
+
+In `packages/cli/src/cli.ts`, the `ctx: WatchServerContext = { ... }` literal at `:369-383` needs the two new fields:
+
+```ts
+const ctx: WatchServerContext = {
+  // ...existing...
+  skeleton: null,
+  skeletonKey: null,
+};
+```
+
+- [ ] **Step 5: Type-check + manual smoke**
+
+```bash
+bun run lint
+bun test packages/cli/src/__tests__/
+```
+
+Expected: green. (Lint may warn — fix any new errors.)
+
+Manual: in a repo with multiple commits ahead of main, run:
+
+```bash
+bun packages/cli/src/cli.ts watch --no-open
+```
+
+Then `curl -s localhost:<port>/api/narrative | jq '.watch.skeleton.totals, .watch.skeleton.byCategory, (.watch.skeleton.touchedDirs | length)'` and confirm sensible numbers. Stop the process with Ctrl-C.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cli/src/watch-server.ts packages/cli/src/cli.ts
+git commit -m "$(cat <<'EOF'
+feat(watch): include branch skeleton in /api/narrative payload
+
+Computed from base..HEAD on demand and cached on the server context
+keyed by (baseSha, headSha). Invalidated when refreshCommits fires.
+EOF
+)"
+```
+
+---
+
+## Task 3: Default selection = unified (whole-branch primary)
+
+**Files:**
+- Modify: `packages/cli/src/watch-server.ts:296-337` (`selectionFromQuery`)
+
+Right now `selectionFromQuery` returns the latest commit when no `sha`/`mode` is provided. The spec wants whole-branch as the primary unit.
+
+- [ ] **Step 1: Flip the default branch in `selectionFromQuery`**
+
+Replace the body. Show the full new function:
+
+```ts
+async function selectionFromQuery(c: { req: { query: (k: string) => string | undefined } }): Promise<{
+  selection: WatchPayload['selection'];
+  narrative: NarrativeResponse | null;
+  files: DiffFile[];
+  pr: PRMetadata;
+}> {
+  const sha = c.req.query('sha');
+  const mode = c.req.query('mode');
+
+  // Explicit per-commit request.
+  if (sha) {
+    const commit = ctx.commits.find((cm) => cm.sha === sha);
+    if (commit) {
+      const files = await loadFilesForCommit(ctx.repoRoot, commit.sha);
+      const pr = syntheticPrForCommit(ctx, commit, files);
+      const narrative = ctx.narratives.get(commit.sha) ?? null;
+      return { selection: { kind: 'commit', sha: commit.sha }, narrative, files, pr };
+    }
+    // Fall through to unified default if sha unknown.
+  }
+
+  // Default and `?mode=unified` both land on the whole-branch view.
+  if (ctx.commits.length === 0) {
+    return {
+      selection: { kind: 'pending' },
+      narrative: null,
+      files: [],
+      pr: syntheticPrForUnified(ctx, []),
+    };
+  }
+
+  const files = await loadFilesForRange(ctx.repoRoot, ctx.base, ctx.headSha);
+  const pr = syntheticPrForUnified(ctx, files);
+  const ready = ctx.unified && ctx.unifiedKey === `${ctx.baseSha}:${ctx.headSha}`;
+  return {
+    selection: { kind: 'unified' },
+    narrative: ready ? ctx.unified : null,
+    files,
+    pr,
+  };
+  // Note: `mode` query param is now informational; both undefined and
+  // 'unified' produce the same result.
+}
+```
+
+- [ ] **Step 2: Verify the request path**
+
+Manual: build, run `dad watch`, open the browser. The "Whole branch" pill in the timeline should be selected by default (it already styles `isUnified` correctly — verify visually). The main pane should render the unified narrative or the skeleton (Task 5+) while it generates.
+
+```bash
+bun run build
+bun packages/cli/src/cli.ts watch
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cli/src/watch-server.ts
+git commit -m "feat(watch): default selection to whole-branch view"
+```
+
+---
+
+## Task 4: Auto-fire unified narration on startup; remove eager per-commit loop
+
+**Files:**
+- Modify: `packages/cli/src/cli.ts:400-415` (the eager narration block) and the polling block at `:418-470`
+
+The current startup loop iterates `ctx.commits` and narrates each one synchronously. That contradicts the spec (per-commit on demand) and also blocks the unified narration from getting fair scheduling. Replace it.
+
+- [ ] **Step 1: Replace the startup narration block**
+
+In `cli.ts:watchCommand`, locate:
+
+```ts
+if (commits.length === 0) {
+  console.log(`  ${a.dim}No commits ahead of ${base} yet — waiting for new commits...${a.reset}`);
+} else {
+  console.log(`  ${a.yellow}Narrating ${commits.length} commit${commits.length === 1 ? '' : 's'}...${a.reset}`);
+  // Kick off narrations sequentially in the background; SSE updates the UI.
+  void (async () => {
+    for (const c of commits) {
+      await narrateCommit(c.sha, { broadcastWhenDone: true });
+      if (ctx.narratives.has(c.sha)) {
+        console.log(
+          `  ${a.green}✓${a.reset} ${a.gray}${c.shortSha}${a.reset} ${a.white}${c.subject}${a.reset}`,
+        );
+      }
+    }
+  })();
+}
+```
+
+Replace with:
+
+```ts
+const { narrateUnified } = createWatchServerHandle; // see Step 2 — destructure earlier
+
+if (commits.length === 0) {
+  console.log(`  ${a.dim}No commits ahead of ${base} yet — waiting for new commits...${a.reset}`);
+} else {
+  console.log(
+    `  ${a.yellow}Narrating whole branch${a.reset} ${a.dim}(${commits.length} commit${commits.length === 1 ? '' : 's'} as one story)${a.reset}`,
+  );
+  void (async () => {
+    const narrative = await narrateUnified();
+    if (narrative) {
+      console.log(
+        `  ${a.green}✓${a.reset} ${a.white}whole-branch story ready${a.reset} ${a.dim}(${narrative.chapters.length} chapters)${a.reset}`,
+      );
+    }
+  })();
+}
+```
+
+- [ ] **Step 2: Expose `narrateUnified` from `createWatchServer`**
+
+It is already returned (`return { app, broadcast, narrateCommit, narrateUnified, refreshCommits };` at the bottom of `watch-server.ts`). Update the destructure in `cli.ts:385`:
+
+```ts
+const { app, narrateUnified, refreshCommits } = createWatchServer(ctx);
+```
+
+`narrateCommit` is no longer needed at the cli layer (Task 4 removes its only caller); the watch-server uses it internally for the on-demand POST endpoint.
+
+- [ ] **Step 3: Update the polling block to refresh skeleton + re-fire unified**
+
+Find the `setInterval` at `cli.ts:420-471`. After the existing `await refreshCommits(freshCommits, freshHead)` call, also re-fire unified narration in the background (skeleton invalidation already happens inside `refreshCommits` thanks to Task 2):
+
+```ts
+ctx.baseSha = freshBase;
+await refreshCommits(freshCommits, freshHead);
+
+// Whole-branch story is the primary surface — regenerate it when the
+// branch moves. Per-commit narration stays on demand.
+void (async () => {
+  const narrative = await narrateUnified();
+  if (narrative) {
+    console.log(
+      `  ${a.green}✓${a.reset} ${a.white}whole-branch story refreshed${a.reset} ${a.dim}(${narrative.chapters.length} chapters)${a.reset}`,
+    );
+  }
+})();
+```
+
+Remove the `tickShas` block that polled `ctx.generating` for per-commit completion logging — it's dead now that commits aren't auto-narrated.
+
+- [ ] **Step 4: Make `narrateUnified` idempotent across stale calls**
+
+Read `watch-server.ts:225-258` (`narrateUnified`). It already early-returns when `ctx.unifiedGenerating` is true. After `refreshCommits` invalidates `ctx.unified`, the next call will start a fresh generation. Confirm by reading; no code change expected.
+
+- [ ] **Step 5: Build and smoke**
+
+```bash
+bun run build
+bun packages/cli/src/cli.ts watch --no-open
+```
+
+Expected console output (in a repo with N>0 commits):
+```
+  Narrating whole branch (N commits as one story)
+  http://localhost:XXXX
+  "<dad joke>"
+  ✓ whole-branch story ready (M chapters)
+```
+
+No per-commit `✓ <shortSha>` lines on startup. Open the browser; "Whole branch" is the default selection; the unified narrative renders.
+
+Then make a new commit on the watched branch in another terminal and confirm:
+- `↻ History rewritten` or `+ 1 new commit:` log fires
+- `✓ whole-branch story refreshed` follows
+- The browser updates via SSE
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cli/src/cli.ts
+git commit -m "$(cat <<'EOF'
+feat(watch): auto-narrate whole branch; remove eager per-commit loop
+
+The whole-branch story is the primary view per the spec; per-commit
+narration drops back to on-demand only. The polling tick still
+refreshes when the branch moves, and the unified narrative is
+regenerated alongside the skeleton.
+EOF
+)"
+```
+
+---
+
+## Task 5: Frontend skeleton type, state, and `BranchSkeletonView`
+
+**Files:**
+- Modify: `packages/web/src/state/types.ts`
+- Modify: `packages/web/src/state/review-store.ts` (no behavior change beyond accepting the extended `WatchData`)
+- Create: `packages/web/src/components/BranchSkeletonView.tsx`
+
+The skeleton needs to render even when `narrative` is `null`. It uses data from `useReviewStore((s) => s.watch.skeleton)`.
+
+- [ ] **Step 1: Add types**
+
+Append to `packages/web/src/state/types.ts`:
+
+```ts
+export type SkeletonFileCategory =
+  | 'test'
+  | 'config'
+  | 'schema'
+  | 'migration'
+  | 'docs'
+  | 'public-api'
+  | 'source';
+
+export type SkeletonFile = {
+  path: string;
+  category: SkeletonFileCategory;
+  additions: number;
+  deletions: number;
+  isNewFile: boolean;
+  isDeleted: boolean;
+};
+
+export type BranchSkeleton = {
+  totals: { additions: number; deletions: number; changedFiles: number };
+  byCategory: Record<SkeletonFileCategory, number>;
+  touchedDirs: { dir: string; count: number }[];
+  notable: SkeletonFile[];
+  files: SkeletonFile[];
+};
+```
+
+Then update `WatchData`:
+
+```ts
+export type WatchData = {
+  branch: string;
+  base: string;
+  baseSha: string;
+  headSha: string;
+  commits: WatchCommitSummary[];
+  selection: WatchSelection;
+  unifiedReady: boolean;
+  skeleton: BranchSkeleton;
+};
+```
+
+The store's `setWatch`/`patchWatch` already accept whatever `WatchData` shape we declare; no store changes are needed.
+
+- [ ] **Step 2: Create `BranchSkeletonView.tsx`**
+
+Create `packages/web/src/components/BranchSkeletonView.tsx`:
+
+```tsx
+import { useReviewStore } from '../state/review-store';
+import type { BranchSkeleton, SkeletonFileCategory } from '../state/types';
+
+const CATEGORY_LABELS: Record<SkeletonFileCategory, string> = {
+  test: 'Tests',
+  config: 'Config',
+  schema: 'Schema',
+  migration: 'Migrations',
+  docs: 'Docs',
+  'public-api': 'Public API',
+  source: 'Source',
+};
+
+const CATEGORY_ORDER: SkeletonFileCategory[] = [
+  'source',
+  'test',
+  'public-api',
+  'schema',
+  'migration',
+  'config',
+  'docs',
+];
+
+export function BranchSkeletonView({ message }: { message: string }) {
+  const watch = useReviewStore((s) => s.watch);
+  if (!watch) return null;
+  const { skeleton } = watch;
+  return (
+    <section className="px-6 py-6 text-[var(--fg-1)]">
+      <header className="mb-4">
+        <p className="text-[13px] uppercase tracking-[0.08em] text-[var(--fg-3)]">Branch skeleton</p>
+        <p className="mt-1 text-[15px] text-[var(--fg-2)]">{message}</p>
+      </header>
+
+      <Totals skeleton={skeleton} />
+      <Categories skeleton={skeleton} />
+      <TouchedDirs skeleton={skeleton} />
+      <Notable skeleton={skeleton} />
+    </section>
+  );
+}
+
+function Totals({ skeleton }: { skeleton: BranchSkeleton }) {
+  const { totals } = skeleton;
+  return (
+    <div className="mb-5 flex flex-wrap items-baseline gap-x-4 gap-y-1 text-[14px]">
+      <span className="font-medium" style={{ color: 'var(--green-11)' }}>+{totals.additions}</span>
+      <span className="font-medium" style={{ color: 'var(--red-11)' }}>−{totals.deletions}</span>
+      <span className="text-[var(--fg-2)]">across {totals.changedFiles} {totals.changedFiles === 1 ? 'file' : 'files'}</span>
+    </div>
+  );
+}
+
+function Categories({ skeleton }: { skeleton: BranchSkeleton }) {
+  const entries = CATEGORY_ORDER
+    .map((c) => ({ category: c, count: skeleton.byCategory[c] ?? 0 }))
+    .filter((e) => e.count > 0);
+  if (entries.length === 0) return null;
+  return (
+    <div className="mb-5">
+      <h3 className="mb-2 text-[12.5px] font-semibold uppercase tracking-[0.06em] text-[var(--fg-3)]">By category</h3>
+      <ul className="flex flex-wrap gap-2">
+        {entries.map(({ category, count }) => (
+          <li
+            key={category}
+            className="rounded-[6px] bg-[var(--gray-2)] px-2.5 py-1 text-[12.5px]"
+            style={{ boxShadow: 'inset 0 0 0 1px var(--gray-a4)' }}
+          >
+            <span className="font-medium text-[var(--fg-1)]">{CATEGORY_LABELS[category]}</span>
+            <span className="ml-1.5 text-[var(--fg-3)]">{count}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function TouchedDirs({ skeleton }: { skeleton: BranchSkeleton }) {
+  if (skeleton.touchedDirs.length === 0) return null;
+  return (
+    <div className="mb-5">
+      <h3 className="mb-2 text-[12.5px] font-semibold uppercase tracking-[0.06em] text-[var(--fg-3)]">Touched directories</h3>
+      <ul className="flex flex-col gap-1">
+        {skeleton.touchedDirs.map(({ dir, count }) => (
+          <li key={dir} className="flex items-center justify-between text-[13px]">
+            <span className="truncate font-mono text-[var(--fg-1)]">{dir || '.'}</span>
+            <span className="ml-3 text-[var(--fg-3)]">{count}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function Notable({ skeleton }: { skeleton: BranchSkeleton }) {
+  if (skeleton.notable.length === 0) return null;
+  return (
+    <div className="mb-2">
+      <h3 className="mb-2 text-[12.5px] font-semibold uppercase tracking-[0.06em] text-[var(--fg-3)]">Notable changes</h3>
+      <ul className="flex flex-col gap-1">
+        {skeleton.notable.map((f) => (
+          <li key={f.path} className="flex items-center justify-between text-[13px]">
+            <span className="truncate font-mono text-[var(--fg-1)]">{f.path}</span>
+            <span className="ml-3 text-[var(--fg-3)]">
+              <span style={{ color: 'var(--green-11)' }}>+{f.additions}</span>{' '}
+              <span style={{ color: 'var(--red-11)' }}>−{f.deletions}</span>
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Verify type-checking**
+
+```bash
+bun run --filter '@diffdad/web' build
+```
+
+Expected: build succeeds. If TypeScript complains about `WatchData.skeleton` in code paths that previously accepted partial watch data, narrow the access to inside `BranchSkeletonView` (which already guards on `watch`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/src/state/types.ts packages/web/src/components/BranchSkeletonView.tsx
+git commit -m "feat(web): add BranchSkeletonView and skeleton types"
+```
+
+---
+
+## Task 6: Render `BranchSkeletonView` before narrative arrives
+
+**Files:**
+- Modify: `packages/web/src/App.tsx:125-148` (the `mode === 'watch'` branch)
+
+The watch-mode branch currently renders `GeneratingScreen` when `narrative` is null. Swap it for `BranchSkeletonView`. Keep the loading-message rotation.
+
+- [ ] **Step 1: Replace `GeneratingScreen` in watch mode**
+
+In `App.tsx`, the watch-mode branch:
+
+```tsx
+if (mode === 'watch') {
+  return (
+    <div className="min-h-screen bg-[var(--bg-page)] pb-20 text-[var(--fg-1)]">
+      <AppBar onOpenActivity={() => setActivityOpen(true)} />
+      <WatchHeader />
+      <CommitTimeline />
+      {narrative ? (
+        view === 'story' ? <StoryView /> : <ClassicView />
+      ) : (
+        <BranchSkeletonView message={copy.loadingMessages[loadingMsgIndex]!} />
+      )}
+      <ActivityDrawer open={activityOpen} onClose={() => setActivityOpen(false)} />
+      <ShortcutsHelp open={shortcutsHelpOpen} onClose={() => setShortcutsHelpOpen(false)} />
+    </div>
+  );
+}
+```
+
+Add the import:
+
+```tsx
+import { BranchSkeletonView } from './components/BranchSkeletonView';
+```
+
+Remove the now-unused `GeneratingScreen` import only if no other branch uses it — the PR-mode branch at `:150` still does, so keep it.
+
+- [ ] **Step 2: Build and visually verify**
+
+```bash
+bun run build
+bun packages/cli/src/cli.ts watch
+```
+
+Open the browser. While the unified narrative is generating, you should see:
+- `WatchHeader` with branch/base/totals
+- `CommitTimeline` with "Whole branch" pill selected
+- `BranchSkeletonView` with totals, categories, touched dirs, notable files
+
+When narration completes, the skeleton view is replaced by `StoryView`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/web/src/App.tsx
+git commit -m "$(cat <<'EOF'
+feat(web): show branch skeleton before whole-branch narrative arrives
+
+Replaces the generic GeneratingScreen in watch mode with the cheap
+local-facts view, keeping the UI useful while the model runs.
+EOF
+)"
+```
+
+---
+
+## Task 7: End-to-end manual verification
+
+This is the gate before declaring the slice done.
+
+- [ ] **Step 1: Fresh build**
+
+```bash
+bun run build
+```
+
+- [ ] **Step 2: Smoke a real branch**
+
+Pick a branch with several commits ahead of `main`. From the diffdad repo this branch (`claude/realtime-code-review-feedback-3uWQd`) is fine.
+
+```bash
+bun packages/cli/src/cli.ts watch
+```
+
+Verify each:
+
+- [ ] Console shows "Narrating whole branch (N commits as one story)" — NOT a per-commit list.
+- [ ] Browser opens; "Whole branch" pill is selected by default.
+- [ ] `BranchSkeletonView` renders immediately (totals, categories, touched dirs, notable files) — before the model finishes.
+- [ ] When the unified narrative completes, `StoryView` replaces the skeleton.
+- [ ] Clicking a commit chip narrates that commit on demand and switches the main pane to the commit narrative.
+- [ ] Console shows "✓ whole-branch story ready (M chapters)" on completion.
+- [ ] Stop with Ctrl-C; console exits cleanly.
+
+- [ ] **Step 3: Branch movement**
+
+In another terminal, make a small commit on the watched branch. Confirm:
+
+- [ ] Console logs the new commit.
+- [ ] Console logs "✓ whole-branch story refreshed (...)" within ~2 polling ticks.
+- [ ] Browser timeline updates via SSE; the new commit appears.
+- [ ] Skeleton recomputes (totals/categories include the new file).
+
+- [ ] **Step 4: Cache hit**
+
+Restart `dad watch` on the same branch (no new commits). Verify:
+
+- [ ] No "Generating narrative" message — cache hit on `(repoFp, baseSha, headSha)`.
+- [ ] Whole-branch story renders immediately.
+
+- [ ] **Step 5: No commits ahead**
+
+Check out a branch with zero commits ahead of base (e.g., main itself):
+
+```bash
+git checkout main
+bun packages/cli/src/cli.ts watch
+```
+
+Verify:
+
+- [ ] Console: "No commits ahead of <base> yet — waiting for new commits..."
+- [ ] Browser shows the WatchHeader with "0 commits ahead" and a clear empty state. The skeleton is empty (zero totals, empty lists). No crash.
+
+- [ ] **Step 6: Lint and tests**
+
+```bash
+bun run lint
+bun test packages/cli/src/__tests__/
+```
+
+Both green.
+
+- [ ] **Step 7: Final commit (if any cleanup)**
+
+If the verification turned up small fixes, commit them with a clear message. Otherwise the slice is done.
+
+---
+
+## Out of scope (do NOT do here)
+
+These are listed in `docs/dad-watch.md` as "Build now" items 4-10 or "Consider and add later". They are deferred:
+
+- Calibrated review items (concerns/missing/verify) — needs the comprehension+scrutiny prompt rewrite, separate plan.
+- Latest-commit "what just changed" companion behavior — stays on the simpler "regenerate whole branch" path for the walking skeleton.
+- Feedback objects, agent-readable feedback store, MCP surface.
+- Manual resolution and dismissal UI.
+- Eager mode (`--eager`) for narrating all commits on short branches.
+- Working-tree auto-watch.
+- GitHub publishing (`dad publish`).
+- Stronger cross-rebase anchoring.
+
+A new plan should pick the next slice — likely the prompt rewrite + review-item schema, since that's load-bearing for everything downstream.
+
+---
+
+## Spike findings
+
+**Verdict: keep the split, defer extraction.**
+
+Routes verified against `server.ts` and `watch-server.ts` — match the expected list in Task 0 Step 1 exactly (PR mode: 7 API routes + static; watch mode: 4 API routes + static). API surfaces meaningfully diverge: watch mode has zero GitHub I/O (no `/api/checks`, `/api/comments`, `/api/review`, no `/api/ai`), while PR mode has none of watch's selection-driven payload, on-demand `POST /api/narrative/{unified,commit}` kicks, or commit-narration SSE events. The two `/api/narrative` handlers and the two `/api/events` handlers share names but not contracts — collapsing them would mean a router with `if (mode === 'watch')` branches in every handler.
+
+Genuinely duplicated plumbing is ~30 lines across the two files: the SSE writer/controller/abort wiring (~15 lines — PR mode then layers a 10s GitHub poll and a shutdown-joke timer on top, neither of which belongs in watch mode) and the `webDist` candidate resolution + `serveStatic` mount + SPA fallback (~16 lines, near-identical). Order-of-magnitude matches the plan's "~40 lines" estimate.
+
+**Optional follow-up (out of scope for this plan):** a small `packages/cli/src/server-utils.ts` exporting `attachStaticAssets(app)` and `makeSseHandler({ onConnect, onAbort })` would erase the duplication without forcing the surfaces to converge. Cosmetic only — does not unlock any spec item, so it is deferred.
+
+---
+
+## Self-review checklist
+
+**Spec coverage:**
+- Build-now item 1 (whole-branch primary) → Tasks 3, 4, 6.
+- Build-now item 2 (immediate local skeleton) → Tasks 1, 2, 5, 6.
+- Build-now item 3 (whole-branch narrative + cache) → Task 4 (auto-fire); Task 6 (renders it). Cache plumbing already exists.
+- Spike requested by the brief → Task 0.
+
+**No placeholders:** every step shows the actual code or the actual command. No "TBD" or "implement appropriately."
+
+**Type consistency:** `BranchSkeleton`, `SkeletonFile`, `FileCategory` (CLI side) ↔ `BranchSkeleton`, `SkeletonFile`, `SkeletonFileCategory` (web side) — names diverge intentionally because the web side avoids the bare-word `FileCategory` collision with general DOM types. Field names match exactly. `WatchData.skeleton` is non-optional on both sides because the server always sends one (empty when zero commits — verify in Task 7 Step 5; if it crashes, make it optional and adjust `BranchSkeletonView` to render an empty state).
+
+**Risks the plan already names:**
+- Empty branch (zero commits) — Task 7 Step 5 verifies the skeleton handles it without crashing.
+- Cache hit on cold start — Task 7 Step 4 verifies.
+- Polling-tick race between unified narration in flight and a new commit landing — `narrateUnified` early-returns when `ctx.unifiedGenerating`; the next tick will pick up the fresher key. Confirmed by reading the existing implementation; no code change.

--- a/packages/cli/src/__tests__/local-git.test.ts
+++ b/packages/cli/src/__tests__/local-git.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  detectBaseBranch,
+  findRepoRoot,
+  getCommitStats,
+  getCurrentBranch,
+  getDiffForCommit,
+  getDiffForRange,
+  getHeadSha,
+  getRangeStats,
+  listCommits,
+  mergeBase,
+  repoFingerprint,
+} from '../git/local';
+
+async function git(args: string[], cwd: string): Promise<void> {
+  const proc = Bun.spawn(['git', ...args], { cwd, stdout: 'pipe', stderr: 'pipe' });
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(`git ${args.join(' ')} failed: ${stderr}`);
+  }
+}
+
+async function gitOutput(args: string[], cwd: string): Promise<string> {
+  const proc = Bun.spawn(['git', ...args], { cwd, stdout: 'pipe', stderr: 'pipe' });
+  const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+  if (exitCode !== 0) throw new Error(`git ${args.join(' ')} failed`);
+  return stdout.trim();
+}
+
+async function makeRepo(): Promise<string> {
+  const repo = await mkdtemp(join(tmpdir(), 'diffdad-git-'));
+  await git(['init', '--initial-branch=main', '-q'], repo);
+  await git(['config', 'user.email', 'test@diffdad.local'], repo);
+  await git(['config', 'user.name', 'Test'], repo);
+  await git(['config', 'commit.gpgsign', 'false'], repo);
+  return repo;
+}
+
+const repos: string[] = [];
+
+afterEach(async () => {
+  while (repos.length > 0) {
+    const r = repos.pop();
+    if (r) await rm(r, { recursive: true, force: true });
+  }
+});
+
+describe('local git', () => {
+  it('finds the repo root and current branch', async () => {
+    const repo = await makeRepo();
+    repos.push(repo);
+    await writeFile(join(repo, 'a.txt'), 'hello\n');
+    await git(['add', 'a.txt'], repo);
+    await git(['commit', '-m', 'init'], repo);
+
+    expect(await findRepoRoot(repo)).toBe(repo);
+    expect(await getCurrentBranch(repo)).toBe('main');
+    const head = await getHeadSha('main', repo);
+    expect(head).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it('lists commits and skips merge commits', async () => {
+    const repo = await makeRepo();
+    repos.push(repo);
+    await writeFile(join(repo, 'a.txt'), 'hello\n');
+    await git(['add', 'a.txt'], repo);
+    await git(['commit', '-m', 'init'], repo);
+
+    await git(['checkout', '-b', 'feature'], repo);
+    await writeFile(join(repo, 'a.txt'), 'hello\nworld\n');
+    await git(['add', 'a.txt'], repo);
+    await git(['commit', '-m', 'add world'], repo);
+
+    await writeFile(join(repo, 'b.txt'), 'two\n');
+    await git(['add', 'b.txt'], repo);
+    await git(['commit', '-m', 'add b'], repo);
+
+    const commits = await listCommits('main', 'feature', repo);
+    expect(commits).toHaveLength(2);
+    expect(commits[0]!.subject).toBe('add world');
+    expect(commits[1]!.subject).toBe('add b');
+    expect(commits[0]!.shortSha.length).toBeGreaterThanOrEqual(7);
+  });
+
+  it('produces a diff for a single commit', async () => {
+    const repo = await makeRepo();
+    repos.push(repo);
+    await writeFile(join(repo, 'a.txt'), 'one\n');
+    await git(['add', 'a.txt'], repo);
+    await git(['commit', '-m', 'first'], repo);
+    await writeFile(join(repo, 'a.txt'), 'one\ntwo\n');
+    await git(['add', 'a.txt'], repo);
+    await git(['commit', '-m', 'second'], repo);
+
+    const head = await getHeadSha('main', repo);
+    const diff = await getDiffForCommit(head, repo);
+    expect(diff).toContain('a.txt');
+    expect(diff).toContain('+two');
+  });
+
+  it('produces a diff for a range and stats line up', async () => {
+    const repo = await makeRepo();
+    repos.push(repo);
+    await writeFile(join(repo, 'a.txt'), 'one\n');
+    await git(['add', 'a.txt'], repo);
+    await git(['commit', '-m', 'init'], repo);
+    const baseSha = await getHeadSha('main', repo);
+
+    await git(['checkout', '-b', 'feature'], repo);
+    await writeFile(join(repo, 'a.txt'), 'one\ntwo\nthree\n');
+    await git(['add', 'a.txt'], repo);
+    await git(['commit', '-m', 'add lines'], repo);
+
+    const rangeDiff = await getDiffForRange(baseSha, 'feature', repo);
+    expect(rangeDiff).toContain('+two');
+    expect(rangeDiff).toContain('+three');
+
+    const stats = await getRangeStats(baseSha, 'feature', repo);
+    expect(stats.additions).toBe(2);
+    expect(stats.deletions).toBe(0);
+    expect(stats.changedFiles).toBe(1);
+  });
+
+  it('handles root commits via getDiffForCommit', async () => {
+    const repo = await makeRepo();
+    repos.push(repo);
+    await writeFile(join(repo, 'a.txt'), 'hello\n');
+    await git(['add', 'a.txt'], repo);
+    await git(['commit', '-m', 'root'], repo);
+
+    const head = await getHeadSha('main', repo);
+    const diff = await getDiffForCommit(head, repo);
+    expect(diff).toContain('a.txt');
+    expect(diff).toContain('+hello');
+
+    const stats = await getCommitStats(head, repo);
+    expect(stats.additions).toBe(1);
+    expect(stats.deletions).toBe(0);
+  });
+
+  it('detects base branch via origin/HEAD when set, falls back to main', async () => {
+    const repo = await makeRepo();
+    repos.push(repo);
+    await writeFile(join(repo, 'a.txt'), 'hello\n');
+    await git(['add', 'a.txt'], repo);
+    await git(['commit', '-m', 'init'], repo);
+
+    // No origin remote set — should fall back to local 'main'.
+    const detected = await detectBaseBranch(repo);
+    expect(detected).toBe('main');
+  });
+
+  it('computes mergeBase for diverged branches', async () => {
+    const repo = await makeRepo();
+    repos.push(repo);
+    await writeFile(join(repo, 'a.txt'), 'one\n');
+    await git(['add', 'a.txt'], repo);
+    await git(['commit', '-m', 'init'], repo);
+    const initSha = await gitOutput(['rev-parse', 'HEAD'], repo);
+
+    await git(['checkout', '-b', 'feature'], repo);
+    await writeFile(join(repo, 'a.txt'), 'one\nfeature\n');
+    await git(['add', 'a.txt'], repo);
+    await git(['commit', '-m', 'feature work'], repo);
+
+    const base = await mergeBase('main', 'feature', repo);
+    expect(base).toBe(initSha);
+  });
+
+  it('produces a stable repo fingerprint', () => {
+    const a = repoFingerprint('/Users/x/code/diffdad');
+    const b = repoFingerprint('/Users/x/code/diffdad');
+    const c = repoFingerprint('/Users/x/code/other');
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+    expect(a).toMatch(/^[0-9a-f]{12}$/);
+  });
+});
+
+beforeAll(() => {
+  // touch import to silence unused-var for direct re-exports
+});

--- a/packages/cli/src/__tests__/watch-skeleton.test.ts
+++ b/packages/cli/src/__tests__/watch-skeleton.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import type { DiffFile } from '../github/types';
+import { buildBranchSkeleton, classifyFile } from '../watch/skeleton';
+
+function file(path: string, opts: Partial<{ additions: number; deletions: number; isNewFile: boolean; isDeleted: boolean }> = {}): DiffFile {
+  const adds = opts.additions ?? 1;
+  const dels = opts.deletions ?? 0;
+  return {
+    file: path,
+    isNewFile: opts.isNewFile ?? false,
+    isDeleted: opts.isDeleted ?? false,
+    hunks: [
+      {
+        header: '@@ -1,1 +1,1 @@',
+        oldStart: 1,
+        oldCount: dels,
+        newStart: 1,
+        newCount: adds,
+        lines: [
+          ...Array.from({ length: adds }, (_, i) => ({ type: 'add' as const, content: `a${i}`, lineNumber: { new: i + 1 } })),
+          ...Array.from({ length: dels }, (_, i) => ({ type: 'remove' as const, content: `d${i}`, lineNumber: { old: i + 1 } })),
+        ],
+      },
+    ],
+  };
+}
+
+describe('classifyFile', () => {
+  it('detects tests by directory', () => {
+    expect(classifyFile('packages/cli/src/__tests__/foo.test.ts')).toBe('test');
+    expect(classifyFile('src/foo.spec.ts')).toBe('test');
+    expect(classifyFile('tests/integration/api.ts')).toBe('test');
+  });
+
+  it('detects migrations', () => {
+    expect(classifyFile('db/migrations/0001_init.sql')).toBe('migration');
+    expect(classifyFile('prisma/migrations/20240101_x/migration.sql')).toBe('migration');
+  });
+
+  it('detects schemas', () => {
+    expect(classifyFile('prisma/schema.prisma')).toBe('schema');
+    expect(classifyFile('src/db/schema.ts')).toBe('schema');
+    expect(classifyFile('src/types/schema.ts')).toBe('schema');
+  });
+
+  it('detects config', () => {
+    expect(classifyFile('vite.config.ts')).toBe('config');
+    expect(classifyFile('tailwind.config.js')).toBe('config');
+    expect(classifyFile('tsconfig.json')).toBe('config');
+    expect(classifyFile('.oxlintrc.json')).toBe('config');
+    expect(classifyFile('package.json')).toBe('config');
+    expect(classifyFile('bun.lock')).toBe('config');
+  });
+
+  it('detects docs', () => {
+    expect(classifyFile('README.md')).toBe('docs');
+    expect(classifyFile('docs/dad-watch.md')).toBe('docs');
+    expect(classifyFile('CHANGELOG.md')).toBe('docs');
+  });
+
+  it('detects public api', () => {
+    expect(classifyFile('packages/cli/src/index.ts')).toBe('public-api');
+    expect(classifyFile('src/types/public.d.ts')).toBe('public-api');
+  });
+
+  it('falls back to source', () => {
+    expect(classifyFile('src/lib/foo.ts')).toBe('source');
+    expect(classifyFile('packages/web/src/components/Hunk.tsx')).toBe('source');
+  });
+});
+
+describe('buildBranchSkeleton', () => {
+  const files: DiffFile[] = [
+    file('packages/cli/src/watch-server.ts', { additions: 80, deletions: 10 }),
+    file('packages/cli/src/__tests__/watch.test.ts', { additions: 40, deletions: 0, isNewFile: true }),
+    file('packages/web/src/components/Foo.tsx', { additions: 20, deletions: 5 }),
+    file('packages/web/src/components/Bar.tsx', { additions: 5, deletions: 1 }),
+    file('docs/dad-watch.md', { additions: 200, deletions: 0 }),
+    file('vite.config.ts', { additions: 2, deletions: 1 }),
+  ];
+
+  it('counts totals and category buckets', () => {
+    const s = buildBranchSkeleton(files);
+    expect(s.totals.changedFiles).toBe(6);
+    expect(s.totals.additions).toBe(347);
+    expect(s.totals.deletions).toBe(17);
+    expect(s.byCategory.test).toBe(1);
+    expect(s.byCategory.docs).toBe(1);
+    expect(s.byCategory.config).toBe(1);
+    expect(s.byCategory.source).toBe(3);
+  });
+
+  it('aggregates touched directories sorted by count', () => {
+    const s = buildBranchSkeleton(files);
+    const top = s.touchedDirs[0];
+    expect(top.dir).toBe('packages/web/src/components');
+    expect(top.count).toBe(2);
+  });
+
+  it('flags notable files by total change size', () => {
+    const s = buildBranchSkeleton(files);
+    expect(s.notable[0].path).toBe('docs/dad-watch.md');
+    expect(s.notable.length).toBeLessThanOrEqual(5);
+  });
+
+  it('records every file in files[] preserving order', () => {
+    const s = buildBranchSkeleton(files);
+    expect(s.files.map((f) => f.path)).toEqual(files.map((f) => f.file));
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -415,7 +415,7 @@ async function watchCommand(branchArg?: string): Promise<number> {
     skeletonKey: null,
   };
 
-  const { app, narrateCommit, refreshCommits } = createWatchServer(ctx);
+  const { app, narrateUnified, refreshCommits } = createWatchServer(ctx);
   const portFlag = Bun.argv.find((f) => f.startsWith('--port='));
   const port = portFlag ? parseInt(portFlag.split('=')[1]) : 0;
   const server = Bun.serve({ fetch: app.fetch, port, idleTimeout: 255 });
@@ -433,16 +433,15 @@ async function watchCommand(branchArg?: string): Promise<number> {
   if (commits.length === 0) {
     console.log(`  ${a.dim}No commits ahead of ${base} yet — waiting for new commits...${a.reset}`);
   } else {
-    console.log(`  ${a.yellow}Narrating ${commits.length} commit${commits.length === 1 ? '' : 's'}...${a.reset}`);
-    // Kick off narrations sequentially in the background; SSE updates the UI.
+    console.log(
+      `  ${a.yellow}Narrating whole branch${a.reset} ${a.dim}(${commits.length} commit${commits.length === 1 ? '' : 's'} as one story)${a.reset}`,
+    );
     void (async () => {
-      for (const c of commits) {
-        await narrateCommit(c.sha, { broadcastWhenDone: true });
-        if (ctx.narratives.has(c.sha)) {
-          console.log(
-            `  ${a.green}✓${a.reset} ${a.gray}${c.shortSha}${a.reset} ${a.white}${c.subject}${a.reset}`,
-          );
-        }
+      const narrative = await narrateUnified();
+      if (narrative) {
+        console.log(
+          `  ${a.green}✓${a.reset} ${a.white}whole-branch story ready${a.reset} ${a.dim}(${narrative.chapters.length} chapters)${a.reset}`,
+        );
       }
     })();
   }
@@ -478,20 +477,15 @@ async function watchCommand(branchArg?: string): Promise<number> {
 
       ctx.baseSha = freshBase;
       await refreshCommits(freshCommits, freshHead);
-      // narrateCommit is fire-and-forget inside refreshCommits, but we
-      // also want a console log per success. Hook into the cache: when
-      // narratives.has(sha) is set we log it.
-      const tickShas = added.map((c) => c.sha);
+
+      // Whole-branch story is the primary surface — regenerate it when the
+      // branch moves. Per-commit narration stays on demand.
       void (async () => {
-        for (const sha of tickShas) {
-          // Wait until it's either generated or errored.
-          while (ctx.generating.has(sha)) await new Promise((r) => setTimeout(r, 250));
-          const c = freshCommits.find((cm) => cm.sha === sha);
-          if (c && ctx.narratives.has(sha)) {
-            console.log(
-              `  ${a.green}✓${a.reset} ${a.gray}${c.shortSha}${a.reset} ${a.white}${c.subject}${a.reset}`,
-            );
-          }
+        const narrative = await narrateUnified();
+        if (narrative) {
+          console.log(
+            `  ${a.green}✓${a.reset} ${a.white}whole-branch story refreshed${a.reset} ${a.dim}(${narrative.chapters.length} chapters)${a.reset}`,
+          );
         }
       })();
     } catch (err) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,10 +1,22 @@
 #!/usr/bin/env bun
 import { resolveGitHubToken } from './auth';
 import { readConfig, resetConfig, runConfig, showConfig } from './config';
+import {
+  branchExists,
+  detectBaseBranch,
+  findRepoRoot,
+  getCurrentBranch,
+  getHeadSha,
+  getRemoteSlug,
+  listCommits,
+  mergeBase,
+  repoFingerprint,
+} from './git/local';
 import { GitHubClient } from './github/client';
 import { cacheNarrative, clearCache, getCachedNarrative } from './narrative/cache';
 import { generateNarrative, setCliOverride } from './narrative/engine';
 import { createServer } from './server';
+import { createWatchServer, type WatchServerContext } from './watch-server';
 
 const a = {
   reset: '\x1b[0m',
@@ -50,6 +62,8 @@ const USAGE = `dad - GitHub PRs as narrated stories
 Usage:
   dad <pr>                           Review a PR (shorthand for dad review)
   dad review <pr>                    Review a PR
+  dad watch [branch]                 Narrate the current (or given) branch as you work
+                                     Options: --base <ref>  (override base, default: origin/HEAD)
   dad config                         Configure dad (interactive)
   dad config show                    Print the current config (secrets redacted)
   dad config reset [--yes]           Delete the saved config
@@ -317,6 +331,185 @@ async function reviewCommand(prArg: string | undefined): Promise<number> {
   await new Promise(() => {});
 }
 
+function getFlag(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  const eq = Bun.argv.find((a) => a.startsWith(prefix));
+  if (eq) return eq.slice(prefix.length);
+  const idx = Bun.argv.findIndex((a) => a === `--${name}`);
+  if (idx !== -1 && Bun.argv[idx + 1] && !Bun.argv[idx + 1]!.startsWith('--')) {
+    return Bun.argv[idx + 1];
+  }
+  return undefined;
+}
+
+async function watchCommand(branchArg?: string): Promise<number> {
+  let repoRoot: string;
+  try {
+    repoRoot = await findRepoRoot();
+  } catch {
+    console.error(`\n  ${a.red}${a.bold}error:${a.reset} not inside a git repository.\n`);
+    return 1;
+  }
+
+  let branch: string;
+  if (branchArg) {
+    if (!(await branchExists(branchArg, repoRoot))) {
+      console.error(`\n  ${a.red}${a.bold}error:${a.reset} branch ${a.cyan}${branchArg}${a.reset} not found.\n`);
+      return 1;
+    }
+    branch = branchArg;
+  } else {
+    try {
+      branch = await getCurrentBranch(repoRoot);
+    } catch {
+      console.error(
+        `\n  ${a.red}${a.bold}error:${a.reset} couldn't determine current branch (detached HEAD?). Pass a branch name.\n`,
+      );
+      return 1;
+    }
+  }
+
+  const baseFlag = getFlag('base');
+  let base: string;
+  try {
+    base = baseFlag ?? (await detectBaseBranch(repoRoot));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`\n  ${a.red}${a.bold}error:${a.reset} ${msg}\n`);
+    return 1;
+  }
+
+  if (!(await branchExists(base, repoRoot))) {
+    console.error(`\n  ${a.red}${a.bold}error:${a.reset} base ref ${a.cyan}${base}${a.reset} not found.\n`);
+    return 1;
+  }
+
+  const withFlag = Bun.argv.find((f) => f.startsWith('--with='));
+  if (withFlag) setCliOverride(withFlag.split('=')[1]!);
+
+  const headSha = await getHeadSha(branch, repoRoot);
+  const baseSha = await mergeBase(base, branch, repoRoot);
+  const commits = await listCommits(baseSha, headSha, repoRoot);
+  const remoteSlug = await getRemoteSlug(repoRoot);
+
+  console.log(`\n  ${a.purple}${a.bold}Diff Dad${a.reset}  ${a.dim}—${a.reset}  ${a.white}watch mode${a.reset}`);
+  console.log(
+    `  ${a.dim}branch:${a.reset} ${a.cyan}${branch}${a.reset}  ${a.dim}base:${a.reset} ${a.cyan}${base}${a.reset}  ${a.dim}commits:${a.reset} ${a.white}${commits.length}${a.reset}`,
+  );
+
+  const ctx: WatchServerContext = {
+    repoRoot,
+    repoFp: repoFingerprint(repoRoot),
+    branch,
+    base,
+    baseSha,
+    headSha,
+    commits,
+    narratives: new Map(),
+    unified: null,
+    unifiedKey: null,
+    generating: new Set(),
+    unifiedGenerating: false,
+    remoteSlug,
+  };
+
+  const { app, narrateCommit, refreshCommits } = createWatchServer(ctx);
+  const portFlag = Bun.argv.find((f) => f.startsWith('--port='));
+  const port = portFlag ? parseInt(portFlag.split('=')[1]) : 0;
+  const server = Bun.serve({ fetch: app.fetch, port, idleTimeout: 255 });
+  const url = `http://localhost:${server.port}`;
+
+  console.log(`\n  ${a.purple}${a.bold}${url}${a.reset}`);
+  const joke = DAD_JOKES[Math.floor(Math.random() * DAD_JOKES.length)];
+  console.log(`\n  ${a.italic}${a.gray}"${joke}"${a.reset}\n`);
+
+  if (!Bun.argv.includes('--no-open')) {
+    const { default: open } = await import('open');
+    await open(url);
+  }
+
+  if (commits.length === 0) {
+    console.log(`  ${a.dim}No commits ahead of ${base} yet — waiting for new commits...${a.reset}`);
+  } else {
+    console.log(`  ${a.yellow}Narrating ${commits.length} commit${commits.length === 1 ? '' : 's'}...${a.reset}`);
+    // Kick off narrations sequentially in the background; SSE updates the UI.
+    void (async () => {
+      for (const c of commits) {
+        await narrateCommit(c.sha, { broadcastWhenDone: true });
+        if (ctx.narratives.has(c.sha)) {
+          console.log(
+            `  ${a.green}✓${a.reset} ${a.gray}${c.shortSha}${a.reset} ${a.white}${c.subject}${a.reset}`,
+          );
+        }
+      }
+    })();
+  }
+
+  // Poll for new commits on the branch.
+  const pollMs = 2000;
+  let polling = false;
+  const interval = setInterval(async () => {
+    if (polling) return;
+    polling = true;
+    try {
+      const freshHead = await getHeadSha(branch, repoRoot);
+      if (freshHead === ctx.headSha) return;
+
+      // Recompute merge-base in case the base ref has moved (e.g. someone
+      // pulled main while you were working).
+      const freshBase = await mergeBase(base, branch, repoRoot);
+      const freshCommits = await listCommits(freshBase, freshHead, repoRoot);
+      const oldShas = new Set(ctx.commits.map((c) => c.sha));
+      const added = freshCommits.filter((c) => !oldShas.has(c.sha));
+      const newShas = new Set(freshCommits.map((c) => c.sha));
+      const dropped = ctx.commits.filter((c) => !newShas.has(c.sha));
+
+      if (dropped.length > 0) {
+        console.log(
+          `  ${a.yellow}↻${a.reset} History rewritten ${a.dim}(dropped ${dropped.length}, added ${added.length})${a.reset}`,
+        );
+      } else if (added.length > 0) {
+        const labels = added.map((c) => `${c.shortSha} ${c.subject}`).join('\n      ');
+        console.log(`  ${a.green}+${a.reset} ${added.length} new commit${added.length === 1 ? '' : 's'}:`);
+        console.log(`      ${a.dim}${labels}${a.reset}`);
+      }
+
+      ctx.baseSha = freshBase;
+      await refreshCommits(freshCommits, freshHead);
+      // narrateCommit is fire-and-forget inside refreshCommits, but we
+      // also want a console log per success. Hook into the cache: when
+      // narratives.has(sha) is set we log it.
+      const tickShas = added.map((c) => c.sha);
+      void (async () => {
+        for (const sha of tickShas) {
+          // Wait until it's either generated or errored.
+          while (ctx.generating.has(sha)) await new Promise((r) => setTimeout(r, 250));
+          const c = freshCommits.find((cm) => cm.sha === sha);
+          if (c && ctx.narratives.has(sha)) {
+            console.log(
+              `  ${a.green}✓${a.reset} ${a.gray}${c.shortSha}${a.reset} ${a.white}${c.subject}${a.reset}`,
+            );
+          }
+        }
+      })();
+    } catch (err) {
+      // Swallow polling errors — branch may be momentarily unreadable
+      // during a rebase, etc.
+      void err;
+    } finally {
+      polling = false;
+    }
+  }, pollMs);
+
+  // Keep the process alive forever.
+  process.on('SIGINT', () => {
+    clearInterval(interval);
+    console.log(`\n  ${a.dim}Goodbye.${a.reset}\n`);
+    process.exit(0);
+  });
+  await new Promise(() => {});
+}
+
 async function configCommand(sub?: string): Promise<number> {
   if (sub === 'show') return await showConfig();
   if (sub === 'reset') {
@@ -359,6 +552,8 @@ async function main(argv: string[]): Promise<number> {
   switch (cmd) {
     case 'review':
       return await reviewCommand(rest[0]);
+    case 'watch':
+      return await watchCommand(rest[0]);
     case 'config':
       return await configCommand(rest[0]);
     case 'cache': {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -411,6 +411,8 @@ async function watchCommand(branchArg?: string): Promise<number> {
     generating: new Set(),
     unifiedGenerating: false,
     remoteSlug,
+    skeleton: null,
+    skeletonKey: null,
   };
 
   const { app, narrateCommit, refreshCommits } = createWatchServer(ctx);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -408,6 +408,7 @@ async function watchCommand(branchArg?: string): Promise<number> {
     narratives: new Map(),
     unified: null,
     unifiedKey: null,
+    unifiedHeadSha: null,
     generating: new Set(),
     unifiedGenerating: false,
     remoteSlug,
@@ -478,16 +479,25 @@ async function watchCommand(branchArg?: string): Promise<number> {
       ctx.baseSha = freshBase;
       await refreshCommits(freshCommits, freshHead);
 
-      // Whole-branch story is the primary surface — regenerate it when the
-      // branch moves. Per-commit narration stays on demand.
-      void (async () => {
-        const narrative = await narrateUnified();
-        if (narrative) {
-          console.log(
-            `  ${a.green}✓${a.reset} ${a.white}whole-branch story refreshed${a.reset} ${a.dim}(${narrative.chapters.length} chapters)${a.reset}`,
-          );
-        }
-      })();
+      // Whole-branch story regenerates only on history rewrite (rebase /
+      // amend / squash). On a simple linear advance the unified story
+      // stays put and refreshCommits fires per-commit "addendum" narration
+      // for each new SHA — the story doesn't get jumbled, but you still
+      // see what just changed.
+      if (dropped.length > 0) {
+        void (async () => {
+          const narrative = await narrateUnified();
+          if (narrative) {
+            console.log(
+              `  ${a.green}✓${a.reset} ${a.white}whole-branch story regenerated${a.reset} ${a.dim}(${narrative.chapters.length} chapters)${a.reset}`,
+            );
+          }
+        })();
+      } else if (added.length > 0) {
+        console.log(
+          `  ${a.dim}(addendum narration in progress for ${added.length} new commit${added.length === 1 ? '' : 's'})${a.reset}`,
+        );
+      }
     } catch (err) {
       // Swallow polling errors — branch may be momentarily unreadable
       // during a rebase, etc.

--- a/packages/cli/src/git/local.ts
+++ b/packages/cli/src/git/local.ts
@@ -1,0 +1,226 @@
+import { createHash } from 'crypto';
+import { resolve } from 'path';
+
+export type LocalCommit = {
+  sha: string;
+  shortSha: string;
+  subject: string;
+  body: string;
+  author: { name: string; email: string };
+  date: string;
+  parents: string[];
+};
+
+export class GitError extends Error {
+  constructor(
+    message: string,
+    public readonly stderr?: string,
+  ) {
+    super(message);
+    this.name = 'GitError';
+  }
+}
+
+async function run(args: string[], cwd?: string): Promise<string> {
+  const proc = Bun.spawn(['git', ...args], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+    cwd,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new GitError(`git ${args.join(' ')} failed (exit ${exitCode}): ${stderr.trim()}`, stderr);
+  }
+  return stdout;
+}
+
+async function tryRun(args: string[], cwd?: string): Promise<string | null> {
+  try {
+    return await run(args, cwd);
+  } catch {
+    return null;
+  }
+}
+
+export async function findRepoRoot(cwd: string = process.cwd()): Promise<string> {
+  const out = await run(['rev-parse', '--show-toplevel'], cwd);
+  return out.trim();
+}
+
+export async function getCurrentBranch(cwd?: string): Promise<string> {
+  const out = await run(['symbolic-ref', '--short', 'HEAD'], cwd);
+  return out.trim();
+}
+
+export async function getHeadSha(branch?: string, cwd?: string): Promise<string> {
+  const ref = branch ?? 'HEAD';
+  const out = await run(['rev-parse', ref], cwd);
+  return out.trim();
+}
+
+export async function branchExists(branch: string, cwd?: string): Promise<boolean> {
+  const out = await tryRun(['rev-parse', '--verify', '--quiet', branch], cwd);
+  return out !== null && out.trim().length > 0;
+}
+
+/**
+ * Detect the base branch this branch should be compared against.
+ * Order:
+ *   1. origin/HEAD symbolic ref (the conventional default)
+ *   2. main, then master, if they exist locally or on origin
+ */
+export async function detectBaseBranch(cwd?: string): Promise<string> {
+  const symbolic = await tryRun(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], cwd);
+  if (symbolic) {
+    const ref = symbolic.trim();
+    if (ref.length > 0) return ref;
+  }
+
+  for (const candidate of ['origin/main', 'main', 'origin/master', 'master']) {
+    if (await branchExists(candidate, cwd)) return candidate;
+  }
+
+  throw new GitError(
+    "Couldn't detect a base branch (tried origin/HEAD, main, master). Pass --base <ref> to specify one.",
+  );
+}
+
+export async function mergeBase(base: string, head: string, cwd?: string): Promise<string> {
+  const out = await run(['merge-base', base, head], cwd);
+  return out.trim();
+}
+
+const COMMIT_FIELD_SEP = '\x1f';
+const COMMIT_RECORD_SEP = '\x1e';
+
+/**
+ * List commits in `base..head` from oldest to newest.
+ * Skips merge commits — narration of merge diffs is brittle and rarely
+ * tells a useful story.
+ */
+export async function listCommits(base: string, head: string, cwd?: string): Promise<LocalCommit[]> {
+  const format = ['%H', '%h', '%s', '%b', '%an', '%ae', '%aI', '%P'].join(COMMIT_FIELD_SEP) + COMMIT_RECORD_SEP;
+  const out = await run(['log', '--no-merges', '--reverse', `--format=${format}`, `${base}..${head}`], cwd);
+
+  if (!out.trim()) return [];
+
+  const records = out.split(COMMIT_RECORD_SEP).filter((r) => r.trim().length > 0);
+  return records.map((record) => {
+    const fields = record.replace(/^\n/, '').split(COMMIT_FIELD_SEP);
+    const [sha, shortSha, subject, body, authorName, authorEmail, date, parents] = fields;
+    return {
+      sha: (sha ?? '').trim(),
+      shortSha: (shortSha ?? '').trim(),
+      subject: (subject ?? '').trim(),
+      body: (body ?? '').trim(),
+      author: { name: (authorName ?? '').trim(), email: (authorEmail ?? '').trim() },
+      date: (date ?? '').trim(),
+      parents: (parents ?? '').trim().split(/\s+/).filter(Boolean),
+    };
+  });
+}
+
+/**
+ * Get the diff for a single commit. Uses `<sha>^..<sha>` for non-root
+ * commits, and falls back to `git show --format=` for root commits where
+ * `<sha>^` doesn't resolve.
+ */
+export async function getDiffForCommit(sha: string, cwd?: string): Promise<string> {
+  const parent = await tryRun(['rev-parse', '--verify', '--quiet', `${sha}^`], cwd);
+  if (parent && parent.trim().length > 0) {
+    return await run(['diff', `${sha}^..${sha}`], cwd);
+  }
+  // Root commit: emit the whole thing as a diff against the empty tree.
+  return await run(['show', '--format=', sha], cwd);
+}
+
+export async function getDiffForRange(base: string, head: string, cwd?: string): Promise<string> {
+  return await run(['diff', `${base}...${head}`], cwd);
+}
+
+/**
+ * Compute commit-level totals (additions, deletions, files changed) for a
+ * range, used to populate the synthetic PR metadata in watch mode.
+ */
+export async function getRangeStats(
+  base: string,
+  head: string,
+  cwd?: string,
+): Promise<{ additions: number; deletions: number; changedFiles: number }> {
+  const out = await run(['diff', '--numstat', `${base}...${head}`], cwd);
+  let additions = 0;
+  let deletions = 0;
+  let files = 0;
+  for (const line of out.split('\n')) {
+    if (!line.trim()) continue;
+    const [a, d] = line.split('\t');
+    if (a === '-' || d === '-') {
+      // binary file
+      files += 1;
+      continue;
+    }
+    const an = Number(a);
+    const dn = Number(d);
+    if (!Number.isNaN(an)) additions += an;
+    if (!Number.isNaN(dn)) deletions += dn;
+    files += 1;
+  }
+  return { additions, deletions, changedFiles: files };
+}
+
+export async function getCommitStats(
+  sha: string,
+  cwd?: string,
+): Promise<{ additions: number; deletions: number; changedFiles: number }> {
+  const parent = await tryRun(['rev-parse', '--verify', '--quiet', `${sha}^`], cwd);
+  if (parent && parent.trim().length > 0) {
+    return getRangeStats(`${sha}^`, sha, cwd);
+  }
+  // Root commit — `git show --numstat` works without needing a parent.
+  const out = await run(['show', '--numstat', '--format=', sha], cwd);
+  let additions = 0;
+  let deletions = 0;
+  let files = 0;
+  for (const line of out.split('\n')) {
+    if (!line.trim()) continue;
+    const [a, d] = line.split('\t');
+    if (a === '-' || d === '-') {
+      files += 1;
+      continue;
+    }
+    const an = Number(a);
+    const dn = Number(d);
+    if (!Number.isNaN(an)) additions += an;
+    if (!Number.isNaN(dn)) deletions += dn;
+    files += 1;
+  }
+  return { additions, deletions, changedFiles: files };
+}
+
+/**
+ * Stable short hash of an absolute repo path, used as a cache namespace so
+ * two checkouts of the same repo don't collide.
+ */
+export function repoFingerprint(repoRoot: string): string {
+  const abs = resolve(repoRoot);
+  return createHash('sha1').update(abs).digest('hex').slice(0, 12);
+}
+
+/**
+ * Try to infer owner/repo from the origin remote, for building GitHub URLs
+ * (used only for display links — watch mode doesn't call the GitHub API).
+ */
+export async function getRemoteSlug(cwd?: string): Promise<{ owner: string; repo: string } | null> {
+  const url = await tryRun(['remote', 'get-url', 'origin'], cwd);
+  if (!url) return null;
+  const trimmed = url.trim();
+  const ssh = trimmed.match(/^git@github\.com:([^/\s]+)\/([^/\s]+?)(?:\.git)?$/i);
+  if (ssh) return { owner: ssh[1]!, repo: ssh[2]! };
+  const https = trimmed.match(/^https?:\/\/github\.com\/([^/\s]+)\/([^/\s]+?)(?:\.git)?\/?$/i);
+  if (https) return { owner: https[1]!, repo: https[2]! };
+  return null;
+}

--- a/packages/cli/src/narrative/cache.ts
+++ b/packages/cli/src/narrative/cache.ts
@@ -4,9 +4,18 @@ import { readdir, readFile, rm, writeFile, mkdir } from 'fs/promises';
 import type { NarrativeResponse } from './types';
 
 const CACHE_DIR = join(homedir(), '.cache', 'diffdad');
+const WATCH_DIR = join(CACHE_DIR, 'watch');
 
 function cachePath(owner: string, repo: string, number: number, sha: string): string {
   return join(CACHE_DIR, `${owner}-${repo}-${number}-${sha}.json`);
+}
+
+function watchCommitPath(repoFp: string, sha: string): string {
+  return join(WATCH_DIR, `${repoFp}-commit-${sha}.json`);
+}
+
+function watchUnifiedPath(repoFp: string, baseSha: string, headSha: string): string {
+  return join(WATCH_DIR, `${repoFp}-unified-${baseSha}-${headSha}.json`);
 }
 
 export async function getCachedNarrative(
@@ -25,16 +34,26 @@ export async function getCachedNarrative(
 }
 
 export async function clearCache(): Promise<number> {
+  let count = 0;
   try {
     const entries = await readdir(CACHE_DIR);
-    const jsonFiles = entries.filter((e) => e.endsWith('.json'));
-    for (const file of jsonFiles) {
+    for (const file of entries.filter((e) => e.endsWith('.json'))) {
       await rm(join(CACHE_DIR, file));
+      count += 1;
     }
-    return jsonFiles.length;
   } catch {
-    return 0;
+    // ignore
   }
+  try {
+    const entries = await readdir(WATCH_DIR);
+    for (const file of entries.filter((e) => e.endsWith('.json'))) {
+      await rm(join(WATCH_DIR, file));
+      count += 1;
+    }
+  } catch {
+    // ignore
+  }
+  return count;
 }
 
 export async function cacheNarrative(
@@ -47,4 +66,45 @@ export async function cacheNarrative(
   const path = cachePath(owner, repo, number, sha);
   await mkdir(CACHE_DIR, { recursive: true });
   await writeFile(path, JSON.stringify(narrative));
+}
+
+export async function getCachedCommitNarrative(repoFp: string, sha: string): Promise<NarrativeResponse | null> {
+  try {
+    const raw = await readFile(watchCommitPath(repoFp, sha), 'utf-8');
+    return JSON.parse(raw) as NarrativeResponse;
+  } catch {
+    return null;
+  }
+}
+
+export async function cacheCommitNarrative(
+  repoFp: string,
+  sha: string,
+  narrative: NarrativeResponse,
+): Promise<void> {
+  await mkdir(WATCH_DIR, { recursive: true });
+  await writeFile(watchCommitPath(repoFp, sha), JSON.stringify(narrative));
+}
+
+export async function getCachedUnifiedNarrative(
+  repoFp: string,
+  baseSha: string,
+  headSha: string,
+): Promise<NarrativeResponse | null> {
+  try {
+    const raw = await readFile(watchUnifiedPath(repoFp, baseSha, headSha), 'utf-8');
+    return JSON.parse(raw) as NarrativeResponse;
+  } catch {
+    return null;
+  }
+}
+
+export async function cacheUnifiedNarrative(
+  repoFp: string,
+  baseSha: string,
+  headSha: string,
+  narrative: NarrativeResponse,
+): Promise<void> {
+  await mkdir(WATCH_DIR, { recursive: true });
+  await writeFile(watchUnifiedPath(repoFp, baseSha, headSha), JSON.stringify(narrative));
 }

--- a/packages/cli/src/narrative/engine.ts
+++ b/packages/cli/src/narrative/engine.ts
@@ -10,6 +10,7 @@ import type { DiffFile, PRMetadata } from '../github/types';
 import {
   buildNarrativePrompt,
   partitionMechanicalFiles,
+  type NarrativeMode,
   type PreviousNarrativeContext,
   type PromptCapStats,
 } from './prompt';
@@ -345,6 +346,7 @@ export async function generateNarrative(
   fileTree: string[],
   config: DiffDadConfig,
   previousContext?: PreviousNarrativeContext,
+  mode: NarrativeMode = 'narrate',
   onProgress?: NarrativeProgressHandler,
 ): Promise<{ narrative: NarrativeResponse; provider: string }> {
   const { narrate, skipped } = partitionMechanicalFiles(files);
@@ -356,6 +358,7 @@ export async function generateNarrative(
     fileTree,
     skippedFiles: skipped.map((f) => f.file),
     previousContext,
+    mode,
   });
   logPromptStats(stats, skipped.length);
 

--- a/packages/cli/src/narrative/prompt.ts
+++ b/packages/cli/src/narrative/prompt.ts
@@ -5,6 +5,8 @@ export type PreviousNarrativeContext = {
   previousChapterTitles?: string[];
 };
 
+export type NarrativeMode = 'narrate' | 'scrutinize';
+
 export interface NarrativePromptInput {
   title: string;
   description: string;
@@ -13,6 +15,7 @@ export interface NarrativePromptInput {
   fileTree: string[];
   skippedFiles?: string[];
   previousContext?: PreviousNarrativeContext;
+  mode?: NarrativeMode;
 }
 
 export interface PromptCapStats {
@@ -274,6 +277,23 @@ You are output-token-bound. Every chapter and sentence costs the reader real wai
 Output format — return ONLY valid JSON, no prose around it, matching this schema:
 ${RESPONSE_SCHEMA}`;
 
+const SCRUTINIZE_ADDENDUM = `
+
+---
+
+## Scrutinize Mode
+
+This narrative is for a developer reviewing their *own* in-progress work — typically code an AI agent just wrote — before sending it for human review. Your job here is not to celebrate the change but to **stress-test** it.
+
+Shift your priorities:
+- **Lead with what's questionable.** Each chapter should surface what a senior reviewer would push back on: implicit assumptions, hidden coupling, ordering dependencies, error paths that aren't handled, edge cases that aren't covered, validation that was skipped, race conditions, off-by-ones.
+- **Hunt for absences, not just presence.** Use the "missing" array aggressively. Missing tests for new behavior, missing error handling, missing input validation, missing cleanup on failure paths, missing docs for public surface changes, missing migrations. Be specific — "no test for the empty-input case in foo()" beats "needs more tests."
+- **Treat callouts as the real product.** Prefer "concern" and "warning" callouts over "nit". Each callout should be specific enough that the reader can verify it in under a minute. If you can't be specific, don't write the callout.
+- **Be honest about what you can't tell from the diff.** If a change *might* be wrong but you can't verify without running the code, say so explicitly in the chapter narrative ("verify that X actually fires when Y").
+- **Default verdict to caution.** Reserve "safe" for genuinely mechanical changes. If you flagged a single warning callout or a non-trivial absence, the verdict should be "caution" or "risky".
+
+The reviewer trusts you more when you find real problems than when you tell them everything is fine. Err toward skepticism.`;
+
 function formatHunkLine(line: DiffLine): string {
   const prefix = line.type === 'add' ? '+' : line.type === 'remove' ? '-' : ' ';
   return `${prefix}${line.content}`;
@@ -327,7 +347,8 @@ function formatFile(
 }
 
 export function buildNarrativePrompt(input: NarrativePromptInput): NarrativePrompt {
-  const { title, description, labels, files, fileTree, skippedFiles, previousContext } = input;
+  const { title, description, labels, files, fileTree, skippedFiles, previousContext, mode = 'narrate' } = input;
+  const system = mode === 'scrutinize' ? SYSTEM_PROMPT + SCRUTINIZE_ADDENDUM : SYSTEM_PROMPT;
 
   const truncatedTree = fileTree.slice(0, FILE_TREE_LIMIT);
   const labelLine = labels.length > 0 ? labels.join(', ') : '(none)';
@@ -426,5 +447,5 @@ export function buildNarrativePrompt(input: NarrativePromptInput): NarrativeProm
     truncatedFiles: truncatedFileDetails,
     droppedFiles,
   };
-  return { system: SYSTEM_PROMPT, user, stats };
+  return { system, user, stats };
 }

--- a/packages/cli/src/watch-server.ts
+++ b/packages/cli/src/watch-server.ts
@@ -1,0 +1,460 @@
+import { existsSync } from 'fs';
+import { Hono } from 'hono';
+import { serveStatic } from 'hono/bun';
+import { dirname, resolve } from 'path';
+import { readConfig } from './config';
+import {
+  cacheCommitNarrative,
+  cacheUnifiedNarrative,
+  getCachedCommitNarrative,
+  getCachedUnifiedNarrative,
+} from './narrative/cache';
+import { generateNarrative } from './narrative/engine';
+import type { NarrativeResponse } from './narrative/types';
+import { parseDiff } from './github/diff-parser';
+import type { DiffFile, PRMetadata } from './github/types';
+import {
+  getDiffForCommit,
+  getDiffForRange,
+  getCommitStats,
+  type LocalCommit,
+} from './git/local';
+
+export type WatchServerContext = {
+  repoRoot: string;
+  repoFp: string;
+  branch: string;
+  base: string;
+  baseSha: string;
+  headSha: string;
+  commits: LocalCommit[];
+  narratives: Map<string, NarrativeResponse>;
+  unified: NarrativeResponse | null;
+  unifiedKey: string | null;
+  generating: Set<string>;
+  unifiedGenerating: boolean;
+  remoteSlug: { owner: string; repo: string } | null;
+};
+
+type CommitSummary = {
+  sha: string;
+  shortSha: string;
+  subject: string;
+  author: string;
+  date: string;
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+  hasNarrative: boolean;
+};
+
+type WatchPayload = {
+  branch: string;
+  base: string;
+  baseSha: string;
+  headSha: string;
+  commits: CommitSummary[];
+  selection: { kind: 'commit'; sha: string } | { kind: 'unified' } | { kind: 'pending' };
+  unifiedReady: boolean;
+};
+
+function syntheticPrForCommit(ctx: WatchServerContext, commit: LocalCommit, files: DiffFile[]): PRMetadata {
+  const totals = files.reduce(
+    (acc, f) => {
+      for (const h of f.hunks) {
+        for (const l of h.lines) {
+          if (l.type === 'add') acc.additions += 1;
+          else if (l.type === 'remove') acc.deletions += 1;
+        }
+      }
+      return acc;
+    },
+    { additions: 0, deletions: 0 },
+  );
+
+  return {
+    number: 0,
+    title: commit.subject || commit.shortSha,
+    body: commit.body,
+    state: 'open',
+    draft: false,
+    author: { login: commit.author.name, avatarUrl: '' },
+    branch: ctx.branch,
+    base: ctx.base,
+    labels: [],
+    createdAt: commit.date,
+    updatedAt: commit.date,
+    additions: totals.additions,
+    deletions: totals.deletions,
+    changedFiles: files.length,
+    commits: 1,
+    headSha: commit.sha,
+  };
+}
+
+function syntheticPrForUnified(ctx: WatchServerContext, files: DiffFile[]): PRMetadata {
+  const subject = `${ctx.branch} → ${ctx.base}`;
+  const body =
+    ctx.commits.length > 0
+      ? ctx.commits.map((c) => `${c.shortSha} ${c.subject}`).join('\n')
+      : '(no commits)';
+  const totals = files.reduce(
+    (acc, f) => {
+      for (const h of f.hunks) {
+        for (const l of h.lines) {
+          if (l.type === 'add') acc.additions += 1;
+          else if (l.type === 'remove') acc.deletions += 1;
+        }
+      }
+      return acc;
+    },
+    { additions: 0, deletions: 0 },
+  );
+  const last = ctx.commits[ctx.commits.length - 1];
+
+  return {
+    number: 0,
+    title: subject,
+    body,
+    state: 'open',
+    draft: false,
+    author: { login: last?.author.name ?? '', avatarUrl: '' },
+    branch: ctx.branch,
+    base: ctx.base,
+    labels: [],
+    createdAt: ctx.commits[0]?.date ?? new Date().toISOString(),
+    updatedAt: last?.date ?? new Date().toISOString(),
+    additions: totals.additions,
+    deletions: totals.deletions,
+    changedFiles: files.length,
+    commits: ctx.commits.length,
+    headSha: ctx.headSha,
+  };
+}
+
+async function loadFilesForCommit(repoRoot: string, sha: string): Promise<DiffFile[]> {
+  const raw = await getDiffForCommit(sha, repoRoot);
+  return parseDiff(raw);
+}
+
+async function loadFilesForRange(repoRoot: string, base: string, head: string): Promise<DiffFile[]> {
+  const raw = await getDiffForRange(base, head, repoRoot);
+  return parseDiff(raw);
+}
+
+function commitSummary(ctx: WatchServerContext, c: LocalCommit, stats: { additions: number; deletions: number; changedFiles: number }): CommitSummary {
+  return {
+    sha: c.sha,
+    shortSha: c.shortSha,
+    subject: c.subject,
+    author: c.author.name,
+    date: c.date,
+    additions: stats.additions,
+    deletions: stats.deletions,
+    changedFiles: stats.changedFiles,
+    hasNarrative: ctx.narratives.has(c.sha),
+  };
+}
+
+export function createWatchServer(ctx: WatchServerContext) {
+  const app = new Hono();
+  type SseClient = (event: string, data: unknown) => void;
+  const sseClients = new Set<SseClient>();
+  const commitStats = new Map<string, { additions: number; deletions: number; changedFiles: number }>();
+
+  function broadcast(event: string, data: unknown) {
+    for (const send of sseClients) send(event, data);
+  }
+
+  async function getCommitStatsCached(sha: string): Promise<{ additions: number; deletions: number; changedFiles: number }> {
+    const cached = commitStats.get(sha);
+    if (cached) return cached;
+    const stats = await getCommitStats(sha, ctx.repoRoot);
+    commitStats.set(sha, stats);
+    return stats;
+  }
+
+  async function buildCommitSummaries(): Promise<CommitSummary[]> {
+    const out: CommitSummary[] = [];
+    for (const c of ctx.commits) {
+      const stats = await getCommitStatsCached(c.sha);
+      out.push(commitSummary(ctx, c, stats));
+    }
+    return out;
+  }
+
+  async function narrateCommit(sha: string, opts: { broadcastWhenDone?: boolean } = {}): Promise<NarrativeResponse | null> {
+    if (ctx.narratives.has(sha)) return ctx.narratives.get(sha)!;
+    if (ctx.generating.has(sha)) return null;
+
+    const cached = await getCachedCommitNarrative(ctx.repoFp, sha);
+    if (cached) {
+      ctx.narratives.set(sha, cached);
+      if (opts.broadcastWhenDone) {
+        broadcast('commit-narrative', { sha });
+      }
+      return cached;
+    }
+
+    const commit = ctx.commits.find((c) => c.sha === sha);
+    if (!commit) return null;
+
+    ctx.generating.add(sha);
+    broadcast('commit-narrating', { sha });
+    try {
+      const config = await readConfig();
+      const files = await loadFilesForCommit(ctx.repoRoot, sha);
+      const pr = syntheticPrForCommit(ctx, commit, files);
+      const { narrative } = await generateNarrative(pr, files, [], config, undefined, 'scrutinize');
+      ctx.narratives.set(sha, narrative);
+      await cacheCommitNarrative(ctx.repoFp, sha, narrative);
+      if (opts.broadcastWhenDone) {
+        broadcast('commit-narrative', { sha });
+      }
+      return narrative;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`  \x1b[38;5;204m✗\x1b[0m Narration failed for ${sha.slice(0, 7)}: ${msg}`);
+      broadcast('commit-narrate-error', { sha, message: msg });
+      return null;
+    } finally {
+      ctx.generating.delete(sha);
+    }
+  }
+
+  async function narrateUnified(): Promise<NarrativeResponse | null> {
+    const key = `${ctx.baseSha}:${ctx.headSha}`;
+    if (ctx.unified && ctx.unifiedKey === key) return ctx.unified;
+    if (ctx.unifiedGenerating) return null;
+
+    const cached = await getCachedUnifiedNarrative(ctx.repoFp, ctx.baseSha, ctx.headSha);
+    if (cached) {
+      ctx.unified = cached;
+      ctx.unifiedKey = key;
+      broadcast('unified-narrative', { ready: true });
+      return cached;
+    }
+
+    ctx.unifiedGenerating = true;
+    broadcast('unified-narrating', {});
+    try {
+      const config = await readConfig();
+      const files = await loadFilesForRange(ctx.repoRoot, ctx.base, ctx.headSha);
+      const pr = syntheticPrForUnified(ctx, files);
+      const { narrative } = await generateNarrative(pr, files, [], config, undefined, 'scrutinize');
+      ctx.unified = narrative;
+      ctx.unifiedKey = key;
+      await cacheUnifiedNarrative(ctx.repoFp, ctx.baseSha, ctx.headSha, narrative);
+      broadcast('unified-narrative', { ready: true });
+      return narrative;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`  \x1b[38;5;204m✗\x1b[0m Unified narration failed: ${msg}`);
+      broadcast('unified-narrate-error', { message: msg });
+      return null;
+    } finally {
+      ctx.unifiedGenerating = false;
+    }
+  }
+
+  async function refreshCommits(newCommits: LocalCommit[], newHeadSha: string) {
+    const previousShas = new Set(ctx.commits.map((c) => c.sha));
+    ctx.commits = newCommits;
+    ctx.headSha = newHeadSha;
+    // Drop unified — branch moved.
+    ctx.unified = null;
+    ctx.unifiedKey = null;
+    const newShas = new Set(newCommits.map((c) => c.sha));
+    const dropStats: string[] = [];
+    for (const sha of commitStats.keys()) {
+      if (!newShas.has(sha)) dropStats.push(sha);
+    }
+    for (const sha of dropStats) commitStats.delete(sha);
+
+    const dropNarratives: string[] = [];
+    for (const sha of ctx.narratives.keys()) {
+      if (!newShas.has(sha)) dropNarratives.push(sha);
+    }
+    for (const sha of dropNarratives) ctx.narratives.delete(sha);
+
+    const summaries = await buildCommitSummaries();
+    broadcast('watch-update', {
+      branch: ctx.branch,
+      base: ctx.base,
+      baseSha: ctx.baseSha,
+      headSha: ctx.headSha,
+      commits: summaries,
+    });
+
+    // Narrate any new commits in background (oldest first).
+    for (const c of newCommits) {
+      if (previousShas.has(c.sha)) continue;
+      void narrateCommit(c.sha, { broadcastWhenDone: true });
+    }
+  }
+
+  async function selectionFromQuery(c: { req: { query: (k: string) => string | undefined } }): Promise<{
+    selection: WatchPayload['selection'];
+    narrative: NarrativeResponse | null;
+    files: DiffFile[];
+    pr: PRMetadata;
+  }> {
+    const sha = c.req.query('sha');
+    const mode = c.req.query('mode');
+
+    if (mode === 'unified') {
+      const files = await loadFilesForRange(ctx.repoRoot, ctx.base, ctx.headSha);
+      const pr = syntheticPrForUnified(ctx, files);
+      const ready = ctx.unified && ctx.unifiedKey === `${ctx.baseSha}:${ctx.headSha}`;
+      return {
+        selection: { kind: 'unified' },
+        narrative: ready ? ctx.unified : null,
+        files,
+        pr,
+      };
+    }
+
+    const targetSha = sha ?? ctx.commits[ctx.commits.length - 1]?.sha;
+    if (!targetSha) {
+      // No commits yet — return an empty placeholder.
+      return {
+        selection: { kind: 'pending' },
+        narrative: null,
+        files: [],
+        pr: syntheticPrForUnified(ctx, []),
+      };
+    }
+    const commit = ctx.commits.find((cm) => cm.sha === targetSha) ?? ctx.commits[ctx.commits.length - 1]!;
+    const files = await loadFilesForCommit(ctx.repoRoot, commit.sha);
+    const pr = syntheticPrForCommit(ctx, commit, files);
+    const narrative = ctx.narratives.get(commit.sha) ?? null;
+    return {
+      selection: { kind: 'commit', sha: commit.sha },
+      narrative,
+      files,
+      pr,
+    };
+  }
+
+  app.get('/api/narrative', async (c) => {
+    const config = await readConfig();
+    const summaries = await buildCommitSummaries();
+    const { selection, narrative, files, pr } = await selectionFromQuery(c);
+    const unifiedReady = !!(ctx.unified && ctx.unifiedKey === `${ctx.baseSha}:${ctx.headSha}`);
+
+    const watch: WatchPayload = {
+      branch: ctx.branch,
+      base: ctx.base,
+      baseSha: ctx.baseSha,
+      headSha: ctx.headSha,
+      commits: summaries,
+      selection,
+      unifiedReady,
+    };
+
+    const repoUrl = ctx.remoteSlug
+      ? `https://github.com/${ctx.remoteSlug.owner}/${ctx.remoteSlug.repo}`
+      : '';
+
+    const body: Record<string, unknown> = {
+      mode: 'watch',
+      pr,
+      files,
+      comments: [],
+      checkRuns: [],
+      reviews: [],
+      repoUrl,
+      watch,
+      config: {
+        theme: config.theme ?? 'auto',
+        storyStructure: config.storyStructure ?? 'chapters',
+        layoutMode: config.layoutMode ?? 'toc',
+        displayDensity: config.displayDensity ?? 'comfortable',
+        defaultNarrationDensity: config.defaultNarrationDensity ?? 'normal',
+        clusterBots: config.clusterBots ?? true,
+        accent: config.accent ?? 'classic',
+      },
+    };
+
+    if (narrative) {
+      body.narrative = narrative;
+    } else {
+      body.generating = true;
+    }
+    return c.json(body);
+  });
+
+  app.post('/api/narrative/unified', async (c) => {
+    void narrateUnified();
+    return c.json({ ok: true, generating: ctx.unifiedGenerating });
+  });
+
+  app.post('/api/narrative/commit', async (c) => {
+    let payload: { sha?: string };
+    try {
+      payload = (await c.req.json()) as { sha?: string };
+    } catch {
+      return c.json({ error: 'invalid JSON body' }, 400);
+    }
+    if (!payload.sha) return c.json({ error: "missing 'sha'" }, 400);
+    if (!ctx.commits.some((c) => c.sha === payload.sha)) {
+      return c.json({ error: 'unknown commit' }, 404);
+    }
+    void narrateCommit(payload.sha, { broadcastWhenDone: true });
+    return c.json({ ok: true });
+  });
+
+  app.get('/api/events', (c) => {
+    const stream = new ReadableStream({
+      start(controller) {
+        const encoder = new TextEncoder();
+        const send = (event: string, data: unknown) => {
+          try {
+            controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
+          } catch {
+            // controller closed
+          }
+        };
+
+        send('connected', { timestamp: Date.now() });
+        sseClients.add(send);
+
+        c.req.raw.signal.addEventListener('abort', () => {
+          sseClients.delete(send);
+          try {
+            controller.close();
+          } catch {
+            // already closed
+          }
+        });
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      },
+    });
+  });
+
+  const candidates = [
+    resolve(import.meta.dir, '../../web/dist'),
+    resolve(dirname(process.execPath), 'packages', 'web', 'dist'),
+    resolve(dirname(process.execPath), 'share', 'diffdad', 'web'),
+    resolve(dirname(process.execPath), '..', 'share', 'diffdad', 'web'),
+  ];
+  const webDist = candidates.find((p) => existsSync(p)) ?? candidates[0]!;
+
+  app.use(
+    '/*',
+    serveStatic({
+      root: webDist,
+      rewriteRequestPath: (path) => (path === '/' ? '/index.html' : path),
+    }),
+  );
+  app.get('/*', serveStatic({ root: webDist, path: 'index.html' }));
+
+  return { app, broadcast, narrateCommit, narrateUnified, refreshCommits };
+}

--- a/packages/cli/src/watch-server.ts
+++ b/packages/cli/src/watch-server.ts
@@ -19,6 +19,7 @@ import {
   getCommitStats,
   type LocalCommit,
 } from './git/local';
+import { buildBranchSkeleton, type BranchSkeleton } from './watch/skeleton';
 
 export type WatchServerContext = {
   repoRoot: string;
@@ -34,6 +35,8 @@ export type WatchServerContext = {
   generating: Set<string>;
   unifiedGenerating: boolean;
   remoteSlug: { owner: string; repo: string } | null;
+  skeleton: BranchSkeleton | null;
+  skeletonKey: string | null;
 };
 
 type CommitSummary = {
@@ -56,6 +59,7 @@ type WatchPayload = {
   commits: CommitSummary[];
   selection: { kind: 'commit'; sha: string } | { kind: 'unified' } | { kind: 'pending' };
   unifiedReady: boolean;
+  skeleton: BranchSkeleton;
 };
 
 function syntheticPrForCommit(ctx: WatchServerContext, commit: LocalCommit, files: DiffFile[]): PRMetadata {
@@ -183,6 +187,16 @@ export function createWatchServer(ctx: WatchServerContext) {
     return out;
   }
 
+  async function getSkeleton(): Promise<BranchSkeleton> {
+    const key = `${ctx.baseSha}:${ctx.headSha}`;
+    if (ctx.skeleton && ctx.skeletonKey === key) return ctx.skeleton;
+    const files = await loadFilesForRange(ctx.repoRoot, ctx.base, ctx.headSha);
+    const skeleton = buildBranchSkeleton(files);
+    ctx.skeleton = skeleton;
+    ctx.skeletonKey = key;
+    return skeleton;
+  }
+
   async function narrateCommit(sha: string, opts: { broadcastWhenDone?: boolean } = {}): Promise<NarrativeResponse | null> {
     if (ctx.narratives.has(sha)) return ctx.narratives.get(sha)!;
     if (ctx.generating.has(sha)) return null;
@@ -264,6 +278,8 @@ export function createWatchServer(ctx: WatchServerContext) {
     // Drop unified — branch moved.
     ctx.unified = null;
     ctx.unifiedKey = null;
+    ctx.skeleton = null;
+    ctx.skeletonKey = null;
     const newShas = new Set(newCommits.map((c) => c.sha));
     const dropStats: string[] = [];
     for (const sha of commitStats.keys()) {
@@ -339,6 +355,7 @@ export function createWatchServer(ctx: WatchServerContext) {
   app.get('/api/narrative', async (c) => {
     const config = await readConfig();
     const summaries = await buildCommitSummaries();
+    const skeleton = await getSkeleton();
     const { selection, narrative, files, pr } = await selectionFromQuery(c);
     const unifiedReady = !!(ctx.unified && ctx.unifiedKey === `${ctx.baseSha}:${ctx.headSha}`);
 
@@ -350,6 +367,7 @@ export function createWatchServer(ctx: WatchServerContext) {
       commits: summaries,
       selection,
       unifiedReady,
+      skeleton,
     };
 
     const repoUrl = ctx.remoteSlug

--- a/packages/cli/src/watch-server.ts
+++ b/packages/cli/src/watch-server.ts
@@ -293,12 +293,14 @@ export function createWatchServer(ctx: WatchServerContext) {
     for (const sha of dropNarratives) ctx.narratives.delete(sha);
 
     const summaries = await buildCommitSummaries();
+    const unifiedReady = !!(ctx.unified && ctx.unifiedKey === `${ctx.baseSha}:${ctx.headSha}`);
     broadcast('watch-update', {
       branch: ctx.branch,
       base: ctx.base,
       baseSha: ctx.baseSha,
       headSha: ctx.headSha,
       commits: summaries,
+      unifiedReady,
     });
   }
 
@@ -429,7 +431,19 @@ export function createWatchServer(ctx: WatchServerContext) {
         send('connected', { timestamp: Date.now() });
         sseClients.add(send);
 
+        // Keepalive: watch mode only emits SSE on git changes, but Bun's
+        // idleTimeout drops idle sockets after ~4min. A comment frame every
+        // 25s keeps the connection alive without polluting the event log.
+        const keepalive = setInterval(() => {
+          try {
+            controller.enqueue(encoder.encode(`: keepalive ${Date.now()}\n\n`));
+          } catch {
+            // controller closed
+          }
+        }, 25_000);
+
         c.req.raw.signal.addEventListener('abort', () => {
+          clearInterval(keepalive);
           sseClients.delete(send);
           try {
             controller.close();

--- a/packages/cli/src/watch-server.ts
+++ b/packages/cli/src/watch-server.ts
@@ -32,11 +32,24 @@ export type WatchServerContext = {
   narratives: Map<string, NarrativeResponse>;
   unified: NarrativeResponse | null;
   unifiedKey: string | null;
+  // The headSha the unified narrative was generated against. Commits that
+  // landed AFTER this point are "addendums" — visible-but-separate updates
+  // appended to the main story instead of forcing a regeneration.
+  unifiedHeadSha: string | null;
   generating: Set<string>;
   unifiedGenerating: boolean;
   remoteSlug: { owner: string; repo: string } | null;
   skeleton: BranchSkeleton | null;
   skeletonKey: string | null;
+};
+
+export type AddendumEntry = {
+  sha: string;
+  shortSha: string;
+  subject: string;
+  additions: number;
+  deletions: number;
+  narrative: NarrativeResponse | null; // null while generation is in flight
 };
 
 type CommitSummary = {
@@ -59,6 +72,8 @@ type WatchPayload = {
   commits: CommitSummary[];
   selection: { kind: 'commit'; sha: string } | { kind: 'unified' } | { kind: 'pending' };
   unifiedReady: boolean;
+  unifiedHeadSha: string | null;
+  addendums: AddendumEntry[];
   skeleton: BranchSkeleton;
 };
 
@@ -236,17 +251,20 @@ export function createWatchServer(ctx: WatchServerContext) {
     }
   }
 
-  async function narrateUnified(): Promise<NarrativeResponse | null> {
+  async function narrateUnified(opts: { force?: boolean } = {}): Promise<NarrativeResponse | null> {
     const key = `${ctx.baseSha}:${ctx.headSha}`;
-    if (ctx.unified && ctx.unifiedKey === key) return ctx.unified;
+    if (!opts.force && ctx.unified && ctx.unifiedKey === key) return ctx.unified;
     if (ctx.unifiedGenerating) return null;
 
-    const cached = await getCachedUnifiedNarrative(ctx.repoFp, ctx.baseSha, ctx.headSha);
-    if (cached) {
-      ctx.unified = cached;
-      ctx.unifiedKey = key;
-      broadcast('unified-narrative', { ready: true });
-      return cached;
+    if (!opts.force) {
+      const cached = await getCachedUnifiedNarrative(ctx.repoFp, ctx.baseSha, ctx.headSha);
+      if (cached) {
+        ctx.unified = cached;
+        ctx.unifiedKey = key;
+        ctx.unifiedHeadSha = ctx.headSha;
+        broadcast('unified-narrative', { ready: true });
+        return cached;
+      }
     }
 
     ctx.unifiedGenerating = true;
@@ -258,6 +276,7 @@ export function createWatchServer(ctx: WatchServerContext) {
       const { narrative } = await generateNarrative(pr, files, [], config, undefined, 'scrutinize');
       ctx.unified = narrative;
       ctx.unifiedKey = key;
+      ctx.unifiedHeadSha = ctx.headSha;
       await cacheUnifiedNarrative(ctx.repoFp, ctx.baseSha, ctx.headSha, narrative);
       broadcast('unified-narrative', { ready: true });
       return narrative;
@@ -271,14 +290,35 @@ export function createWatchServer(ctx: WatchServerContext) {
     }
   }
 
+  /**
+   * Decide whether the branch update is a simple linear advance (old SHAs all
+   * still present, new SHAs appended) or a history rewrite (a previously-known
+   * SHA disappeared — rebase, amend, squash, reset).
+   */
+  function isSimpleAdvance(prevCommits: LocalCommit[], next: LocalCommit[]): boolean {
+    if (next.length < prevCommits.length) return false;
+    for (let i = 0; i < prevCommits.length; i++) {
+      if (next[i]?.sha !== prevCommits[i]?.sha) return false;
+    }
+    return true;
+  }
+
   async function refreshCommits(newCommits: LocalCommit[], newHeadSha: string) {
+    const prevCommits = ctx.commits;
+    const advance = isSimpleAdvance(prevCommits, newCommits);
+
     ctx.commits = newCommits;
     ctx.headSha = newHeadSha;
-    // Drop unified — branch moved.
-    ctx.unified = null;
-    ctx.unifiedKey = null;
+    // Skeleton always invalidates — totals change with any new commit.
     ctx.skeleton = null;
     ctx.skeletonKey = null;
+    if (!advance) {
+      // History rewrite: the unified story no longer corresponds to a real
+      // ancestor of HEAD. Drop it; cli polling tick will regenerate.
+      ctx.unified = null;
+      ctx.unifiedKey = null;
+      ctx.unifiedHeadSha = null;
+    }
     const newShas = new Set(newCommits.map((c) => c.sha));
     const dropStats: string[] = [];
     for (const sha of commitStats.keys()) {
@@ -294,6 +334,7 @@ export function createWatchServer(ctx: WatchServerContext) {
 
     const summaries = await buildCommitSummaries();
     const unifiedReady = !!(ctx.unified && ctx.unifiedKey === `${ctx.baseSha}:${ctx.headSha}`);
+    const addendums = await buildAddendums();
     broadcast('watch-update', {
       branch: ctx.branch,
       base: ctx.base,
@@ -301,7 +342,40 @@ export function createWatchServer(ctx: WatchServerContext) {
       headSha: ctx.headSha,
       commits: summaries,
       unifiedReady,
+      unifiedHeadSha: ctx.unifiedHeadSha,
+      addendums,
     });
+
+    // On simple advance, fire per-commit narration for each new SHA. These
+    // become the addendum chain — visible "what just changed" notes appended
+    // to the main story instead of forcing a unified regeneration.
+    if (advance) {
+      const prevShas = new Set(prevCommits.map((c) => c.sha));
+      for (const c of newCommits) {
+        if (prevShas.has(c.sha)) continue;
+        void narrateCommit(c.sha, { broadcastWhenDone: true });
+      }
+    }
+  }
+
+  async function buildAddendums(): Promise<AddendumEntry[]> {
+    if (!ctx.unifiedHeadSha) return [];
+    const idx = ctx.commits.findIndex((c) => c.sha === ctx.unifiedHeadSha);
+    if (idx < 0) return [];
+    const tail = ctx.commits.slice(idx + 1);
+    const out: AddendumEntry[] = [];
+    for (const c of tail) {
+      const stats = await getCommitStatsCached(c.sha);
+      out.push({
+        sha: c.sha,
+        shortSha: c.shortSha,
+        subject: c.subject,
+        additions: stats.additions,
+        deletions: stats.deletions,
+        narrative: ctx.narratives.get(c.sha) ?? null,
+      });
+    }
+    return out;
   }
 
   async function selectionFromQuery(c: { req: { query: (k: string) => string | undefined } }): Promise<{
@@ -352,6 +426,7 @@ export function createWatchServer(ctx: WatchServerContext) {
     const skeleton = await getSkeleton();
     const { selection, narrative, files, pr } = await selectionFromQuery(c);
     const unifiedReady = !!(ctx.unified && ctx.unifiedKey === `${ctx.baseSha}:${ctx.headSha}`);
+    const addendums = await buildAddendums();
 
     const watch: WatchPayload = {
       branch: ctx.branch,
@@ -361,6 +436,8 @@ export function createWatchServer(ctx: WatchServerContext) {
       commits: summaries,
       selection,
       unifiedReady,
+      unifiedHeadSha: ctx.unifiedHeadSha,
+      addendums,
       skeleton,
     };
 
@@ -397,7 +474,18 @@ export function createWatchServer(ctx: WatchServerContext) {
   });
 
   app.post('/api/narrative/unified', async (c) => {
-    void narrateUnified();
+    let body: { force?: boolean } = {};
+    try {
+      body = (await c.req.json()) as { force?: boolean };
+    } catch {
+      // empty body is allowed
+    }
+    if (body.force) {
+      ctx.unified = null;
+      ctx.unifiedKey = null;
+      ctx.unifiedHeadSha = null;
+    }
+    void narrateUnified({ force: !!body.force });
     return c.json({ ok: true, generating: ctx.unifiedGenerating });
   });
 

--- a/packages/cli/src/watch-server.ts
+++ b/packages/cli/src/watch-server.ts
@@ -272,7 +272,6 @@ export function createWatchServer(ctx: WatchServerContext) {
   }
 
   async function refreshCommits(newCommits: LocalCommit[], newHeadSha: string) {
-    const previousShas = new Set(ctx.commits.map((c) => c.sha));
     ctx.commits = newCommits;
     ctx.headSha = newHeadSha;
     // Drop unified — branch moved.
@@ -301,12 +300,6 @@ export function createWatchServer(ctx: WatchServerContext) {
       headSha: ctx.headSha,
       commits: summaries,
     });
-
-    // Narrate any new commits in background (oldest first).
-    for (const c of newCommits) {
-      if (previousShas.has(c.sha)) continue;
-      void narrateCommit(c.sha, { broadcastWhenDone: true });
-    }
   }
 
   async function selectionFromQuery(c: { req: { query: (k: string) => string | undefined } }): Promise<{

--- a/packages/cli/src/watch-server.ts
+++ b/packages/cli/src/watch-server.ts
@@ -316,23 +316,22 @@ export function createWatchServer(ctx: WatchServerContext) {
     pr: PRMetadata;
   }> {
     const sha = c.req.query('sha');
-    const mode = c.req.query('mode');
 
-    if (mode === 'unified') {
-      const files = await loadFilesForRange(ctx.repoRoot, ctx.base, ctx.headSha);
-      const pr = syntheticPrForUnified(ctx, files);
-      const ready = ctx.unified && ctx.unifiedKey === `${ctx.baseSha}:${ctx.headSha}`;
-      return {
-        selection: { kind: 'unified' },
-        narrative: ready ? ctx.unified : null,
-        files,
-        pr,
-      };
+    // Explicit per-commit request.
+    if (sha) {
+      const commit = ctx.commits.find((cm) => cm.sha === sha);
+      if (commit) {
+        const files = await loadFilesForCommit(ctx.repoRoot, commit.sha);
+        const pr = syntheticPrForCommit(ctx, commit, files);
+        const narrative = ctx.narratives.get(commit.sha) ?? null;
+        return { selection: { kind: 'commit', sha: commit.sha }, narrative, files, pr };
+      }
+      // Fall through to unified default if sha unknown.
     }
 
-    const targetSha = sha ?? ctx.commits[ctx.commits.length - 1]?.sha;
-    if (!targetSha) {
-      // No commits yet — return an empty placeholder.
+    // Default and `?mode=unified` both land on the whole-branch view.
+    // 'mode' query param is now informational; default and ?mode=unified are equivalent.
+    if (ctx.commits.length === 0) {
       return {
         selection: { kind: 'pending' },
         narrative: null,
@@ -340,13 +339,13 @@ export function createWatchServer(ctx: WatchServerContext) {
         pr: syntheticPrForUnified(ctx, []),
       };
     }
-    const commit = ctx.commits.find((cm) => cm.sha === targetSha) ?? ctx.commits[ctx.commits.length - 1]!;
-    const files = await loadFilesForCommit(ctx.repoRoot, commit.sha);
-    const pr = syntheticPrForCommit(ctx, commit, files);
-    const narrative = ctx.narratives.get(commit.sha) ?? null;
+
+    const files = await loadFilesForRange(ctx.repoRoot, ctx.base, ctx.headSha);
+    const pr = syntheticPrForUnified(ctx, files);
+    const ready = ctx.unified && ctx.unifiedKey === `${ctx.baseSha}:${ctx.headSha}`;
     return {
-      selection: { kind: 'commit', sha: commit.sha },
-      narrative,
+      selection: { kind: 'unified' },
+      narrative: ready ? ctx.unified : null,
       files,
       pr,
     };

--- a/packages/cli/src/watch/skeleton.ts
+++ b/packages/cli/src/watch/skeleton.ts
@@ -1,0 +1,125 @@
+import type { DiffFile } from '../github/types';
+
+export type FileCategory = 'test' | 'config' | 'schema' | 'migration' | 'docs' | 'public-api' | 'source';
+
+export type SkeletonFile = {
+  path: string;
+  category: FileCategory;
+  additions: number;
+  deletions: number;
+  isNewFile: boolean;
+  isDeleted: boolean;
+};
+
+export type BranchSkeleton = {
+  totals: { additions: number; deletions: number; changedFiles: number };
+  byCategory: Record<FileCategory, number>;
+  touchedDirs: { dir: string; count: number }[];
+  notable: SkeletonFile[];
+  files: SkeletonFile[];
+};
+
+const TEST_RE = /(^|\/)(__tests__|tests?)\//i;
+const TEST_SUFFIX_RE = /\.(test|spec)\.[a-z0-9]+$/i;
+const MIGRATION_RE = /(^|\/)migrations?\//i;
+const SCHEMA_RE = /(^|\/)(schema)\.(ts|js|prisma|sql)$/i;
+const SCHEMA_PRISMA_RE = /(^|\/)prisma\/schema\.prisma$/i;
+const DOCS_RE = /(^|\/)docs?\//i;
+const MARKDOWN_RE = /\.(md|mdx)$/i;
+const PUBLIC_API_RE = /(^|\/)(src\/index|index)\.(ts|tsx|js)$/i;
+const DTS_RE = /\.d\.ts$/i;
+const CONFIG_FILES = new Set([
+  'package.json',
+  'bun.lock',
+  'package-lock.json',
+  'yarn.lock',
+  'tsconfig.json',
+  '.oxlintrc.json',
+  '.oxfmtrc.json',
+  '.gitignore',
+  '.npmrc',
+]);
+const CONFIG_PATTERNS = [
+  /\.config\.(ts|js|mjs|cjs|json)$/i,
+  /(^|\/)(vite|vitest|tailwind|eslint|prettier|postcss|babel|rollup|webpack)\.config\./i,
+  /(^|\/)\.[a-z0-9-]+rc(\.[a-z]+)?$/i, // .eslintrc, .prettierrc, .oxlintrc.json (also caught above)
+];
+
+export function classifyFile(path: string): FileCategory {
+  if (TEST_RE.test(path) || TEST_SUFFIX_RE.test(path)) return 'test';
+  if (MIGRATION_RE.test(path)) return 'migration';
+  if (SCHEMA_PRISMA_RE.test(path) || SCHEMA_RE.test(path)) return 'schema';
+  const basename = path.split('/').pop() ?? path;
+  if (CONFIG_FILES.has(basename)) return 'config';
+  if (CONFIG_PATTERNS.some((re) => re.test(path))) return 'config';
+  if (MARKDOWN_RE.test(path) || DOCS_RE.test(path)) return 'docs';
+  if (PUBLIC_API_RE.test(path) || DTS_RE.test(path)) return 'public-api';
+  return 'source';
+}
+
+function countLines(file: DiffFile): { additions: number; deletions: number } {
+  let additions = 0;
+  let deletions = 0;
+  for (const h of file.hunks) {
+    for (const l of h.lines) {
+      if (l.type === 'add') additions += 1;
+      else if (l.type === 'remove') deletions += 1;
+    }
+  }
+  return { additions, deletions };
+}
+
+function dirOf(path: string): string {
+  const i = path.lastIndexOf('/');
+  return i === -1 ? '' : path.slice(0, i);
+}
+
+export function buildBranchSkeleton(files: DiffFile[]): BranchSkeleton {
+  const skeletonFiles: SkeletonFile[] = files.map((f) => {
+    const { additions, deletions } = countLines(f);
+    return {
+      path: f.file,
+      category: classifyFile(f.file),
+      additions,
+      deletions,
+      isNewFile: f.isNewFile,
+      isDeleted: f.isDeleted,
+    };
+  });
+
+  const totals = skeletonFiles.reduce(
+    (acc, f) => ({
+      additions: acc.additions + f.additions,
+      deletions: acc.deletions + f.deletions,
+      changedFiles: acc.changedFiles + 1,
+    }),
+    { additions: 0, deletions: 0, changedFiles: 0 },
+  );
+
+  const byCategory: Record<FileCategory, number> = {
+    test: 0,
+    config: 0,
+    schema: 0,
+    migration: 0,
+    docs: 0,
+    'public-api': 0,
+    source: 0,
+  };
+  for (const f of skeletonFiles) byCategory[f.category] += 1;
+
+  const dirCounts = new Map<string, number>();
+  for (const f of skeletonFiles) {
+    const d = dirOf(f.path) || '.';
+    dirCounts.set(d, (dirCounts.get(d) ?? 0) + 1);
+  }
+  const touchedDirs = [...dirCounts.entries()]
+    .map(([dir, count]) => ({ dir, count }))
+    .sort((a, b) => b.count - a.count || a.dir.localeCompare(b.dir))
+    .slice(0, 8);
+
+  const notable = [...skeletonFiles]
+    .sort((a, b) => b.additions + b.deletions - (a.additions + a.deletions))
+    .slice(0, 5);
+
+  return { totals, byCategory, touchedDirs, notable, files: skeletonFiles };
+}

--- a/packages/site/src/components/Features.astro
+++ b/packages/site/src/components/Features.astro
@@ -1,10 +1,12 @@
 ---
 const feats = [
   { ico: '§', title: 'Semantic chapters', body: 'AI groups hunks across files by behavior — not filename. Each chapter has a title, risk level, and prose explaining what changed and why.' },
-  { ico: '↔', title: 'Two-way GitHub sync', body: "Comments flow both directions — replies you post in dad land in GitHub as real review comments, and GitHub comments show up next to the matching line. No tab-juggling required." },
+  { ico: '👁', title: 'Watch your branch', body: "dad watch narrates your in-progress branch as a single feature, not a sequence of edits. Whole-branch story up front, per-commit detail on demand. No GitHub required." },
+  { ico: '🦴', title: 'Branch skeleton', body: "Before the model finishes thinking, watch mode shows you the cheap stuff: totals, touched directories, file categorization (test / config / schema / migration / docs / public-api), notable changes." },
+  { ico: '↔', title: 'Two-way GitHub sync', body: "In PR mode, comments flow both directions — replies you post in dad land in GitHub as real review comments, and GitHub comments show up next to the matching line. No tab-juggling required." },
   { ico: '↻', title: 'Auto re-narrates on new commits', body: 'Push a fixup? Dad notices and regenerates the story for the new SHA. Old narratives stay cached so you can flip between revisions and see how the plot thickened.' },
   { ico: '💬', title: 'Inline comments', body: "GitHub review comments render next to the relevant lines. Bot comments (Greptile, CodeRabbit) cluster into collapsible groups so they don't bury the humans." },
-  { ico: '📡', title: 'Live SSE updates', body: 'An SSE connection polls every 10 seconds. New comments, CI status, and check runs appear in real time. Like a baby monitor, but for your PR.' },
+  { ico: '📡', title: 'Live SSE updates', body: 'An SSE connection pushes new comments, CI status, and check runs in real time (PR mode). Watch mode polls git every 2s for new commits and re-narrates on the fly. Like a baby monitor, but for your code.' },
   { ico: '≋', title: 'Story controls', body: 'Toggle terse / normal / verbose narration per chapter. Re-narrate through different lenses (security, performance, API consumer). Choose your own adventure.' },
   { ico: '?', title: 'Ask AI', body: "Ask follow-up questions about a specific chapter's code. Dad keeps the chapter context so answers stay grounded — no off-topic ramblings about the lawn." },
   { ico: '✓', title: 'Submit reviews', body: 'Comment, Approve, or Request Changes — directly from the UI. Inline comments post to GitHub with your summary. Then dad pats you on the back.' },

--- a/packages/site/src/components/Hero.astro
+++ b/packages/site/src/components/Hero.astro
@@ -10,10 +10,10 @@ import InstallPill from './InstallPill.astro';
       <span>// hold my coffee, I'll explain this PR</span>
     </div>
     <h1 class="font-serif font-semibold text-[56px] md:text-[76px] leading-[1.0] tracking-[-0.025em] m-0 mb-6 text-balance">
-      Your PRs, told as a <em class="not-italic italic text-accent-2 font-semibold">story</em> — not a wall of diffs.
+      Your PRs and your branches, told as a <em class="not-italic italic text-accent-2 font-semibold">story</em> — not a wall of diffs.
     </h1>
     <p class="text-xl text-ink-2 max-w-[540px] m-0 mb-9 leading-[1.45]">
-      <code class="font-mono bg-card border border-line px-[6px] py-[2px] rounded text-base">dad</code> reads the whole pull request, groups changes by behavior into chapters, and walks you through them with prose, risk levels, and inline comments. Think of it as a code review with a <i>thicker mustache</i>.
+      <code class="font-mono bg-card border border-line px-[6px] py-[2px] rounded text-base">dad</code> reads the whole pull request, groups changes by behavior into chapters, and walks you through them with prose, risk levels, and inline comments. <code class="font-mono bg-card border border-line px-[6px] py-[2px] rounded text-base">dad watch</code> does the same for the branch you're working on right now — before you ever open a PR. Code review with a <i>thicker mustache</i>.
     </p>
     <div class="flex gap-3 items-center flex-wrap">
       <InstallPill cmd="brew install nicknisi/diffdad/dad" />

--- a/packages/site/src/components/Usage.astro
+++ b/packages/site/src/components/Usage.astro
@@ -6,7 +6,7 @@ import InstallPill from './InstallPill.astro';
   <div class="wrap">
     <div class="section-eye">// usage</div>
     <h2 class="font-serif font-semibold text-[44px] leading-[1.1] tracking-[-0.02em] m-0 mb-[18px] text-balance">
-      Five commands, three flags, <em class="italic text-accent-2">one</em> mustache.
+      Six commands, four flags, <em class="italic text-accent-2">one</em> mustache.
     </h2>
     <p class="text-lg text-ink-2 max-w-[620px] m-0 mb-10">
       The CLI fetches a PR, generates the narrative, starts a local server, and opens your browser.
@@ -18,6 +18,7 @@ import InstallPill from './InstallPill.astro';
         <div class="text-[11px] text-[#6B7B9A] tracking-[0.1em] uppercase mb-[14px]">// commands</div>
         <div class="grid grid-cols-[minmax(180px,max-content)_1fr] gap-[18px] py-1"><span class="text-[#FFF6E6]">dad &lt;pr&gt;</span><span class="text-[#8A95AD]">Open a PR as a narrated story</span></div>
         <div class="grid grid-cols-[minmax(180px,max-content)_1fr] gap-[18px] py-1"><span class="text-[#FFF6E6]">dad review &lt;pr&gt;</span><span class="text-[#8A95AD]">Same as above (explicit)</span></div>
+        <div class="grid grid-cols-[minmax(180px,max-content)_1fr] gap-[18px] py-1"><span class="text-[#FFF6E6]">dad watch [branch]</span><span class="text-[#8A95AD]">Narrate your in-progress branch (no GitHub)</span></div>
         <div class="grid grid-cols-[minmax(180px,max-content)_1fr] gap-[18px] py-1"><span class="text-[#FFF6E6]">dad config</span><span class="text-[#8A95AD]">Configure AI provider, GH token, display</span></div>
         <div class="grid grid-cols-[minmax(180px,max-content)_1fr] gap-[18px] py-1"><span class="text-[#FFF6E6]">dad cache clear</span><span class="text-[#8A95AD]">Wipe cached narratives</span></div>
         <div class="grid grid-cols-[minmax(180px,max-content)_1fr] gap-[18px] py-1"><span class="text-[#FFF6E6]">dad --version</span><span class="text-[#8A95AD]">Print version</span></div>
@@ -32,6 +33,7 @@ import InstallPill from './InstallPill.astro';
       <div class="bg-card border border-line rounded-[18px] px-6 py-[22px]">
         <h4 class="font-serif font-semibold text-xl m-0 mb-3">Flags (any position)</h4>
         <div class="grid grid-cols-[minmax(170px,max-content)_1fr] gap-[14px] py-2 text-[13px] items-baseline"><span class="font-mono text-accent-2 font-medium whitespace-nowrap">--with=claude|pi</span><span class="text-ink-2">Force a specific AI CLI</span></div>
+        <div class="grid grid-cols-[minmax(170px,max-content)_1fr] gap-[14px] py-2 text-[13px] items-baseline border-t border-line"><span class="font-mono text-accent-2 font-medium whitespace-nowrap">--base &lt;ref&gt;</span><span class="text-ink-2">Watch mode: override base (default origin/HEAD)</span></div>
         <div class="grid grid-cols-[minmax(170px,max-content)_1fr] gap-[14px] py-2 text-[13px] items-baseline border-t border-line"><span class="font-mono text-accent-2 font-medium whitespace-nowrap">--no-cache</span><span class="text-ink-2">Regenerate narrative even if cached</span></div>
         <div class="grid grid-cols-[minmax(170px,max-content)_1fr] gap-[14px] py-2 text-[13px] items-baseline border-t border-line"><span class="font-mono text-accent-2 font-medium whitespace-nowrap">--no-open</span><span class="text-ink-2">Don't auto-open the browser</span></div>
         <div class="grid grid-cols-[minmax(170px,max-content)_1fr] gap-[14px] py-2 text-[13px] items-baseline border-t border-line"><span class="font-mono text-accent-2 font-medium whitespace-nowrap">--port=3000</span><span class="text-ink-2">Use a specific port</span></div>

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -137,12 +137,10 @@ export default function App() {
             <CommitTimeline />
           </aside>
           <main className="min-w-0 flex-1">
-            {narrative ? (
-              view === 'story' ? (
-                <StoryView />
-              ) : (
-                <ClassicView />
-              )
+            {view === 'files' ? (
+              <ClassicView />
+            ) : narrative ? (
+              <StoryView />
             ) : (
               <BranchSkeletonView message={copy.loadingMessages[loadingMsgIndex]!} />
             )}

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -5,6 +5,7 @@ import { useLiveStream } from './hooks/useLiveStream';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { ActivityDrawer } from './components/ActivityDrawer';
 import { AppBar } from './components/AppBar';
+import { BranchSkeletonView } from './components/BranchSkeletonView';
 import { ClassicView } from './components/ClassicView';
 import { CommitTimeline } from './components/CommitTimeline';
 import { GeneratingScreen } from './components/GeneratingScreen';
@@ -135,11 +136,7 @@ export default function App() {
             <ClassicView />
           )
         ) : (
-          <GeneratingScreen
-            compact
-            message={copy.loadingMessages[loadingMsgIndex]!}
-            subtitle="Pick another commit while you wait."
-          />
+          <BranchSkeletonView message={copy.loadingMessages[loadingMsgIndex]!} />
         )}
         <ActivityDrawer open={activityOpen} onClose={() => setActivityOpen(false)} />
         <ShortcutsHelp open={shortcutsHelpOpen} onClose={() => setShortcutsHelpOpen(false)} />

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -6,11 +6,13 @@ import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { ActivityDrawer } from './components/ActivityDrawer';
 import { AppBar } from './components/AppBar';
 import { ClassicView } from './components/ClassicView';
+import { CommitTimeline } from './components/CommitTimeline';
 import { GeneratingScreen } from './components/GeneratingScreen';
 import { PRHeader } from './components/PRHeader';
 import { ShortcutsHelp } from './components/ShortcutsHelp';
 import { StoryView } from './components/StoryView';
 import { SubmitBar } from './components/SubmitBar';
+import { WatchHeader } from './components/WatchHeader';
 import { copy } from './lib/microcopy';
 import { getAccentMeta } from './lib/accents';
 import { renderDadMarkSVG } from './components/DadMark';
@@ -21,15 +23,18 @@ export default function App() {
   const view = useReviewStore((s) => s.view);
   const pr = useReviewStore((s) => s.pr);
   const narrative = useReviewStore((s) => s.narrative);
+  const mode = useReviewStore((s) => s.mode);
   const shortcutsHelpOpen = useReviewStore((s) => s.shortcutsHelpOpen);
   const setShortcutsHelpOpen = useReviewStore((s) => s.setShortcutsHelpOpen);
   const { loading, generating, setGenerating, error } = useNarrative();
 
   useEffect(() => {
-    if (pr) {
+    if (mode === 'watch' && pr) {
+      document.title = `${pr.title} — Diff Dad (watch)`;
+    } else if (pr) {
       document.title = `#${pr.number} ${pr.title} — Diff Dad`;
     }
-  }, [pr]);
+  }, [pr, mode]);
   useLiveStream();
   useKeyboardShortcuts();
   const [activityOpen, setActivityOpen] = useState(false);
@@ -114,6 +119,31 @@ export default function App() {
           <p className="mt-2 text-sm text-[var(--fg-3)]">{error}</p>
         </div>
       </main>
+    );
+  }
+
+  if (mode === 'watch') {
+    return (
+      <div className="min-h-screen bg-[var(--bg-page)] pb-20 text-[var(--fg-1)]">
+        <AppBar onOpenActivity={() => setActivityOpen(true)} />
+        <WatchHeader />
+        <CommitTimeline />
+        {narrative ? (
+          view === 'story' ? (
+            <StoryView />
+          ) : (
+            <ClassicView />
+          )
+        ) : (
+          <div className="mx-auto max-w-[880px] px-6 py-12 text-[var(--fg-3)]">
+            <p className="text-[14px]">
+              Narration in progress for this commit… Click another commit in the timeline above while you wait.
+            </p>
+          </div>
+        )}
+        <ActivityDrawer open={activityOpen} onClose={() => setActivityOpen(false)} />
+        <ShortcutsHelp open={shortcutsHelpOpen} onClose={() => setShortcutsHelpOpen(false)} />
+      </div>
     );
   }
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -44,7 +44,7 @@ export default function App() {
     if (narrative && generating) setGenerating(false);
   }, [narrative, generating, setGenerating]);
 
-  const showLoadingMessages = loading || generating;
+  const showLoadingMessages = loading || generating || (mode === 'watch' && !narrative);
   useEffect(() => {
     if (!showLoadingMessages) return;
     const t = setInterval(() => setLoadingMsgIndex((i) => (i + 1) % copy.loadingMessages.length), 2500);
@@ -135,11 +135,11 @@ export default function App() {
             <ClassicView />
           )
         ) : (
-          <div className="mx-auto max-w-[880px] px-6 py-12 text-[var(--fg-3)]">
-            <p className="text-[14px]">
-              Narration in progress for this commit… Click another commit in the timeline above while you wait.
-            </p>
-          </div>
+          <GeneratingScreen
+            compact
+            message={copy.loadingMessages[loadingMsgIndex]!}
+            subtitle="Pick another commit while you wait."
+          />
         )}
         <ActivityDrawer open={activityOpen} onClose={() => setActivityOpen(false)} />
         <ShortcutsHelp open={shortcutsHelpOpen} onClose={() => setShortcutsHelpOpen(false)} />

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -5,6 +5,7 @@ import { useLiveStream } from './hooks/useLiveStream';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { ActivityDrawer } from './components/ActivityDrawer';
 import { AppBar } from './components/AppBar';
+import { AddendumsView } from './components/AddendumsView';
 import { BranchSkeletonView } from './components/BranchSkeletonView';
 import { ClassicView } from './components/ClassicView';
 import { CommitTimeline } from './components/CommitTimeline';
@@ -140,7 +141,10 @@ export default function App() {
             {view === 'files' ? (
               <ClassicView />
             ) : narrative ? (
-              <StoryView />
+              <>
+                <StoryView />
+                <AddendumsView />
+              </>
             ) : (
               <BranchSkeletonView message={copy.loadingMessages[loadingMsgIndex]!} />
             )}

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -128,16 +128,26 @@ export default function App() {
       <div className="min-h-screen bg-[var(--bg-page)] pb-20 text-[var(--fg-1)]">
         <AppBar onOpenActivity={() => setActivityOpen(true)} />
         <WatchHeader />
-        <CommitTimeline />
-        {narrative ? (
-          view === 'story' ? (
-            <StoryView />
-          ) : (
-            <ClassicView />
-          )
-        ) : (
-          <BranchSkeletonView message={copy.loadingMessages[loadingMsgIndex]!} />
-        )}
+        <div className="flex">
+          <aside
+            className="sticky w-[260px] shrink-0 self-start overflow-y-auto border-r border-[var(--gray-a4)] bg-[var(--bg-page)]"
+            style={{ top: 'calc(52px + 96px)', maxHeight: 'calc(100vh - 52px - 96px)' }}
+            aria-label="Commit timeline sidebar"
+          >
+            <CommitTimeline />
+          </aside>
+          <main className="min-w-0 flex-1">
+            {narrative ? (
+              view === 'story' ? (
+                <StoryView />
+              ) : (
+                <ClassicView />
+              )
+            ) : (
+              <BranchSkeletonView message={copy.loadingMessages[loadingMsgIndex]!} />
+            )}
+          </main>
+        </div>
         <ActivityDrawer open={activityOpen} onClose={() => setActivityOpen(false)} />
         <ShortcutsHelp open={shortcutsHelpOpen} onClose={() => setShortcutsHelpOpen(false)} />
       </div>

--- a/packages/web/src/components/AddendumsView.tsx
+++ b/packages/web/src/components/AddendumsView.tsx
@@ -1,0 +1,159 @@
+import { useState } from 'react';
+import { applyNarrativeResponse, fetchNarrative } from '../hooks/useNarrative';
+import { useReviewStore } from '../state/review-store';
+import type { Addendum } from '../state/types';
+import { Markdown } from './markdown/Markdown';
+
+export function AddendumsView() {
+  const watch = useReviewStore((s) => s.watch);
+  const narrative = useReviewStore((s) => s.narrative);
+  const [regenerating, setRegenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!watch || !narrative) return null;
+  const addendums = watch.addendums ?? [];
+  if (addendums.length === 0) return null;
+
+  async function regenerate() {
+    setError(null);
+    setRegenerating(true);
+    try {
+      await fetch('/api/narrative/unified', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ force: true }),
+      });
+      // The story disappears while regenerating — pull the empty state so the
+      // bobbing-skeleton view can take over until SSE delivers the new one.
+      const data = await fetchNarrative('?mode=unified');
+      applyNarrativeResponse(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to regenerate');
+    } finally {
+      setRegenerating(false);
+    }
+  }
+
+  return (
+    <section
+      className="mx-auto mt-10 max-w-[1100px] px-6 pb-20"
+      aria-label="Story addendums"
+    >
+      <header className="mb-5 flex items-start justify-between gap-4 border-t border-[var(--gray-a4)] pt-6">
+        <div>
+          <p className="text-[11.5px] font-semibold uppercase tracking-[0.08em] text-[var(--fg-3)]">
+            Since this story was generated
+          </p>
+          <p className="mt-1 text-[14px] text-[var(--fg-2)]">
+            {addendums.length} new {addendums.length === 1 ? 'commit' : 'commits'} landed after the
+            whole-branch story above. The story may not reflect them yet — read these notes, then{' '}
+            <button
+              type="button"
+              onClick={regenerate}
+              disabled={regenerating}
+              className="underline underline-offset-2 hover:text-[var(--fg-1)] disabled:opacity-60"
+            >
+              regenerate
+            </button>{' '}
+            if it feels stale.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={regenerate}
+          disabled={regenerating}
+          className="shrink-0 rounded-[8px] px-3 py-2 text-[12.5px] font-medium transition-colors disabled:opacity-60"
+          style={{
+            background: 'var(--purple-3)',
+            color: 'var(--purple-11)',
+            boxShadow: 'inset 0 0 0 1px var(--purple-a5)',
+          }}
+        >
+          {regenerating ? 'Regenerating…' : 'Regenerate story'}
+        </button>
+      </header>
+
+      {error ? <p className="mb-3 text-[12px] text-[var(--red-11)]">{error}</p> : null}
+
+      <ol className="flex flex-col gap-4">
+        {addendums.map((a) => (
+          <AddendumCard key={a.sha} addendum={a} />
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function AddendumCard({ addendum }: { addendum: Addendum }) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <li
+      className="overflow-hidden rounded-[10px] bg-[var(--bg-panel)]"
+      style={{ boxShadow: 'inset 0 0 0 1px var(--gray-a5)' }}
+    >
+      <header
+        className="flex items-baseline gap-3 px-4 py-3"
+        style={{
+          background: 'var(--gray-2)',
+          boxShadow: 'inset 0 -1px 0 var(--gray-a4)',
+        }}
+      >
+        <span className="font-mono text-[11.5px] text-[var(--fg-3)]">{addendum.shortSha}</span>
+        <span className="flex-1 truncate text-[14px] font-medium text-[var(--fg-1)]">
+          {addendum.subject}
+        </span>
+        <span className="shrink-0 text-[11.5px] text-[var(--fg-3)]">
+          <span style={{ color: 'var(--green-11)' }}>+{addendum.additions}</span>{' '}
+          <span style={{ color: 'var(--red-11)' }}>−{addendum.deletions}</span>
+        </span>
+      </header>
+      <div className="px-4 py-3 text-[13.5px] text-[var(--fg-1)]">
+        {addendum.narrative ? (
+          <AddendumBody narrative={addendum.narrative} expanded={expanded} onToggle={() => setExpanded((v) => !v)} />
+        ) : (
+          <p className="italic text-[var(--fg-3)]">Narrating…</p>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function AddendumBody({
+  narrative,
+  expanded,
+  onToggle,
+}: {
+  narrative: NonNullable<Addendum['narrative']>;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  // Show the tldr (or first chapter summary) by default; expose chapter
+  // detail behind a toggle so the addendum stays compact.
+  const tldr = narrative.tldr ?? narrative.chapters[0]?.summary ?? '';
+  return (
+    <div className="flex flex-col gap-3">
+      {tldr ? <Markdown source={tldr} /> : null}
+      {narrative.chapters.length > 0 ? (
+        <button
+          type="button"
+          onClick={onToggle}
+          className="self-start text-[12px] font-medium text-[var(--fg-2)] underline underline-offset-2 hover:text-[var(--fg-1)]"
+        >
+          {expanded ? 'Hide chapter detail' : `Show chapter detail (${narrative.chapters.length})`}
+        </button>
+      ) : null}
+      {expanded
+        ? narrative.chapters.map((ch, i) => (
+            <article
+              key={i}
+              className="rounded-[6px] bg-[var(--bg-page)] px-3 py-2.5"
+              style={{ boxShadow: 'inset 0 0 0 1px var(--gray-a4)' }}
+            >
+              <h4 className="m-0 mb-1 text-[13px] font-semibold text-[var(--fg-1)]">{ch.title}</h4>
+              <Markdown source={ch.summary} />
+            </article>
+          ))
+        : null}
+    </div>
+  );
+}

--- a/packages/web/src/components/AppBar.tsx
+++ b/packages/web/src/components/AppBar.tsx
@@ -104,10 +104,44 @@ export function AppBar({ onOpenActivity }: AppBarProps) {
   const accent = useReviewStore((s) => s.accent);
   const setAccent = useReviewStore((s) => s.setAccent);
   const repoUrl = useReviewStore((s) => s.repoUrl);
+  const mode = useReviewStore((s) => s.mode);
+  const watch = useReviewStore((s) => s.watch);
 
   const slug = repoSlug(repoUrl);
   const { markBg } = getAccentMeta(accent);
   const prNum = pr ? pr.number : null;
+
+  const cliLabel = mode === 'watch' && watch ? `dad watch ${watch.branch}` : `dad review ${prNum ?? '—'}`;
+
+  let target: { href: string | null; primary: string; secondary?: string; title: string } = {
+    href: null,
+    primary: '—',
+    title: '',
+  };
+  if (mode === 'watch' && watch) {
+    if (slug && repoUrl) {
+      target = {
+        href: `${repoUrl}/tree/${encodeURIComponent(watch.branch)}`,
+        primary: slug,
+        secondary: `${watch.branch} → ${watch.base}`,
+        title: 'Open branch on GitHub',
+      };
+    } else {
+      target = {
+        href: null,
+        primary: watch.branch,
+        secondary: `→ ${watch.base}`,
+        title: '',
+      };
+    }
+  } else if (slug && repoUrl && prNum != null) {
+    target = {
+      href: `${repoUrl}/pull/${prNum}`,
+      primary: slug,
+      secondary: `#${prNum}`,
+      title: 'Open PR on GitHub',
+    };
+  }
 
   return (
     <header
@@ -129,26 +163,39 @@ export function AppBar({ onOpenActivity }: AppBarProps) {
           className="whitespace-nowrap rounded-[4px] bg-[var(--gray-3)] px-2 py-0.5 text-[var(--fg-1)]"
           style={{ boxShadow: 'inset 0 0 0 1px var(--gray-a5)' }}
         >
-          dad review {prNum ?? '—'}
+          {cliLabel}
         </span>
         <span className="inline-flex text-[var(--fg-3)]">
           <IconArrowRight className="h-[11px] w-[11px]" />
         </span>
-        {slug && repoUrl && prNum != null ? (
+        {target.href ? (
           <a
-            href={`${repoUrl}/pull/${prNum}`}
+            href={target.href}
             target="_blank"
             rel="noopener noreferrer"
             className="truncate text-[13px] font-medium font-sans hover:underline"
-            title="Open PR on GitHub"
+            title={target.title}
           >
             <span className="font-semibold" style={{ color: 'var(--purple-11)' }}>
-              {slug}
+              {target.primary}
             </span>
-            <span style={{ color: 'var(--fg-1)' }}>#{prNum}</span>
+            {target.secondary ? (
+              <span className="ml-1" style={{ color: 'var(--fg-1)' }}>
+                {target.secondary}
+              </span>
+            ) : null}
           </a>
         ) : (
-          <span className="text-[var(--fg-3)]">—</span>
+          <span className="truncate text-[13px] font-medium font-sans">
+            <span className="font-semibold" style={{ color: 'var(--purple-11)' }}>
+              {target.primary}
+            </span>
+            {target.secondary ? (
+              <span className="ml-1" style={{ color: 'var(--fg-1)' }}>
+                {target.secondary}
+              </span>
+            ) : null}
+          </span>
         )}
         <span className="ml-auto font-mono text-[11px] font-medium text-[var(--fg-3)]">pid 41278</span>
       </div>

--- a/packages/web/src/components/AppBar.tsx
+++ b/packages/web/src/components/AppBar.tsx
@@ -109,30 +109,35 @@ export function AppBar({ onOpenActivity }: AppBarProps) {
 
   const slug = repoSlug(repoUrl);
   const { markBg } = getAccentMeta(accent);
-  const prNum = pr ? pr.number : null;
+  const isWatch = mode === 'watch' || !!watch;
+  const prNum = !isWatch && pr ? pr.number : null;
 
-  const cliLabel = mode === 'watch' && watch ? `dad watch ${watch.branch}` : `dad review ${prNum ?? '—'}`;
+  const cliLabel = isWatch ? (watch ? `dad watch ${watch.branch}` : 'dad watch') : `dad review ${prNum ?? '—'}`;
 
   let target: { href: string | null; primary: string; secondary?: string; title: string } = {
     href: null,
     primary: '—',
     title: '',
   };
-  if (mode === 'watch' && watch) {
-    if (slug && repoUrl) {
-      target = {
-        href: `${repoUrl}/tree/${encodeURIComponent(watch.branch)}`,
-        primary: slug,
-        secondary: `${watch.branch} → ${watch.base}`,
-        title: 'Open branch on GitHub',
-      };
+  if (isWatch) {
+    if (watch) {
+      if (slug && repoUrl) {
+        target = {
+          href: `${repoUrl}/tree/${watch.branch}`,
+          primary: slug,
+          secondary: `${watch.branch} → ${watch.base}`,
+          title: 'Open branch on GitHub',
+        };
+      } else {
+        target = {
+          href: null,
+          primary: watch.branch,
+          secondary: `→ ${watch.base}`,
+          title: '',
+        };
+      }
     } else {
-      target = {
-        href: null,
-        primary: watch.branch,
-        secondary: `→ ${watch.base}`,
-        title: '',
-      };
+      target = { href: null, primary: '—', title: '' };
     }
   } else if (slug && repoUrl && prNum != null) {
     target = {

--- a/packages/web/src/components/BranchSkeletonView.tsx
+++ b/packages/web/src/components/BranchSkeletonView.tsx
@@ -1,0 +1,113 @@
+import { useReviewStore } from '../state/review-store';
+import type { BranchSkeleton, SkeletonFileCategory } from '../state/types';
+
+const CATEGORY_LABELS: Record<SkeletonFileCategory, string> = {
+  test: 'Tests',
+  config: 'Config',
+  schema: 'Schema',
+  migration: 'Migrations',
+  docs: 'Docs',
+  'public-api': 'Public API',
+  source: 'Source',
+};
+
+const CATEGORY_ORDER: SkeletonFileCategory[] = [
+  'source',
+  'test',
+  'public-api',
+  'schema',
+  'migration',
+  'config',
+  'docs',
+];
+
+export function BranchSkeletonView({ message }: { message: string }) {
+  const watch = useReviewStore((s) => s.watch);
+  if (!watch) return null;
+  const { skeleton } = watch;
+  return (
+    <section className="px-6 py-6 text-[var(--fg-1)]">
+      <header className="mb-4">
+        <p className="text-[13px] uppercase tracking-[0.08em] text-[var(--fg-3)]">Branch skeleton</p>
+        <p className="mt-1 text-[15px] text-[var(--fg-2)]">{message}</p>
+      </header>
+
+      <Totals skeleton={skeleton} />
+      <Categories skeleton={skeleton} />
+      <TouchedDirs skeleton={skeleton} />
+      <Notable skeleton={skeleton} />
+    </section>
+  );
+}
+
+function Totals({ skeleton }: { skeleton: BranchSkeleton }) {
+  const { totals } = skeleton;
+  return (
+    <div className="mb-5 flex flex-wrap items-baseline gap-x-4 gap-y-1 text-[14px]">
+      <span className="font-medium" style={{ color: 'var(--green-11)' }}>+{totals.additions}</span>
+      <span className="font-medium" style={{ color: 'var(--red-11)' }}>−{totals.deletions}</span>
+      <span className="text-[var(--fg-2)]">across {totals.changedFiles} {totals.changedFiles === 1 ? 'file' : 'files'}</span>
+    </div>
+  );
+}
+
+function Categories({ skeleton }: { skeleton: BranchSkeleton }) {
+  const entries = CATEGORY_ORDER
+    .map((c) => ({ category: c, count: skeleton.byCategory[c] ?? 0 }))
+    .filter((e) => e.count > 0);
+  if (entries.length === 0) return null;
+  return (
+    <div className="mb-5">
+      <h3 className="mb-2 text-[12.5px] font-semibold uppercase tracking-[0.06em] text-[var(--fg-3)]">By category</h3>
+      <ul className="flex flex-wrap gap-2">
+        {entries.map(({ category, count }) => (
+          <li
+            key={category}
+            className="rounded-[6px] bg-[var(--gray-2)] px-2.5 py-1 text-[12.5px]"
+            style={{ boxShadow: 'inset 0 0 0 1px var(--gray-a4)' }}
+          >
+            <span className="font-medium text-[var(--fg-1)]">{CATEGORY_LABELS[category]}</span>
+            <span className="ml-1.5 text-[var(--fg-3)]">{count}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function TouchedDirs({ skeleton }: { skeleton: BranchSkeleton }) {
+  if (skeleton.touchedDirs.length === 0) return null;
+  return (
+    <div className="mb-5">
+      <h3 className="mb-2 text-[12.5px] font-semibold uppercase tracking-[0.06em] text-[var(--fg-3)]">Touched directories</h3>
+      <ul className="flex flex-col gap-1">
+        {skeleton.touchedDirs.map(({ dir, count }) => (
+          <li key={dir} className="flex items-center justify-between text-[13px]">
+            <span className="truncate font-mono text-[var(--fg-1)]">{dir || '.'}</span>
+            <span className="ml-3 text-[var(--fg-3)]">{count}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function Notable({ skeleton }: { skeleton: BranchSkeleton }) {
+  if (skeleton.notable.length === 0) return null;
+  return (
+    <div className="mb-2">
+      <h3 className="mb-2 text-[12.5px] font-semibold uppercase tracking-[0.06em] text-[var(--fg-3)]">Notable changes</h3>
+      <ul className="flex flex-col gap-1">
+        {skeleton.notable.map((f) => (
+          <li key={f.path} className="flex items-center justify-between text-[13px]">
+            <span className="truncate font-mono text-[var(--fg-1)]">{f.path}</span>
+            <span className="ml-3 text-[var(--fg-3)]">
+              <span style={{ color: 'var(--green-11)' }}>+{f.additions}</span>{' '}
+              <span style={{ color: 'var(--red-11)' }}>−{f.deletions}</span>
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/packages/web/src/components/BranchSkeletonView.tsx
+++ b/packages/web/src/components/BranchSkeletonView.tsx
@@ -1,5 +1,7 @@
 import { useReviewStore } from '../state/review-store';
 import type { BranchSkeleton, SkeletonFileCategory } from '../state/types';
+import { DadMark } from './DadMark';
+import { getAccentMeta } from '../lib/accents';
 
 const CATEGORY_LABELS: Record<SkeletonFileCategory, string> = {
   test: 'Tests',
@@ -23,13 +25,43 @@ const CATEGORY_ORDER: SkeletonFileCategory[] = [
 
 export function BranchSkeletonView({ message }: { message: string }) {
   const watch = useReviewStore((s) => s.watch);
+  const accent = useReviewStore((s) => s.accent);
   if (!watch) return null;
   const { skeleton } = watch;
+  const { markBg } = getAccentMeta(accent);
   return (
     <section className="px-6 py-6 text-[var(--fg-1)]">
-      <header className="mb-4">
-        <p className="text-[13px] uppercase tracking-[0.08em] text-[var(--fg-3)]">Branch skeleton</p>
-        <p className="mt-1 text-[15px] text-[var(--fg-2)]">{message}</p>
+      <header className="mb-6 flex items-center gap-4">
+        <div style={{ animation: 'generating-bob 2s ease-in-out infinite' }}>
+          <DadMark size={44} bg={markBg} shape="circle" showBadge={false} showWink />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <p className="text-[11.5px] font-semibold uppercase tracking-[0.08em] text-[var(--fg-3)]">
+            Branch skeleton · narrating…
+          </p>
+          <div className="flex items-center gap-2.5">
+            <span className="generating-dots flex gap-1">
+              <span
+                className="h-1.5 w-1.5 rounded-full"
+                style={{ background: 'var(--purple-9)', animation: 'generating-dot 1.4s ease-in-out infinite' }}
+              />
+              <span
+                className="h-1.5 w-1.5 rounded-full"
+                style={{ background: 'var(--purple-9)', animation: 'generating-dot 1.4s ease-in-out 0.2s infinite' }}
+              />
+              <span
+                className="h-1.5 w-1.5 rounded-full"
+                style={{ background: 'var(--purple-9)', animation: 'generating-dot 1.4s ease-in-out 0.4s infinite' }}
+              />
+            </span>
+            <p
+              className="text-[14px] italic text-[var(--fg-2)]"
+              style={{ animation: 'generating-fade 2.5s ease-in-out infinite' }}
+            >
+              {message}
+            </p>
+          </div>
+        </div>
       </header>
 
       <Totals skeleton={skeleton} />

--- a/packages/web/src/components/CommitTimeline.tsx
+++ b/packages/web/src/components/CommitTimeline.tsx
@@ -138,32 +138,18 @@ function CommitRow({
       }
     : { background: 'transparent', color: 'var(--fg-1)' };
 
-  const indicator = commit.hasNarrative ? '✓' : '○';
-  const indicatorColor = selected
-    ? 'var(--brand-11, var(--purple-11))'
-    : commit.hasNarrative
-      ? 'var(--green-11)'
-      : 'var(--fg-3)';
+  const buttonLabel = commit.hasNarrative ? 'View' : 'Narrate';
+  const buttonTitle = commit.hasNarrative
+    ? `View ${commit.shortSha}'s narrative`
+    : `Generate a narrative for ${commit.shortSha} (one model call)`;
 
   return (
     <li>
-      <button
-        type="button"
-        onClick={onSelect}
-        disabled={disabled}
-        className="group flex w-full items-start gap-2 rounded-[6px] px-2 py-1.5 text-left transition-colors hover:bg-[var(--gray-2)] disabled:opacity-60"
+      <div
+        className="group flex w-full items-start gap-2 rounded-[6px] px-2 py-1.5 text-left transition-colors"
         style={rowStyle}
-        title={`${commit.shortSha}  ${commit.subject}\n${commit.author} · ${shortDate(commit.date)}\n+${commit.additions} −${commit.deletions} across ${commit.changedFiles} ${commit.changedFiles === 1 ? 'file' : 'files'}${
-          commit.hasNarrative ? '' : '\n(narration pending — click to generate)'
-        }`}
+        title={`${commit.shortSha}  ${commit.subject}\n${commit.author} · ${shortDate(commit.date)}\n+${commit.additions} −${commit.deletions} across ${commit.changedFiles} ${commit.changedFiles === 1 ? 'file' : 'files'}`}
       >
-        <span
-          aria-hidden
-          className="mt-[1px] w-3 shrink-0 text-center font-mono text-[11px]"
-          style={{ color: indicatorColor }}
-        >
-          {indicator}
-        </span>
         <span className="flex min-w-0 flex-1 flex-col gap-[1px]">
           <span className="truncate text-[13px] font-medium leading-tight">{commit.subject}</span>
           <span className="flex items-center gap-2 text-[11px] text-[var(--fg-3)]">
@@ -175,7 +161,29 @@ function CommitRow({
             </span>
           </span>
         </span>
-      </button>
+        <button
+          type="button"
+          onClick={onSelect}
+          disabled={disabled}
+          title={buttonTitle}
+          className="shrink-0 rounded-[5px] px-2 py-0.5 text-[11px] font-medium transition-colors disabled:opacity-60"
+          style={
+            commit.hasNarrative
+              ? {
+                  background: 'var(--gray-3)',
+                  color: 'var(--fg-2)',
+                  boxShadow: 'inset 0 0 0 1px var(--gray-a5)',
+                }
+              : {
+                  background: 'transparent',
+                  color: 'var(--fg-2)',
+                  boxShadow: 'inset 0 0 0 1px var(--gray-a5)',
+                }
+          }
+        >
+          {buttonLabel}
+        </button>
+      </div>
     </li>
   );
 }

--- a/packages/web/src/components/CommitTimeline.tsx
+++ b/packages/web/src/components/CommitTimeline.tsx
@@ -1,0 +1,146 @@
+import { useState } from 'react';
+import { applyNarrativeResponse, fetchNarrative } from '../hooks/useNarrative';
+import { useReviewStore } from '../state/review-store';
+import type { WatchCommitSummary } from '../state/types';
+
+function shortDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+export function CommitTimeline() {
+  const watch = useReviewStore((s) => s.watch);
+  const setWatchLoading = useReviewStore((s) => s.setWatchLoading);
+  const watchLoading = useReviewStore((s) => s.watchLoading);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!watch) return null;
+
+  const isUnified = watch.selection.kind === 'unified';
+  const selectedSha = watch.selection.kind === 'commit' ? watch.selection.sha : null;
+
+  async function selectCommit(sha: string) {
+    setError(null);
+    setWatchLoading(true);
+    try {
+      const data = await fetchNarrative(`?sha=${encodeURIComponent(sha)}`);
+      applyNarrativeResponse(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load commit');
+    } finally {
+      setWatchLoading(false);
+    }
+  }
+
+  async function selectUnified() {
+    setError(null);
+    setWatchLoading(true);
+    try {
+      // If unified isn't ready yet, ask the server to start generating.
+      if (!watch?.unifiedReady) {
+        await fetch('/api/narrative/unified', { method: 'POST' });
+      }
+      const data = await fetchNarrative('?mode=unified');
+      applyNarrativeResponse(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load unified view');
+    } finally {
+      setWatchLoading(false);
+    }
+  }
+
+  if (watch.commits.length === 0) {
+    return (
+      <section
+        className="sticky z-10 bg-[var(--bg-page)] px-6 py-3"
+        style={{ top: 'calc(52px + 96px)', boxShadow: 'inset 0 -1px 0 var(--gray-a4)' }}
+      >
+        <p className="text-[13px] text-[var(--fg-3)]">No commits ahead of {watch.base} yet — waiting for new commits.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      className="sticky z-10 bg-[var(--bg-page)] px-6 py-3"
+      style={{ top: 'calc(52px + 96px)', boxShadow: 'inset 0 -1px 0 var(--gray-a4)' }}
+    >
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={selectUnified}
+          disabled={watchLoading}
+          className="shrink-0 rounded-[6px] px-2.5 py-1 text-[12.5px] font-medium transition-colors disabled:opacity-60"
+          style={
+            isUnified
+              ? {
+                  background: 'var(--purple-3)',
+                  color: 'var(--purple-11)',
+                  boxShadow: 'inset 0 0 0 1px var(--purple-a5)',
+                }
+              : { background: 'var(--gray-2)', color: 'var(--fg-2)', boxShadow: 'inset 0 0 0 1px var(--gray-a4)' }
+          }
+          title={watch.unifiedReady ? 'Whole-branch story (already generated)' : 'Generate the whole-branch story'}
+        >
+          {watch.unifiedReady ? '◉ Whole branch' : '○ Whole branch'}
+        </button>
+        <div className="flex-1 overflow-x-auto">
+          <ol className="flex items-center gap-2 whitespace-nowrap">
+            {watch.commits.map((c) => (
+              <CommitChip
+                key={c.sha}
+                commit={c}
+                selected={selectedSha === c.sha}
+                onSelect={() => selectCommit(c.sha)}
+                disabled={watchLoading}
+              />
+            ))}
+          </ol>
+        </div>
+      </div>
+      {error ? <p className="mt-2 text-[12px] text-[var(--red-11)]">{error}</p> : null}
+    </section>
+  );
+}
+
+function CommitChip({
+  commit,
+  selected,
+  onSelect,
+  disabled,
+}: {
+  commit: WatchCommitSummary;
+  selected: boolean;
+  onSelect: () => void;
+  disabled: boolean;
+}) {
+  const stateStyle: React.CSSProperties = selected
+    ? {
+        background: 'var(--brand-3, var(--purple-3))',
+        color: 'var(--brand-11, var(--purple-11))',
+        boxShadow: 'inset 0 0 0 1px var(--brand-a6, var(--purple-a6))',
+      }
+    : commit.hasNarrative
+      ? { background: 'var(--gray-2)', color: 'var(--fg-1)', boxShadow: 'inset 0 0 0 1px var(--gray-a5)' }
+      : { background: 'transparent', color: 'var(--fg-3)', boxShadow: 'inset 0 0 0 1px var(--gray-a4)' };
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onSelect}
+        disabled={disabled}
+        className="inline-flex items-center gap-2 rounded-[6px] px-2.5 py-1 text-left text-[12.5px] transition-colors disabled:opacity-60"
+        style={stateStyle}
+        title={`${commit.shortSha}  ${commit.subject}\n${commit.author} · ${shortDate(commit.date)}\n+${commit.additions} −${commit.deletions} across ${commit.changedFiles} ${commit.changedFiles === 1 ? 'file' : 'files'}${
+          commit.hasNarrative ? '' : '\n(narration pending)'
+        }`}
+      >
+        <span className="font-mono text-[11.5px] opacity-80">{commit.shortSha}</span>
+        <span className="max-w-[200px] truncate font-medium">{commit.subject}</span>
+        {!commit.hasNarrative ? <span className="text-[11px] opacity-70">…</span> : null}
+      </button>
+    </li>
+  );
+}

--- a/packages/web/src/components/CommitTimeline.tsx
+++ b/packages/web/src/components/CommitTimeline.tsx
@@ -24,6 +24,16 @@ export function CommitTimeline() {
     setError(null);
     setWatchLoading(true);
     try {
+      // Kick generation if this commit hasn't been narrated yet. Server is
+      // idempotent — already-narrating SHAs early-return.
+      const target = watch?.commits.find((c) => c.sha === sha);
+      if (target && !target.hasNarrative) {
+        await fetch('/api/narrative/commit', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sha }),
+        });
+      }
       const data = await fetchNarrative(`?sha=${encodeURIComponent(sha)}`);
       applyNarrativeResponse(data);
     } catch (err) {

--- a/packages/web/src/components/CommitTimeline.tsx
+++ b/packages/web/src/components/CommitTimeline.tsx
@@ -47,7 +47,6 @@ export function CommitTimeline() {
     setError(null);
     setWatchLoading(true);
     try {
-      // If unified isn't ready yet, ask the server to start generating.
       if (!watch?.unifiedReady) {
         await fetch('/api/narrative/unified', { method: 'POST' });
       }
@@ -60,61 +59,67 @@ export function CommitTimeline() {
     }
   }
 
-  if (watch.commits.length === 0) {
-    return (
-      <section
-        className="sticky z-10 bg-[var(--bg-page)] px-6 py-3"
-        style={{ top: 'calc(52px + 96px)', boxShadow: 'inset 0 -1px 0 var(--gray-a4)' }}
-      >
-        <p className="text-[13px] text-[var(--fg-3)]">No commits ahead of {watch.base} yet — waiting for new commits.</p>
-      </section>
-    );
-  }
-
   return (
-    <section
-      className="sticky z-10 bg-[var(--bg-page)] px-6 py-3"
-      style={{ top: 'calc(52px + 96px)', boxShadow: 'inset 0 -1px 0 var(--gray-a4)' }}
+    <nav
+      aria-label="Branch timeline"
+      className="flex h-full flex-col gap-3 px-4 py-4 text-[13px]"
     >
-      <div className="flex items-center gap-3">
-        <button
-          type="button"
-          onClick={selectUnified}
-          disabled={watchLoading}
-          className="shrink-0 rounded-[6px] px-2.5 py-1 text-[12.5px] font-medium transition-colors disabled:opacity-60"
-          style={
-            isUnified
-              ? {
-                  background: 'var(--purple-3)',
-                  color: 'var(--purple-11)',
-                  boxShadow: 'inset 0 0 0 1px var(--purple-a5)',
-                }
-              : { background: 'var(--gray-2)', color: 'var(--fg-2)', boxShadow: 'inset 0 0 0 1px var(--gray-a4)' }
-          }
-          title={watch.unifiedReady ? 'Whole-branch story (already generated)' : 'Generate the whole-branch story'}
-        >
-          {watch.unifiedReady ? '◉ Whole branch' : '○ Whole branch'}
-        </button>
-        <div className="flex-1 overflow-x-auto">
-          <ol className="flex items-center gap-2 whitespace-nowrap">
-            {watch.commits.map((c) => (
-              <CommitChip
-                key={c.sha}
-                commit={c}
-                selected={selectedSha === c.sha}
-                onSelect={() => selectCommit(c.sha)}
-                disabled={watchLoading}
-              />
-            ))}
-          </ol>
-        </div>
+      <button
+        type="button"
+        onClick={selectUnified}
+        disabled={watchLoading}
+        className="rounded-[8px] px-3 py-2 text-left text-[13px] font-medium transition-colors disabled:opacity-60"
+        style={
+          isUnified
+            ? {
+                background: 'var(--purple-3)',
+                color: 'var(--purple-11)',
+                boxShadow: 'inset 0 0 0 1px var(--purple-a5)',
+              }
+            : {
+                background: 'var(--gray-2)',
+                color: 'var(--fg-2)',
+                boxShadow: 'inset 0 0 0 1px var(--gray-a4)',
+              }
+        }
+        title={watch.unifiedReady ? 'Whole-branch story (already generated)' : 'Generate the whole-branch story'}
+      >
+        <span className="mr-1.5">{watch.unifiedReady ? '◉' : '○'}</span>
+        Whole branch
+        <span className="ml-2 text-[11px] font-normal opacity-70">
+          {watch.commits.length} {watch.commits.length === 1 ? 'commit' : 'commits'}
+        </span>
+      </button>
+
+      <div
+        className="text-[10.5px] font-semibold uppercase tracking-[0.08em] text-[var(--fg-3)]"
+        style={{ paddingLeft: '4px' }}
+      >
+        Commits
       </div>
-      {error ? <p className="mt-2 text-[12px] text-[var(--red-11)]">{error}</p> : null}
-    </section>
+
+      {watch.commits.length === 0 ? (
+        <p className="px-1 text-[12px] text-[var(--fg-3)]">No commits ahead of {watch.base}.</p>
+      ) : (
+        <ol className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto">
+          {[...watch.commits].reverse().map((c) => (
+            <CommitRow
+              key={c.sha}
+              commit={c}
+              selected={selectedSha === c.sha}
+              onSelect={() => selectCommit(c.sha)}
+              disabled={watchLoading}
+            />
+          ))}
+        </ol>
+      )}
+
+      {error ? <p className="px-1 text-[12px] text-[var(--red-11)]">{error}</p> : null}
+    </nav>
   );
 }
 
-function CommitChip({
+function CommitRow({
   commit,
   selected,
   onSelect,
@@ -125,15 +130,20 @@ function CommitChip({
   onSelect: () => void;
   disabled: boolean;
 }) {
-  const stateStyle: React.CSSProperties = selected
+  const rowStyle: React.CSSProperties = selected
     ? {
         background: 'var(--brand-3, var(--purple-3))',
         color: 'var(--brand-11, var(--purple-11))',
         boxShadow: 'inset 0 0 0 1px var(--brand-a6, var(--purple-a6))',
       }
+    : { background: 'transparent', color: 'var(--fg-1)' };
+
+  const indicator = commit.hasNarrative ? '✓' : '○';
+  const indicatorColor = selected
+    ? 'var(--brand-11, var(--purple-11))'
     : commit.hasNarrative
-      ? { background: 'var(--gray-2)', color: 'var(--fg-1)', boxShadow: 'inset 0 0 0 1px var(--gray-a5)' }
-      : { background: 'transparent', color: 'var(--fg-3)', boxShadow: 'inset 0 0 0 1px var(--gray-a4)' };
+      ? 'var(--green-11)'
+      : 'var(--fg-3)';
 
   return (
     <li>
@@ -141,15 +151,30 @@ function CommitChip({
         type="button"
         onClick={onSelect}
         disabled={disabled}
-        className="inline-flex items-center gap-2 rounded-[6px] px-2.5 py-1 text-left text-[12.5px] transition-colors disabled:opacity-60"
-        style={stateStyle}
+        className="group flex w-full items-start gap-2 rounded-[6px] px-2 py-1.5 text-left transition-colors hover:bg-[var(--gray-2)] disabled:opacity-60"
+        style={rowStyle}
         title={`${commit.shortSha}  ${commit.subject}\n${commit.author} · ${shortDate(commit.date)}\n+${commit.additions} −${commit.deletions} across ${commit.changedFiles} ${commit.changedFiles === 1 ? 'file' : 'files'}${
-          commit.hasNarrative ? '' : '\n(narration pending)'
+          commit.hasNarrative ? '' : '\n(narration pending — click to generate)'
         }`}
       >
-        <span className="font-mono text-[11.5px] opacity-80">{commit.shortSha}</span>
-        <span className="max-w-[200px] truncate font-medium">{commit.subject}</span>
-        {!commit.hasNarrative ? <span className="text-[11px] opacity-70">…</span> : null}
+        <span
+          aria-hidden
+          className="mt-[1px] w-3 shrink-0 text-center font-mono text-[11px]"
+          style={{ color: indicatorColor }}
+        >
+          {indicator}
+        </span>
+        <span className="flex min-w-0 flex-1 flex-col gap-[1px]">
+          <span className="truncate text-[13px] font-medium leading-tight">{commit.subject}</span>
+          <span className="flex items-center gap-2 text-[11px] text-[var(--fg-3)]">
+            <span className="font-mono">{commit.shortSha}</span>
+            <span aria-hidden>·</span>
+            <span>
+              <span style={{ color: 'var(--green-11)' }}>+{commit.additions}</span>{' '}
+              <span style={{ color: 'var(--red-11)' }}>−{commit.deletions}</span>
+            </span>
+          </span>
+        </span>
       </button>
     </li>
   );

--- a/packages/web/src/components/GeneratingScreen.tsx
+++ b/packages/web/src/components/GeneratingScreen.tsx
@@ -5,6 +5,8 @@ import { getAccentMeta } from '../lib/accents';
 
 type Props = {
   message: string;
+  compact?: boolean;
+  subtitle?: string;
 };
 
 function formatElapsed(ms: number): string {
@@ -13,10 +15,11 @@ function formatElapsed(ms: number): string {
   return m > 0 ? `${m}m ${String(s % 60).padStart(2, '0')}s` : `${s}s`;
 }
 
-export function GeneratingScreen({ message }: Props) {
+export function GeneratingScreen({ message, compact = false, subtitle }: Props) {
   const pr = useReviewStore((s) => s.pr);
   const files = useReviewStore((s) => s.files);
   const accent = useReviewStore((s) => s.accent);
+  const mode = useReviewStore((s) => s.mode);
   const progressChars = useReviewStore((s) => s.narrativeProgressChars);
   const { markBg } = getAccentMeta(accent);
 
@@ -27,14 +30,19 @@ export function GeneratingScreen({ message }: Props) {
     return () => clearInterval(id);
   }, []);
 
+  const wrapperClass = compact
+    ? 'flex flex-col items-center justify-center px-6 py-16'
+    : 'flex min-h-screen flex-col items-center justify-center bg-[var(--bg-page)] px-6';
+  const markSize = compact ? 48 : 64;
+
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-[var(--bg-page)] px-6">
+    <main className={wrapperClass}>
       <div className="flex flex-col items-center gap-6 text-center">
         <div style={{ animation: 'generating-bob 2s ease-in-out infinite' }}>
-          <DadMark size={64} bg={markBg} shape="circle" showBadge={false} showWink />
+          <DadMark size={markSize} bg={markBg} shape="circle" showBadge={false} showWink />
         </div>
 
-        {pr && (
+        {!compact && pr && mode === 'pr' && (
           <div className="space-y-1">
             <h1 className="m-0 text-[22px] font-bold tracking-tight text-[var(--fg-1)]">
               <span className="font-normal text-[var(--fg-3)]">#{pr.number}</span> {pr.title}
@@ -49,6 +57,8 @@ export function GeneratingScreen({ message }: Props) {
             </div>
           </div>
         )}
+
+        {subtitle ? <p className="text-[13px] text-[var(--fg-3)]">{subtitle}</p> : null}
 
         <div className="flex items-center gap-3">
           <div className="generating-dots flex gap-1">

--- a/packages/web/src/components/Hunk.tsx
+++ b/packages/web/src/components/Hunk.tsx
@@ -270,6 +270,7 @@ function HunkLines({
   openLine,
   setOpenLine,
   clusterBots,
+  commentsEnabled,
 }: {
   file: string;
   hunk: DiffHunk;
@@ -280,6 +281,7 @@ function HunkLines({
   openLine: string | null;
   setOpenLine: (key: string | null) => void;
   clusterBots: boolean;
+  commentsEnabled: boolean;
 }) {
   const normFile = normalizePath(file);
 
@@ -346,7 +348,7 @@ function HunkLines({
       return (
         <div key={lineKey}>
           <CodeLine line={line} lineKey={lineKey} lang={lang} dimmed={dimmed} />
-          {hasThread && (
+          {hasThread && commentsEnabled && (
             <div className="sticky left-0" style={{ width: '100cqw' }}>
               <CollapsibleThread
                 comments={lineComments}
@@ -388,6 +390,8 @@ export function Hunk({ file, hunk, isNewFile, hunkIndex, highlight }: Props) {
   const comments = useReviewStore((s) => s.comments);
   const setOpenLine = useReviewStore((s) => s.setOpenLine);
   const repoUrl = useReviewStore((s) => s.repoUrl);
+  const mode = useReviewStore((s) => s.mode);
+  const commentsEnabled = mode !== 'watch';
   const headSha = useReviewStore((s) => s.pr?.headSha ?? null);
   const clusterBots = useReviewStore((s) => s.clusterBots);
   const lang = guessLang(file);
@@ -486,6 +490,7 @@ export function Hunk({ file, hunk, isNewFile, hunkIndex, highlight }: Props) {
           openLine={openLine}
           setOpenLine={setOpenLine}
           clusterBots={clusterBots}
+          commentsEnabled={commentsEnabled}
         />
       </div>
     </div>

--- a/packages/web/src/components/NarrationAnchor.tsx
+++ b/packages/web/src/components/NarrationAnchor.tsx
@@ -47,6 +47,7 @@ export function NarrationAnchor({ chapterIndex }: Props) {
   const setChapterDensity = useReviewStore((s) => s.setChapterDensity);
   const activeDensity = chapterDensityMap[chapterKey] ?? globalDensity;
 
+  const mode = useReviewStore((s) => s.mode);
   const narrationOverrides = useReviewStore((s) => s.narrationOverrides);
   const setNarrationOverride = useReviewStore((s) => (s as any).setNarrationOverride) as (
     key: string,
@@ -263,15 +264,17 @@ export function NarrationAnchor({ chapterIndex }: Props) {
           Ask AI
         </button>
 
-        <button
-          type="button"
-          onClick={() => setCommentOpen((v) => !v)}
-          className="inline-flex items-center gap-1 rounded-[4px] px-1.5 py-[3px] text-[12px] font-medium hover:bg-[var(--gray-a3)] hover:text-[var(--fg-2)]"
-          style={commentOpen ? { background: 'var(--gray-a3)', color: 'var(--fg-1)' } : { color: 'var(--fg-3)' }}
-        >
-          <IconChat className="h-[11px] w-[11px]" />
-          Comment on chapter
-        </button>
+        {mode !== 'watch' ? (
+          <button
+            type="button"
+            onClick={() => setCommentOpen((v) => !v)}
+            className="inline-flex items-center gap-1 rounded-[4px] px-1.5 py-[3px] text-[12px] font-medium hover:bg-[var(--gray-a3)] hover:text-[var(--fg-2)]"
+            style={commentOpen ? { background: 'var(--gray-a3)', color: 'var(--fg-1)' } : { color: 'var(--fg-3)' }}
+          >
+            <IconChat className="h-[11px] w-[11px]" />
+            Comment on chapter
+          </button>
+        ) : null}
       </div>
 
       {askOpen && (

--- a/packages/web/src/components/WatchHeader.tsx
+++ b/packages/web/src/components/WatchHeader.tsx
@@ -1,0 +1,121 @@
+import { useReviewStore } from '../state/review-store';
+
+function timeAgo(iso: string | undefined | null): string {
+  if (!iso) return '';
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '';
+  const diff = Math.max(0, Date.now() - then);
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 30) return `${day}d ago`;
+  const mo = Math.floor(day / 30);
+  return `${mo}mo ago`;
+}
+
+export function WatchHeader() {
+  const watch = useReviewStore((s) => s.watch);
+  const pr = useReviewStore((s) => s.pr);
+  const view = useReviewStore((s) => s.view);
+  const setView = useReviewStore((s) => s.setView);
+
+  if (!watch || !pr) return null;
+
+  const baseBtn =
+    'h-[26px] inline-flex items-center gap-1 px-2.5 text-[12.5px] font-medium rounded-[5px] transition-colors';
+  const activeBtn = 'bg-[var(--bg-panel)] text-[var(--fg-1)]';
+  const activeBtnStyle: React.CSSProperties = {
+    boxShadow: '0 1px 2px rgba(3,2,13,0.06), inset 0 0 0 1px var(--gray-a5)',
+  };
+  const inactiveBtn = 'bg-transparent text-[var(--fg-2)] hover:text-[var(--fg-1)]';
+
+  const isUnified = watch.selection.kind === 'unified';
+  const isPending = watch.selection.kind === 'pending';
+  const headTitle = isUnified
+    ? `${watch.branch} → ${watch.base}`
+    : isPending
+      ? watch.branch
+      : pr.title;
+
+  return (
+    <section
+      className="sticky top-[52px] z-20 bg-[var(--bg-panel)] px-6 pt-[18px] pb-3.5"
+      style={{ boxShadow: 'inset 0 -1px 0 var(--gray-a4)' }}
+    >
+      <div className="flex items-start gap-3">
+        <h1 className="m-0 flex-1 text-[22px] font-bold leading-[27px] tracking-[-0.0125em] text-[var(--fg-1)]">
+          <span className="mr-2 font-normal text-[var(--fg-3)]">watch</span>
+          {headTitle}
+        </h1>
+        <div className="flex shrink-0 items-center gap-2">
+          <div
+            role="tablist"
+            aria-label="View mode"
+            className="inline-flex items-center rounded-[7px] bg-[var(--gray-2)] p-[2px]"
+            style={{ boxShadow: 'inset 0 0 0 1px var(--gray-a4)' }}
+          >
+            <button
+              type="button"
+              role="tab"
+              aria-selected={view === 'story'}
+              onClick={() => setView('story')}
+              className={`${baseBtn} ${view === 'story' ? activeBtn : inactiveBtn}`}
+              style={view === 'story' ? activeBtnStyle : undefined}
+            >
+              Story
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={view === 'files'}
+              onClick={() => setView('files')}
+              className={`${baseBtn} ${view === 'files' ? activeBtn : inactiveBtn}`}
+              style={view === 'files' ? activeBtnStyle : undefined}
+            >
+              Files
+            </button>
+          </div>
+        </div>
+      </div>
+      <div className="mt-2.5 flex flex-wrap items-center gap-x-3 gap-y-2 text-[13px] text-[var(--fg-2)]">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-2 py-[2px] text-[11.5px] font-bold uppercase tracking-[0.04em]"
+          style={{ background: 'var(--purple-3)', color: 'var(--purple-11)' }}
+        >
+          Watching
+        </span>
+        <span className="rounded-[4px] bg-[var(--gray-3)] px-[7px] py-[2px] font-mono text-[12.5px] text-[var(--fg-2)]">
+          <b className="font-medium text-[var(--fg-1)]">{watch.branch}</b>{' '}
+          <span className="text-[var(--fg-3)]">→</span>{' '}
+          <b className="font-medium text-[var(--fg-1)]">{watch.base}</b>
+        </span>
+        <span className="text-[var(--fg-2)]">
+          {watch.commits.length} {watch.commits.length === 1 ? 'commit' : 'commits'} ahead
+        </span>
+        {!isUnified && pr.headSha ? (
+          <>
+            <span className="text-[var(--fg-3)]">·</span>
+            <span className="font-mono text-[12.5px] text-[var(--fg-2)]">{pr.headSha.slice(0, 7)}</span>
+            <span className="text-[var(--fg-2)]">{timeAgo(pr.createdAt)}</span>
+          </>
+        ) : null}
+        <span className="text-[var(--fg-3)]">·</span>
+        <span>
+          <span className="font-medium" style={{ color: 'var(--green-11)' }}>
+            +{pr.additions}
+          </span>{' '}
+          <span className="font-medium" style={{ color: 'var(--red-11)' }}>
+            −{pr.deletions}
+          </span>{' '}
+          <span className="text-[var(--fg-2)]">
+            across {pr.changedFiles} {pr.changedFiles === 1 ? 'file' : 'files'}
+          </span>
+        </span>
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/web/src/hooks/useKeyboardShortcuts.ts
@@ -30,6 +30,7 @@ export function useKeyboardShortcuts() {
   const shortcutsHelpOpen = useReviewStore((s) => s.shortcutsHelpOpen);
   const setShortcutsHelpOpen = useReviewStore((s) => s.setShortcutsHelpOpen);
   const openLine = useReviewStore((s) => s.openLine);
+  const mode = useReviewStore((s) => s.mode);
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -89,6 +90,9 @@ export function useKeyboardShortcuts() {
       }
 
       if (key === 'c') {
+        // Comment affordance is PR-mode only — watch-mode commenting is part
+        // of the deferred feedback loop and has no destination yet.
+        if (mode === 'watch') return;
         e.preventDefault();
         const chapter = narrative.chapters[idx];
         if (!chapter) return;
@@ -122,5 +126,6 @@ export function useKeyboardShortcuts() {
     shortcutsHelpOpen,
     setShortcutsHelpOpen,
     openLine,
+    mode,
   ]);
 }

--- a/packages/web/src/hooks/useLiveStream.ts
+++ b/packages/web/src/hooks/useLiveStream.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { applyNarrativeResponse, fetchNarrative } from './useNarrative';
 import { useReviewStore } from '../state/review-store';
 import type {
   CheckRun,
@@ -9,6 +10,7 @@ import type {
   PRComment,
   PRData,
   PRReview,
+  WatchCommitSummary,
 } from '../state/types';
 
 function makeEventId(): string {
@@ -147,6 +149,76 @@ export function useLiveStream() {
       }
     };
 
+    const onWatchUpdate = (e: MessageEvent) => {
+      try {
+        const data = JSON.parse(e.data) as {
+          branch: string;
+          base: string;
+          baseSha: string;
+          headSha: string;
+          commits: WatchCommitSummary[];
+        };
+        const store = useReviewStore.getState();
+        if (store.watch) {
+          store.setWatch({ ...store.watch, ...data });
+        }
+        setLastEventAt(Date.now());
+        addLiveEvent(makeEvent('commit', `${data.commits.length} commits ahead of ${data.base}`));
+      } catch {
+        // ignore
+      }
+    };
+
+    const onCommitNarrating = (e: MessageEvent) => {
+      try {
+        const { sha } = JSON.parse(e.data) as { sha: string };
+        addLiveEvent(makeEvent('system', `Narrating ${sha.slice(0, 7)}…`));
+      } catch {
+        // ignore
+      }
+    };
+
+    const onCommitNarrative = async (e: MessageEvent) => {
+      try {
+        const { sha } = JSON.parse(e.data) as { sha: string };
+        const store = useReviewStore.getState();
+        if (store.watch) {
+          const updated = store.watch.commits.map((c) =>
+            c.sha === sha ? { ...c, hasNarrative: true } : c,
+          );
+          store.setWatch({ ...store.watch, commits: updated });
+        }
+        // If the user is currently looking at this commit, refresh the narrative.
+        if (store.watch?.selection.kind === 'commit' && store.watch.selection.sha === sha) {
+          const data = await fetchNarrative(`?sha=${encodeURIComponent(sha)}`);
+          applyNarrativeResponse(data);
+        }
+        setLastEventAt(Date.now());
+        addLiveEvent(makeEvent('system', `Narrative ready for ${sha.slice(0, 7)}`));
+      } catch {
+        // ignore
+      }
+    };
+
+    const onUnifiedNarrative = async () => {
+      try {
+        const store = useReviewStore.getState();
+        if (store.watch) store.setWatch({ ...store.watch, unifiedReady: true });
+        if (store.watch?.selection.kind === 'unified') {
+          const data = await fetchNarrative('?mode=unified');
+          applyNarrativeResponse(data);
+        }
+        addLiveEvent(makeEvent('system', 'Whole-branch narrative ready'));
+        setLastEventAt(Date.now());
+      } catch {
+        // ignore
+      }
+    };
+
+    const onUnifiedNarrating = () => {
+      addLiveEvent(makeEvent('system', 'Generating whole-branch narrative…'));
+    };
+
     es.addEventListener('connected', onConnected);
     es.addEventListener('comment', onComment as EventListener);
     es.addEventListener('comments', onComments as EventListener);
@@ -156,6 +228,11 @@ export function useLiveStream() {
     es.addEventListener('regenerating', onRegenerating as EventListener);
     es.addEventListener('narrative-progress', onNarrativeProgress as EventListener);
     es.addEventListener('narrative', onNarrative as EventListener);
+    es.addEventListener('watch-update', onWatchUpdate as EventListener);
+    es.addEventListener('commit-narrating', onCommitNarrating as EventListener);
+    es.addEventListener('commit-narrative', onCommitNarrative as EventListener);
+    es.addEventListener('unified-narrative', onUnifiedNarrative as EventListener);
+    es.addEventListener('unified-narrating', onUnifiedNarrating as EventListener);
 
     es.onopen = () => {
       setLiveStatus('connected');
@@ -175,6 +252,11 @@ export function useLiveStream() {
       es.removeEventListener('regenerating', onRegenerating as EventListener);
       es.removeEventListener('narrative-progress', onNarrativeProgress as EventListener);
       es.removeEventListener('narrative', onNarrative as EventListener);
+      es.removeEventListener('watch-update', onWatchUpdate as EventListener);
+      es.removeEventListener('commit-narrating', onCommitNarrating as EventListener);
+      es.removeEventListener('commit-narrative', onCommitNarrative as EventListener);
+      es.removeEventListener('unified-narrative', onUnifiedNarrative as EventListener);
+      es.removeEventListener('unified-narrating', onUnifiedNarrating as EventListener);
       es.close();
     };
   }, []);

--- a/packages/web/src/hooks/useLiveStream.ts
+++ b/packages/web/src/hooks/useLiveStream.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { applyNarrativeResponse, fetchNarrative } from './useNarrative';
 import { useReviewStore } from '../state/review-store';
 import type {
+  Addendum,
   CheckRun,
   DiffFile,
   LiveEvent,
@@ -158,6 +159,8 @@ export function useLiveStream() {
           headSha: string;
           commits: WatchCommitSummary[];
           unifiedReady: boolean;
+          unifiedHeadSha: string | null;
+          addendums: Addendum[];
         };
         const store = useReviewStore.getState();
         if (store.watch) {
@@ -184,10 +187,31 @@ export function useLiveStream() {
         const { sha } = JSON.parse(e.data) as { sha: string };
         const store = useReviewStore.getState();
         if (store.watch) {
-          const updated = store.watch.commits.map((c) =>
+          const updatedCommits = store.watch.commits.map((c) =>
             c.sha === sha ? { ...c, hasNarrative: true } : c,
           );
-          store.setWatch({ ...store.watch, commits: updated });
+          // If this commit is in the addendum chain, fetch its narrative and
+          // patch the matching addendum entry inline. Avoids a full /api/narrative
+          // refetch and lets the addendum card swap from "Narrating…" to content.
+          const isAddendum = store.watch.addendums.some((a) => a.sha === sha);
+          let updatedAddendums = store.watch.addendums;
+          if (isAddendum) {
+            try {
+              const data = await fetchNarrative(`?sha=${encodeURIComponent(sha)}`);
+              if (data.narrative) {
+                updatedAddendums = store.watch.addendums.map((a) =>
+                  a.sha === sha ? { ...a, narrative: data.narrative! } : a,
+                );
+              }
+            } catch {
+              // leave as null; the user can refresh
+            }
+          }
+          store.setWatch({
+            ...store.watch,
+            commits: updatedCommits,
+            addendums: updatedAddendums,
+          });
         }
         // If the user is currently looking at this commit, refresh the narrative.
         if (store.watch?.selection.kind === 'commit' && store.watch.selection.sha === sha) {

--- a/packages/web/src/hooks/useLiveStream.ts
+++ b/packages/web/src/hooks/useLiveStream.ts
@@ -157,6 +157,7 @@ export function useLiveStream() {
           baseSha: string;
           headSha: string;
           commits: WatchCommitSummary[];
+          unifiedReady: boolean;
         };
         const store = useReviewStore.getState();
         if (store.watch) {
@@ -216,6 +217,8 @@ export function useLiveStream() {
     };
 
     const onUnifiedNarrating = () => {
+      const store = useReviewStore.getState();
+      if (store.watch) store.setWatch({ ...store.watch, unifiedReady: false });
       addLiveEvent(makeEvent('system', 'Generating whole-branch narrative…'));
     };
 

--- a/packages/web/src/hooks/useNarrative.ts
+++ b/packages/web/src/hooks/useNarrative.ts
@@ -41,6 +41,7 @@ export function applyNarrativeResponse(data: NarrativeApiResponse) {
   if (data.generating && !data.narrative) {
     useReviewStore.setState({
       pr: data.pr,
+      narrative: null,
       files: data.files,
       comments: data.comments,
       checkRuns: data.checkRuns ?? [],

--- a/packages/web/src/hooks/useNarrative.ts
+++ b/packages/web/src/hooks/useNarrative.ts
@@ -1,8 +1,18 @@
 import { useEffect, useState } from 'react';
 import { useReviewStore, type BackendConfig } from '../state/review-store';
-import type { CheckRun, DiffFile, NarrativeResponse, PRComment, PRData, PRReview } from '../state/types';
+import type {
+  AppMode,
+  CheckRun,
+  DiffFile,
+  NarrativeResponse,
+  PRComment,
+  PRData,
+  PRReview,
+  WatchData,
+} from '../state/types';
 
 type NarrativeApiResponse = {
+  mode?: AppMode;
   generating?: boolean;
   pr: PRData;
   narrative?: NarrativeResponse;
@@ -12,10 +22,61 @@ type NarrativeApiResponse = {
   reviews?: PRReview[];
   repoUrl?: string;
   config?: BackendConfig;
+  watch?: WatchData;
 };
 
+export async function fetchNarrative(query: string = ''): Promise<NarrativeApiResponse> {
+  const res = await fetch(`/api/narrative${query}`);
+  if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+  return (await res.json()) as NarrativeApiResponse;
+}
+
+export function applyNarrativeResponse(data: NarrativeApiResponse) {
+  const store = useReviewStore.getState();
+  const mode: AppMode = data.mode === 'watch' ? 'watch' : 'pr';
+  store.setMode(mode);
+  if (data.watch) store.setWatch(data.watch);
+  else if (mode === 'pr') store.setWatch(null);
+
+  if (data.generating && !data.narrative) {
+    useReviewStore.setState({
+      pr: data.pr,
+      files: data.files,
+      comments: data.comments,
+      checkRuns: data.checkRuns ?? [],
+      reviews: data.reviews ?? [],
+      repoUrl: data.repoUrl ?? null,
+    });
+    if (data.config) {
+      const next: Partial<ReturnType<typeof useReviewStore.getState>> = {};
+      if (data.config.theme && !localStorage.getItem('diffdad.theme'))
+        next.theme = data.config.theme as 'light' | 'dark' | 'auto';
+      if (data.config.accent && !localStorage.getItem('diffdad.accent')) next.accent = data.config.accent as any;
+      if (data.config.storyStructure) next.storyStructure = data.config.storyStructure as any;
+      if (data.config.layoutMode) next.layoutMode = data.config.layoutMode as any;
+      if (data.config.displayDensity) next.displayDensity = data.config.displayDensity as any;
+      useReviewStore.setState(next);
+    }
+    return { generating: true };
+  }
+
+  if (data.narrative) {
+    store.setData(
+      data.pr,
+      data.narrative,
+      data.files,
+      data.comments,
+      data.repoUrl ?? null,
+      data.checkRuns ?? [],
+      data.config ?? null,
+      data.reviews ?? [],
+    );
+    return { generating: false };
+  }
+  return { generating: false };
+}
+
 export function useNarrative() {
-  const setData = useReviewStore((s) => s.setData);
   const [loading, setLoading] = useState(true);
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -27,46 +88,10 @@ export function useNarrative() {
       try {
         setLoading(true);
         setError(null);
-        const res = await fetch('/api/narrative');
-        if (!res.ok) {
-          throw new Error(`Request failed: ${res.status}`);
-        }
-        const data = (await res.json()) as NarrativeApiResponse;
+        const data = await fetchNarrative();
         if (cancelled) return;
-
-        if (data.generating && !data.narrative) {
-          setGenerating(true);
-          useReviewStore.setState({
-            pr: data.pr,
-            files: data.files,
-            comments: data.comments,
-            checkRuns: data.checkRuns ?? [],
-            reviews: data.reviews ?? [],
-            repoUrl: data.repoUrl ?? null,
-          });
-          if (data.config) {
-            const next: Partial<typeof useReviewStore extends { getState: () => infer S } ? S : never> = {};
-            if (data.config.theme && !localStorage.getItem('diffdad.theme'))
-              next.theme = data.config.theme as 'light' | 'dark' | 'auto';
-            if (data.config.accent && !localStorage.getItem('diffdad.accent')) next.accent = data.config.accent as any;
-            if (data.config.storyStructure) next.storyStructure = data.config.storyStructure as any;
-            if (data.config.layoutMode) next.layoutMode = data.config.layoutMode as any;
-            if (data.config.displayDensity) next.displayDensity = data.config.displayDensity as any;
-            useReviewStore.setState(next);
-          }
-        } else if (data.narrative) {
-          setGenerating(false);
-          setData(
-            data.pr,
-            data.narrative,
-            data.files,
-            data.comments,
-            data.repoUrl ?? null,
-            data.checkRuns ?? [],
-            data.config ?? null,
-            data.reviews ?? [],
-          );
-        }
+        const result = applyNarrativeResponse(data);
+        setGenerating(result.generating);
       } catch (err) {
         if (cancelled) return;
         setError(err instanceof Error ? err.message : 'Unknown error');
@@ -80,7 +105,7 @@ export function useNarrative() {
     return () => {
       cancelled = true;
     };
-  }, [setData]);
+  }, []);
 
   return { loading, generating, setGenerating, error };
 }

--- a/packages/web/src/state/review-store.ts
+++ b/packages/web/src/state/review-store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import type {
+  AppMode,
   ChapterState,
   CheckRun,
   DiffFile,
@@ -10,6 +11,7 @@ import type {
   PRComment,
   PRData,
   PRReview,
+  WatchData,
 } from './types';
 import type { AccentId } from '../lib/accents';
 
@@ -60,6 +62,9 @@ type ReviewState = {
   clusterBots: boolean;
   regenerating: boolean;
   narrativeProgressChars: number;
+  mode: AppMode;
+  watch: WatchData | null;
+  watchLoading: boolean;
 
   setData: (
     pr: PRData,
@@ -99,6 +104,10 @@ type ReviewState = {
   setRegenerating: (v: boolean) => void;
   setNarrativeProgressChars: (chars: number) => void;
   setPr: (pr: PRData) => void;
+  setMode: (mode: AppMode) => void;
+  setWatch: (watch: WatchData | null) => void;
+  setWatchLoading: (loading: boolean) => void;
+  patchWatch: (patch: Partial<WatchData>) => void;
 };
 
 function draftStorageKey(prNumber: number): string {
@@ -168,6 +177,9 @@ export const useReviewStore = create<ReviewState>((set) => ({
   clusterBots: true,
   regenerating: false,
   narrativeProgressChars: 0,
+  mode: 'pr',
+  watch: null,
+  watchLoading: false,
   narrationOverrides: {} as Record<string, string>,
 
   setData: (pr, narrative, files, comments, repoUrl = null, checkRuns = [], config = null, reviews = []) => {
@@ -299,6 +311,11 @@ export const useReviewStore = create<ReviewState>((set) => ({
   setRegenerating: (regenerating) => set({ regenerating }),
   setNarrativeProgressChars: (narrativeProgressChars) => set({ narrativeProgressChars }),
   setPr: (pr) => set({ pr }),
+  setMode: (mode) => set({ mode }),
+  setWatch: (watch) => set({ watch }),
+  setWatchLoading: (watchLoading) => set({ watchLoading }),
+  patchWatch: (patch) =>
+    set((state) => (state.watch ? { watch: { ...state.watch, ...patch } } : state)),
   setNarrationOverride: (chapterKey: string, text: string) =>
     set((s) => ({ narrationOverrides: { ...s.narrationOverrides, [chapterKey]: text } })),
   clearNarrationOverride: (chapterKey: string) =>

--- a/packages/web/src/state/types.ts
+++ b/packages/web/src/state/types.ts
@@ -121,6 +121,32 @@ export type WatchSelection =
   | { kind: 'unified' }
   | { kind: 'pending' };
 
+export type SkeletonFileCategory =
+  | 'test'
+  | 'config'
+  | 'schema'
+  | 'migration'
+  | 'docs'
+  | 'public-api'
+  | 'source';
+
+export type SkeletonFile = {
+  path: string;
+  category: SkeletonFileCategory;
+  additions: number;
+  deletions: number;
+  isNewFile: boolean;
+  isDeleted: boolean;
+};
+
+export type BranchSkeleton = {
+  totals: { additions: number; deletions: number; changedFiles: number };
+  byCategory: Record<SkeletonFileCategory, number>;
+  touchedDirs: { dir: string; count: number }[];
+  notable: SkeletonFile[];
+  files: SkeletonFile[];
+};
+
 export type WatchData = {
   branch: string;
   base: string;
@@ -129,6 +155,7 @@ export type WatchData = {
   commits: WatchCommitSummary[];
   selection: WatchSelection;
   unifiedReady: boolean;
+  skeleton: BranchSkeleton;
 };
 
 export type AppMode = 'pr' | 'watch';

--- a/packages/web/src/state/types.ts
+++ b/packages/web/src/state/types.ts
@@ -104,6 +104,35 @@ export type DraftComment = {
   chapterIndex?: number;
 };
 
+export type WatchCommitSummary = {
+  sha: string;
+  shortSha: string;
+  subject: string;
+  author: string;
+  date: string;
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+  hasNarrative: boolean;
+};
+
+export type WatchSelection =
+  | { kind: 'commit'; sha: string }
+  | { kind: 'unified' }
+  | { kind: 'pending' };
+
+export type WatchData = {
+  branch: string;
+  base: string;
+  baseSha: string;
+  headSha: string;
+  commits: WatchCommitSummary[];
+  selection: WatchSelection;
+  unifiedReady: boolean;
+};
+
+export type AppMode = 'pr' | 'watch';
+
 export type LiveEventKind = 'comment' | 'ci' | 'commit' | 'system';
 
 export type LiveStatus = 'connected' | 'connecting' | 'disconnected';

--- a/packages/web/src/state/types.ts
+++ b/packages/web/src/state/types.ts
@@ -147,6 +147,15 @@ export type BranchSkeleton = {
   files: SkeletonFile[];
 };
 
+export type Addendum = {
+  sha: string;
+  shortSha: string;
+  subject: string;
+  additions: number;
+  deletions: number;
+  narrative: NarrativeResponse | null;
+};
+
 export type WatchData = {
   branch: string;
   base: string;
@@ -155,6 +164,8 @@ export type WatchData = {
   commits: WatchCommitSummary[];
   selection: WatchSelection;
   unifiedReady: boolean;
+  unifiedHeadSha: string | null;
+  addendums: Addendum[];
   skeleton: BranchSkeleton;
 };
 


### PR DESCRIPTION
## Summary

Adds `dad watch [branch] [--base <ref>]` — a live, read-only narration of a feature branch as you (or your agent) commit. The whole-branch story is the primary view: the moment you run the command, you get a local skeleton (touched directories, file categorization, notable files) without any model call, and a unified `base..HEAD` narrative auto-fires in the background. Per-commit narratives are on demand only — click a commit chip to scrutinize that checkpoint.

This is the read-only half of the realtime-feedback discussion. The feedback-loop half is intentionally deferred — see [docs/dad-watch.md](./docs/dad-watch.md) for the full thesis and the deferred features with reasoning, and [docs/superpowers/plans/2026-05-03-dad-watch-walking-skeleton.md](./docs/superpowers/plans/2026-05-03-dad-watch-walking-skeleton.md) for the implementation plan and a retrospective spike on the parallel-server split.

## What's in it

- **CLI**: `dad watch [branch] [--base <ref>]` polls `git rev-parse <branch>` every 2s, regenerates the whole-branch narrative on branch movement, drops chapters whose SHAs disappear after rebase/squash. Auto-detects base via `origin/HEAD` → `main` → `master`. Skips merge commits.
- **Branch skeleton** (`packages/cli/src/watch/skeleton.ts`): pure functions that turn a `DiffFile[]` into a `BranchSkeleton` — totals, by-category counts (test / config / schema / migration / docs / public-api / source), top 8 touched directories, top 5 notable files. Cached on the server context by `(baseSha, headSha)`. Renders in the UI before any LLM call returns. 11 tests.
- **Server** (`packages/cli/src/watch-server.ts`, parallel to PR-mode `server.ts`): `GET /api/narrative` defaults to the unified whole-branch view; `?sha=<sha>` for explicit per-commit. New SSE events: `watch-update`, `commit-narrating`, `commit-narrative`, `unified-narrating`, `unified-narrative`. No GitHub API in this mode — pure local diff + git metadata. Retrospective spike on the split confirmed: API surfaces genuinely diverge, ~30 lines of plumbing duplication is cosmetic, extraction deferred.
- **Cache**: `~/.cache/diffdad/watch/<repoFp>-{commit-<sha>|unified-<base>-<head>}.json`. Stable SHAs are never re-narrated.
- **Scrutinize prompt**: `mode: 'narrate' | 'scrutinize'` knob on the engine. Watch mode always scrutinizes — emphasizes absences, prefers concern/warning callouts over nits, defaults verdict to "caution", asks the model to be honest about what it can't verify from the diff alone.
- **Frontend**: `WatchHeader`, `CommitTimeline`, and a new `BranchSkeletonView` that renders local facts the moment the page loads. `App.tsx` shows the skeleton while the narrative generates, then swaps to `StoryView` when ready. `mode: 'pr' | 'watch'` flag in the store; existing rendering components reused. SSE auto-refreshes the active view.
- **Tests**: classifier + aggregator covered; CLI suite stable (32 pass, 1 pre-existing macOS symlink failure unrelated to this work).

## Behavioral changes from earlier in this PR

If you were following this branch before the walking-skeleton work landed:

- **Whole-branch is now the default landing view**, not the latest commit. The "Whole branch" pill in the timeline is selected on open.
- **The whole-branch narrative auto-fires on `dad watch`**. No more clicking the pill to kick generation.
- **No more eager per-commit narration on startup** — the for-loop that burned one model call per commit is gone. Per-commit narrative only fires when you click a commit chip (or via `POST /api/narrative/commit`).
- **No more eager per-commit narration on new commits** — the `refreshCommits` loop that auto-narrated every freshly-landed commit is also gone. Branch movement now regenerates only the whole-branch story.
- **The branch skeleton renders before the model finishes**. Even on a cold start, you see totals, touched directories, file categorization, and notable files immediately.

## What's NOT in it (with rationale)

The full version is in [docs/dad-watch.md](./docs/dad-watch.md). Quick list:

1. **Feedback loop** (commenting → agent → code change). Anchoring across rebases is heuristic, chapter identity drifts across re-narrations, agent integration is the part that quietly doesn't work, failure modes are silent. Defer until real watch-mode usage shows what hurts.
2. **MCP server** for feeding feedback to coding agents. The data plane for the feedback loop — pointless without the comments it would expose.
3. **Calibrated review-item schema** (concerns / missing / verify with severity/confidence). Load-bearing for the feedback loop; not in this slice.
4. **Working-tree watching**. Half-edited code makes terrible narratives, no SHA to cache against.
5. **Latest-commit "what just changed" companion narration**. Walking skeleton stays on the regenerate-whole-branch path; companion notes can come back later if missed.
6. **Eager mode** (`--eager`) to narrate every commit up front. Off by default per spec.
7. **Auto-posting per-commit narratives as commit comments**. Future explicit `dad publish` action will consolidate.
8. **Cross-model enforcement** (codex narrating Claude's code). Infrastructure exists (`--with=...`); README nudge to follow before public release.
9. **Comment UI in watch mode**. Currently leftover from PR mode and goes nowhere — drafts hit `localStorage` with no destination. Follow-up will hide until the feedback loop ships.
10. **Non-git VCSes, multi-branch dashboards**. Out of scope.

## Try it

```sh
git fetch origin claude/realtime-code-review-feedback-3uWQd
git checkout claude/realtime-code-review-feedback-3uWQd
bun install && bun run build      # dist/ is gitignored — must rebuild after pulling
git checkout some-feature-branch  # or pass branch as arg
bun packages/cli/src/cli.ts watch
```

You should immediately see the branch skeleton (no LLM wait), and the whole-branch story populates in the background. Click a commit chip to drill into a single commit. Make a new commit on the branch — the skeleton + whole-branch story refresh.

## Test plan

- [ ] `dad watch` from a feature branch with commits — branch skeleton renders immediately (totals, categories, touched dirs, notable files), whole-branch narrative auto-fires
- [ ] `BranchSkeletonView` shows correct counts and groupings
- [ ] No per-commit narration fires on startup (console shows "Narrating whole branch (N commits as one story)" and a single completion log, not N completion logs)
- [ ] Click a commit chip — narrates that commit on demand and switches the main pane
- [ ] Make a new commit while watching — `+ 1 new commit` log, `✓ whole-branch story refreshed (M chapters)` follows, browser updates via SSE, no per-commit `✓` logs
- [ ] Amend or rebase — old chips drop, new ones appear, whole-branch regenerates, per-commit narratives stay on demand
- [ ] `dad watch other-branch` and `--base main` overrides work
- [ ] Cache: kill and restart `dad watch`, whole-branch narrative comes back instantly from disk (`~/.cache/diffdad/watch/<repoFp>-unified-<baseSha>-<headSha>.json`)
- [ ] Empty branch (`git checkout main; dad watch`) — "No commits ahead..." message, skeleton renders with zero totals, no crash
- [ ] AppBar reads `dad watch <branch>` (not `dad review 0`); watch placeholder is the skeleton, not a generic loading screen
- [ ] Sanity-check the scrutinize tone on real code — does it actually push back, or is it still triumphant? (key signal — the whole feature depends on this calibration)

https://claude.ai/code/session_0189cUkqueEaMABj9MBsE3BP