### PR TITLE
feat: live narrative progress, brevity, and defensive prompt caps

### DIFF
--- a/packages/cli/src/__tests__/prompt.test.ts
+++ b/packages/cli/src/__tests__/prompt.test.ts
@@ -131,6 +131,59 @@ describe('isMechanicalFile', () => {
   });
 });
 
+function bigFile(file: string, hunkCount: number, linesPerHunk: number): DiffFile {
+  return {
+    file,
+    isNewFile: false,
+    isDeleted: false,
+    hunks: Array.from({ length: hunkCount }, (_, h) => ({
+      header: `@@ -${h * 100} +${h * 100} @@`,
+      oldStart: h * 100,
+      oldCount: linesPerHunk,
+      newStart: h * 100,
+      newCount: linesPerHunk,
+      lines: Array.from({ length: linesPerHunk }, (_, i) => ({
+        type: 'add' as const,
+        content: `line ${h}-${i}`,
+        lineNumber: { new: h * 100 + i },
+      })),
+    })),
+  };
+}
+
+describe('diff size caps', () => {
+  it('truncates a file that exceeds the per-file line cap and notes it', () => {
+    const huge = bigFile('src/huge.ts', 10, 200);
+    const { user } = buildNarrativePrompt({
+      title: 't',
+      description: '',
+      labels: [],
+      files: [huge],
+      fileTree: [],
+    });
+
+    expect(user).toContain('[FILE TRUNCATED:');
+    expect(user).toContain('Files truncated to fit prompt budget');
+    expect(user).toContain('src/huge.ts');
+    expect(user).not.toContain('line 9-0');
+  });
+
+  it('drops files entirely when the global line budget is exhausted', () => {
+    // Per-file cap is 800; global budget is 12000. 16 files * 800 = 12800 → last file dropped.
+    const files = Array.from({ length: 16 }, (_, i) => bigFile(`src/file${i}.ts`, 5, 200));
+    const { user } = buildNarrativePrompt({
+      title: 't',
+      description: '',
+      labels: [],
+      files,
+      fileTree: [],
+    });
+
+    expect(user).toContain('Files entirely omitted because the prompt budget was exhausted');
+    expect(user).toContain('src/file15.ts');
+  });
+});
+
 describe('partitionMechanicalFiles', () => {
   it('splits files into narrate vs skipped', () => {
     const files = [

--- a/packages/cli/src/__tests__/prompt.test.ts
+++ b/packages/cli/src/__tests__/prompt.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { buildNarrativePrompt } from '../narrative/prompt';
+import { buildNarrativePrompt, isMechanicalFile, partitionMechanicalFiles } from '../narrative/prompt';
 import type { DiffFile } from '../github/types';
+
+function fakeFile(file: string): DiffFile {
+  return { file, isNewFile: false, isDeleted: false, hunks: [] };
+}
 
 describe('buildNarrativePrompt', () => {
   it('includes PR metadata and diff content', () => {
@@ -63,5 +67,82 @@ describe('buildNarrativePrompt', () => {
     expect(user).toContain('src/file0.ts');
     expect(user).toContain('src/file199.ts');
     expect(user).not.toContain('src/file200.ts');
+  });
+
+  it('lists skipped mechanical files in the prompt without their diffs', () => {
+    const files: DiffFile[] = [
+      {
+        file: 'src/main.ts',
+        isNewFile: false,
+        isDeleted: false,
+        hunks: [
+          {
+            header: '@@ -1 +1 @@',
+            oldStart: 1,
+            oldCount: 1,
+            newStart: 1,
+            newCount: 1,
+            lines: [{ type: 'add', content: 'console.log(1)', lineNumber: { new: 1 } }],
+          },
+        ],
+      },
+    ];
+
+    const { user } = buildNarrativePrompt({
+      title: 't',
+      description: '',
+      labels: [],
+      files,
+      fileTree: [],
+      skippedFiles: ['bun.lock', 'dist/index.js'],
+    });
+
+    expect(user).toContain('Mechanical files omitted');
+    expect(user).toContain('bun.lock');
+    expect(user).toContain('dist/index.js');
+  });
+});
+
+describe('isMechanicalFile', () => {
+  it('flags lockfiles by basename', () => {
+    expect(isMechanicalFile('bun.lock')).toBe(true);
+    expect(isMechanicalFile('package-lock.json')).toBe(true);
+    expect(isMechanicalFile('packages/web/yarn.lock')).toBe(true);
+    expect(isMechanicalFile('apps/api/Gemfile.lock')).toBe(true);
+    expect(isMechanicalFile('go.sum')).toBe(true);
+  });
+
+  it('flags minified, sourcemap, and generated dirs', () => {
+    expect(isMechanicalFile('public/app.min.js')).toBe(true);
+    expect(isMechanicalFile('public/app.min.css')).toBe(true);
+    expect(isMechanicalFile('dist/index.js')).toBe(true);
+    expect(isMechanicalFile('packages/web/dist/index.js')).toBe(true);
+    expect(isMechanicalFile('build/output.txt')).toBe(true);
+    expect(isMechanicalFile('node_modules/foo/index.js')).toBe(true);
+    expect(isMechanicalFile('app.js.map')).toBe(true);
+  });
+
+  it('does not flag normal source files', () => {
+    expect(isMechanicalFile('src/main.ts')).toBe(false);
+    expect(isMechanicalFile('packages/cli/src/narrative/engine.ts')).toBe(false);
+    expect(isMechanicalFile('README.md')).toBe(false);
+    expect(isMechanicalFile('package.json')).toBe(false);
+    expect(isMechanicalFile('LICENSE')).toBe(false);
+  });
+});
+
+describe('partitionMechanicalFiles', () => {
+  it('splits files into narrate vs skipped', () => {
+    const files = [
+      fakeFile('src/main.ts'),
+      fakeFile('bun.lock'),
+      fakeFile('packages/web/dist/bundle.js'),
+      fakeFile('docs/README.md'),
+    ];
+
+    const { narrate, skipped } = partitionMechanicalFiles(files);
+
+    expect(narrate.map((f) => f.file)).toEqual(['src/main.ts', 'docs/README.md']);
+    expect(skipped.map((f) => f.file)).toEqual(['bun.lock', 'packages/web/dist/bundle.js']);
   });
 });

--- a/packages/cli/src/__tests__/prompt.test.ts
+++ b/packages/cli/src/__tests__/prompt.test.ts
@@ -184,6 +184,43 @@ describe('diff size caps', () => {
   });
 });
 
+describe('buildNarrativePrompt stats', () => {
+  it('reports input vs narrated counts and per-file truncation details', () => {
+    const huge = bigFile('src/huge.ts', 10, 200);
+    const small = bigFile('src/small.ts', 1, 5);
+    const { stats } = buildNarrativePrompt({
+      title: 't',
+      description: '',
+      labels: [],
+      files: [huge, small],
+      fileTree: [],
+    });
+
+    expect(stats.inputFileCount).toBe(2);
+    expect(stats.inputLineCount).toBe(10 * 200 + 5);
+    expect(stats.narratedFileCount).toBe(2);
+    expect(stats.narratedLineCount).toBeLessThan(stats.inputLineCount);
+    expect(stats.truncatedFiles).toHaveLength(1);
+    expect(stats.truncatedFiles[0].file).toBe('src/huge.ts');
+    expect(stats.truncatedFiles[0].linesDropped).toBeGreaterThan(0);
+    expect(stats.droppedFiles).toEqual([]);
+  });
+
+  it('reports dropped files when the global budget is exhausted', () => {
+    const files = Array.from({ length: 16 }, (_, i) => bigFile(`src/file${i}.ts`, 5, 200));
+    const { stats } = buildNarrativePrompt({
+      title: 't',
+      description: '',
+      labels: [],
+      files,
+      fileTree: [],
+    });
+
+    expect(stats.droppedFiles.length).toBeGreaterThan(0);
+    expect(stats.droppedFiles).toContain('src/file15.ts');
+  });
+});
+
 describe('partitionMechanicalFiles', () => {
   it('splits files into narrate vs skipped', () => {
     const files = [

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -269,7 +269,25 @@ async function reviewCommand(prArg: string | undefined): Promise<number> {
       `  ${a.yellow}Generating narrative${a.reset} ${a.gray}via${a.reset} ${a.cyan}${providerHint}${a.reset}`,
     );
     console.log(`  ${a.italic}${a.gray}"${waitJoke}"${a.reset}`);
-    const { narrative: generated, provider: usedProvider } = await generateNarrative(metadata, files, [], config);
+    const isTty = Boolean(process.stdout.isTTY);
+    let lastRender = 0;
+    const onProgress = ({ chars }: { chars: number }) => {
+      broadcast('narrative-progress', { chars });
+      if (!isTty) return;
+      const now = Date.now();
+      if (now - lastRender < 100) return;
+      lastRender = now;
+      process.stdout.write(`\r  ${a.dim}${chars.toLocaleString()} chars generated...${a.reset}`);
+    };
+    const { narrative: generated, provider: usedProvider } = await generateNarrative(
+      metadata,
+      files,
+      [],
+      config,
+      undefined,
+      onProgress,
+    );
+    if (isTty) process.stdout.write('\r\x1b[2K');
     ctx.narrative = generated;
     await cacheNarrative(parsed.owner, parsed.repo, parsed.number, metadata.headSha, generated);
     console.log(

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -270,28 +270,41 @@ async function reviewCommand(prArg: string | undefined): Promise<number> {
     );
     console.log(`  ${a.italic}${a.gray}"${waitJoke}"${a.reset}`);
     const isTty = Boolean(process.stdout.isTTY);
-    let lastRender = 0;
-    const onProgress = ({ chars }: { chars: number }) => {
-      broadcast('narrative-progress', { chars });
-      if (!isTty) return;
-      const now = Date.now();
-      if (now - lastRender < 100) return;
-      lastRender = now;
-      process.stdout.write(`\r  ${a.dim}${chars.toLocaleString()} chars generated...${a.reset}`);
+    const startedAt = Date.now();
+    let totalChars = 0;
+    const spinnerFrames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+    let spinnerFrame = 0;
+    const fmtElapsed = () => {
+      const s = Math.floor((Date.now() - startedAt) / 1000);
+      const m = Math.floor(s / 60);
+      return m > 0 ? `${m}m${String(s % 60).padStart(2, '0')}s` : `${s}s`;
     };
-    const { narrative: generated, provider: usedProvider } = await generateNarrative(
-      metadata,
-      files,
-      [],
-      config,
-      undefined,
-      onProgress,
-    );
-    if (isTty) process.stdout.write('\r\x1b[2K');
+    const render = () => {
+      if (!isTty) return;
+      const frame = spinnerFrames[spinnerFrame++ % spinnerFrames.length];
+      const chars = totalChars > 0 ? `${a.gray} — ${totalChars.toLocaleString()} chars${a.reset}` : '';
+      process.stdout.write(`\r  ${a.dim}${frame} ${fmtElapsed()} elapsed${a.reset}${chars}`);
+    };
+    render();
+    const heartbeat = setInterval(render, 250);
+    const onProgress = ({ chars }: { chars: number }) => {
+      totalChars = chars;
+      broadcast('narrative-progress', { chars });
+    };
+    let generated;
+    let usedProvider: string;
+    try {
+      const result = await generateNarrative(metadata, files, [], config, undefined, onProgress);
+      generated = result.narrative;
+      usedProvider = result.provider;
+    } finally {
+      clearInterval(heartbeat);
+      if (isTty) process.stdout.write('\r\x1b[2K');
+    }
     ctx.narrative = generated;
     await cacheNarrative(parsed.owner, parsed.repo, parsed.number, metadata.headSha, generated);
     console.log(
-      `  ${a.green}✓${a.reset} ${generated.chapters.length} chapters generated ${a.dim}via ${usedProvider}${a.reset}`,
+      `  ${a.green}✓${a.reset} ${generated.chapters.length} chapters generated ${a.dim}via ${usedProvider} in ${fmtElapsed()}${a.reset}`,
     );
     broadcast('narrative', {
       narrative: generated,

--- a/packages/cli/src/narrative/engine.ts
+++ b/packages/cli/src/narrative/engine.ts
@@ -335,7 +335,7 @@ export async function generateNarrative(
           onProgress({ delta, chars });
         }
       : undefined;
-    const result = await callAi(config, system, user, 8192, onChunk, NARRATIVE_JSON_SCHEMA);
+    const result = await callAi(config, system, user, 4096, onChunk, NARRATIVE_JSON_SCHEMA);
 
     const json = extractJson(result.text);
     try {

--- a/packages/cli/src/narrative/engine.ts
+++ b/packages/cli/src/narrative/engine.ts
@@ -98,11 +98,27 @@ function resolveCliModel(cli: LocalCli, config: DiffDadConfig): string | undefin
 }
 
 async function callClaude(system: string, user: string, config: DiffDadConfig): Promise<AiResult> {
-  const prompt = `${system}\n\n---\n\n${user}`;
-  const args = ['claude', '-p', '--output-format', 'text'];
+  const args = [
+    'claude',
+    '-p',
+    '--output-format',
+    'text',
+    '--system-prompt',
+    system,
+    '--tools',
+    '',
+    '--disable-slash-commands',
+    '--strict-mcp-config',
+    '--mcp-config',
+    '{}',
+    '--setting-sources',
+    '',
+    '--no-session-persistence',
+    '--exclude-dynamic-system-prompt-sections',
+  ];
   const model = resolveCliModel('claude', config);
   if (model) args.push('--model', model);
-  const r = await spawnCli(args, prompt);
+  const r = await spawnCli(args, user);
   return { ...r, provider: model ? `claude (${model})` : 'claude' };
 }
 
@@ -178,10 +194,23 @@ export async function callAi(
 
   const provider = config.aiProvider ?? 'anthropic';
   const model = getModel(config);
+  const cacheSystem = provider === 'anthropic';
   const result = await generateText({
     model,
-    system,
-    messages: [{ role: 'user', content: user }],
+    messages: [
+      {
+        role: 'system',
+        content: system,
+        ...(cacheSystem
+          ? {
+              experimental_providerMetadata: {
+                anthropic: { cacheControl: { type: 'ephemeral' } },
+              },
+            }
+          : {}),
+      },
+      { role: 'user', content: user },
+    ],
     maxTokens,
   });
   return {
@@ -225,7 +254,7 @@ export async function generateNarrative(
 
   const MAX_RETRIES = 2;
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    const result = await callAi(config, system, user, 16384);
+    const result = await callAi(config, system, user, 8192);
 
     const json = extractJson(result.text);
     try {

--- a/packages/cli/src/narrative/engine.ts
+++ b/packages/cli/src/narrative/engine.ts
@@ -7,7 +7,12 @@ import type { LanguageModelV1 } from 'ai';
 export type AiChunkHandler = (delta: string) => void;
 import { DEFAULT_CLI_MODELS, LOCAL_CLIS, type DiffDadConfig, type LocalCli } from '../config';
 import type { DiffFile, PRMetadata } from '../github/types';
-import { buildNarrativePrompt, partitionMechanicalFiles, type PreviousNarrativeContext } from './prompt';
+import {
+  NARRATIVE_JSON_SCHEMA,
+  buildNarrativePrompt,
+  partitionMechanicalFiles,
+  type PreviousNarrativeContext,
+} from './prompt';
 import type { NarrativeResponse } from './types';
 
 const DEFAULT_ANTHROPIC_MODEL = 'claude-sonnet-4-6';
@@ -126,6 +131,7 @@ async function callClaude(
   user: string,
   config: DiffDadConfig,
   onChunk?: AiChunkHandler,
+  jsonSchema?: object,
 ): Promise<AiResult> {
   const args = [
     'claude',
@@ -145,6 +151,7 @@ async function callClaude(
     '--no-session-persistence',
     '--exclude-dynamic-system-prompt-sections',
   ];
+  if (jsonSchema) args.push('--json-schema', JSON.stringify(jsonSchema));
   const model = resolveCliModel('claude', config);
   if (model) args.push('--model', model);
   const r = await spawnCli(args, user, onChunk);
@@ -192,8 +199,9 @@ async function callByCli(
   user: string,
   config: DiffDadConfig,
   onChunk?: AiChunkHandler,
+  jsonSchema?: object,
 ): Promise<AiResult> {
-  if (cli === 'claude') return callClaude(system, user, config, onChunk);
+  if (cli === 'claude') return callClaude(system, user, config, onChunk, jsonSchema);
   if (cli === 'pi') return callPi(system, user, config, onChunk);
   return callCodex(system, user, config, onChunk);
 }
@@ -203,6 +211,7 @@ async function callLocalCli(
   user: string,
   config: DiffDadConfig,
   onChunk?: AiChunkHandler,
+  jsonSchema?: object,
 ): Promise<AiResult> {
   const forced = cliOverride ?? process.env.DIFFDAD_CLI;
 
@@ -210,7 +219,7 @@ async function callLocalCli(
     if (!LOCAL_CLIS.includes(forced as LocalCli)) {
       throw new Error(`Unknown --with value: "${forced}". Use "claude", "codex", or "pi".`);
     }
-    return callByCli(forced as LocalCli, system, user, config, onChunk);
+    return callByCli(forced as LocalCli, system, user, config, onChunk, jsonSchema);
   }
 
   const order: LocalCli[] = config.defaultCli
@@ -219,7 +228,7 @@ async function callLocalCli(
 
   for (const cli of order) {
     if (await whichExists(cli)) {
-      return callByCli(cli, system, user, config, onChunk);
+      return callByCli(cli, system, user, config, onChunk, jsonSchema);
     }
   }
 
@@ -234,13 +243,14 @@ export async function callAi(
   user: string,
   maxTokens?: number,
   onChunk?: AiChunkHandler,
+  jsonSchema?: object,
 ): Promise<AiResult> {
   if (cliOverride) {
-    return callLocalCli(system, user, config, onChunk);
+    return callLocalCli(system, user, config, onChunk, jsonSchema);
   }
 
   if (!hasConfiguredProvider(config)) {
-    return callLocalCli(system, user, config, onChunk);
+    return callLocalCli(system, user, config, onChunk, jsonSchema);
   }
 
   const provider = config.aiProvider ?? 'anthropic';
@@ -325,7 +335,7 @@ export async function generateNarrative(
           onProgress({ delta, chars });
         }
       : undefined;
-    const result = await callAi(config, system, user, 8192, onChunk);
+    const result = await callAi(config, system, user, 8192, onChunk, NARRATIVE_JSON_SCHEMA);
 
     const json = extractJson(result.text);
     try {

--- a/packages/cli/src/narrative/engine.ts
+++ b/packages/cli/src/narrative/engine.ts
@@ -1,8 +1,10 @@
 import { rm } from 'fs/promises';
-import { generateText } from 'ai';
+import { streamText } from 'ai';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
 import type { LanguageModelV1 } from 'ai';
+
+export type AiChunkHandler = (delta: string) => void;
 import { DEFAULT_CLI_MODELS, LOCAL_CLIS, type DiffDadConfig, type LocalCli } from '../config';
 import type { DiffFile, PRMetadata } from '../github/types';
 import { buildNarrativePrompt, type PreviousNarrativeContext } from './prompt';
@@ -59,25 +61,47 @@ async function whichExists(cmd: string): Promise<boolean> {
   }
 }
 
-async function spawnCli(args: string[], input: string): Promise<{ text: string; truncated: boolean }> {
+async function spawnCli(
+  args: string[],
+  input: string,
+  onChunk?: AiChunkHandler,
+): Promise<{ text: string; truncated: boolean }> {
   const proc = Bun.spawn(args, {
     stdin: new Response(input),
     stdout: 'pipe',
     stderr: 'pipe',
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
+  const decoder = new TextDecoder();
+  let text = '';
+  const reader = proc.stdout.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const chunk = decoder.decode(value, { stream: true });
+      if (chunk.length > 0) {
+        text += chunk;
+        onChunk?.(chunk);
+      }
+    }
+    const tail = decoder.decode();
+    if (tail.length > 0) {
+      text += tail;
+      onChunk?.(tail);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const [stderr, exitCode] = await Promise.all([new Response(proc.stderr).text(), proc.exited]);
 
   if (exitCode !== 0) {
     const msg = stderr.trim() || `${args[0]} exited with code ${exitCode}`;
     throw new Error(`${args[0]} failed: ${msg}`);
   }
 
-  return { text: stdout, truncated: false };
+  return { text, truncated: false };
 }
 
 export type AiResult = { text: string; truncated: boolean; provider: string };
@@ -97,7 +121,12 @@ function resolveCliModel(cli: LocalCli, config: DiffDadConfig): string | undefin
   return fallback.length > 0 ? fallback : undefined;
 }
 
-async function callClaude(system: string, user: string, config: DiffDadConfig): Promise<AiResult> {
+async function callClaude(
+  system: string,
+  user: string,
+  config: DiffDadConfig,
+  onChunk?: AiChunkHandler,
+): Promise<AiResult> {
   const args = [
     'claude',
     '-p',
@@ -118,26 +147,36 @@ async function callClaude(system: string, user: string, config: DiffDadConfig): 
   ];
   const model = resolveCliModel('claude', config);
   if (model) args.push('--model', model);
-  const r = await spawnCli(args, user);
+  const r = await spawnCli(args, user, onChunk);
   return { ...r, provider: model ? `claude (${model})` : 'claude' };
 }
 
-async function callPi(system: string, user: string, config: DiffDadConfig): Promise<AiResult> {
+async function callPi(
+  system: string,
+  user: string,
+  config: DiffDadConfig,
+  onChunk?: AiChunkHandler,
+): Promise<AiResult> {
   const args = ['pi', '-p', '--system-prompt', system, '--no-tools'];
   const model = resolveCliModel('pi', config);
   if (model) args.push('--model', model);
-  const r = await spawnCli(args, user);
+  const r = await spawnCli(args, user, onChunk);
   return { ...r, provider: model ? `pi (${model})` : 'pi' };
 }
 
-async function callCodex(system: string, user: string, config: DiffDadConfig): Promise<AiResult> {
+async function callCodex(
+  system: string,
+  user: string,
+  config: DiffDadConfig,
+  onChunk?: AiChunkHandler,
+): Promise<AiResult> {
   const prompt = `${system}\n\n---\n\n${user}`;
   const tmpFile = `/tmp/diffdad-codex-${Date.now()}.txt`;
   const args = ['codex', 'exec', '--skip-git-repo-check', '--ignore-rules', '-o', tmpFile];
   const model = resolveCliModel('codex', config);
   if (model) args.push('--model', model);
   try {
-    const r = await spawnCli(args, prompt);
+    const r = await spawnCli(args, prompt, onChunk);
     const output = await Bun.file(tmpFile)
       .text()
       .catch(() => r.text);
@@ -147,20 +186,31 @@ async function callCodex(system: string, user: string, config: DiffDadConfig): P
   }
 }
 
-async function callByCli(cli: LocalCli, system: string, user: string, config: DiffDadConfig): Promise<AiResult> {
-  if (cli === 'claude') return callClaude(system, user, config);
-  if (cli === 'pi') return callPi(system, user, config);
-  return callCodex(system, user, config);
+async function callByCli(
+  cli: LocalCli,
+  system: string,
+  user: string,
+  config: DiffDadConfig,
+  onChunk?: AiChunkHandler,
+): Promise<AiResult> {
+  if (cli === 'claude') return callClaude(system, user, config, onChunk);
+  if (cli === 'pi') return callPi(system, user, config, onChunk);
+  return callCodex(system, user, config, onChunk);
 }
 
-async function callLocalCli(system: string, user: string, config: DiffDadConfig): Promise<AiResult> {
+async function callLocalCli(
+  system: string,
+  user: string,
+  config: DiffDadConfig,
+  onChunk?: AiChunkHandler,
+): Promise<AiResult> {
   const forced = cliOverride ?? process.env.DIFFDAD_CLI;
 
   if (forced) {
     if (!LOCAL_CLIS.includes(forced as LocalCli)) {
       throw new Error(`Unknown --with value: "${forced}". Use "claude", "codex", or "pi".`);
     }
-    return callByCli(forced as LocalCli, system, user, config);
+    return callByCli(forced as LocalCli, system, user, config, onChunk);
   }
 
   const order: LocalCli[] = config.defaultCli
@@ -169,7 +219,7 @@ async function callLocalCli(system: string, user: string, config: DiffDadConfig)
 
   for (const cli of order) {
     if (await whichExists(cli)) {
-      return callByCli(cli, system, user, config);
+      return callByCli(cli, system, user, config, onChunk);
     }
   }
 
@@ -183,19 +233,20 @@ export async function callAi(
   system: string,
   user: string,
   maxTokens?: number,
+  onChunk?: AiChunkHandler,
 ): Promise<AiResult> {
   if (cliOverride) {
-    return callLocalCli(system, user, config);
+    return callLocalCli(system, user, config, onChunk);
   }
 
   if (!hasConfiguredProvider(config)) {
-    return callLocalCli(system, user, config);
+    return callLocalCli(system, user, config, onChunk);
   }
 
   const provider = config.aiProvider ?? 'anthropic';
   const model = getModel(config);
   const cacheSystem = provider === 'anthropic';
-  const result = await generateText({
+  const stream = streamText({
     model,
     messages: [
       {
@@ -213,9 +264,17 @@ export async function callAi(
     ],
     maxTokens,
   });
+
+  let text = '';
+  for await (const delta of stream.textStream) {
+    if (delta.length === 0) continue;
+    text += delta;
+    onChunk?.(delta);
+  }
+  const finishReason = await stream.finishReason;
   return {
-    text: result.text,
-    truncated: result.finishReason === 'length',
+    text,
+    truncated: finishReason === 'length',
     provider: `${provider} (${config.aiModel ?? 'default'})`,
   };
 }
@@ -236,12 +295,15 @@ function extractJson(text: string): string {
   return trimmed;
 }
 
+export type NarrativeProgressHandler = (info: { delta: string; chars: number }) => void;
+
 export async function generateNarrative(
   pr: PRMetadata,
   files: DiffFile[],
   fileTree: string[],
   config: DiffDadConfig,
   previousContext?: PreviousNarrativeContext,
+  onProgress?: NarrativeProgressHandler,
 ): Promise<{ narrative: NarrativeResponse; provider: string }> {
   const { system, user } = buildNarrativePrompt({
     title: pr.title,
@@ -254,7 +316,14 @@ export async function generateNarrative(
 
   const MAX_RETRIES = 2;
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    const result = await callAi(config, system, user, 8192);
+    let chars = 0;
+    const onChunk: AiChunkHandler | undefined = onProgress
+      ? (delta) => {
+          chars += delta.length;
+          onProgress({ delta, chars });
+        }
+      : undefined;
+    const result = await callAi(config, system, user, 8192, onChunk);
 
     const json = extractJson(result.text);
     try {

--- a/packages/cli/src/narrative/engine.ts
+++ b/packages/cli/src/narrative/engine.ts
@@ -7,7 +7,12 @@ import type { LanguageModelV1 } from 'ai';
 export type AiChunkHandler = (delta: string) => void;
 import { DEFAULT_CLI_MODELS, LOCAL_CLIS, type DiffDadConfig, type LocalCli } from '../config';
 import type { DiffFile, PRMetadata } from '../github/types';
-import { buildNarrativePrompt, partitionMechanicalFiles, type PreviousNarrativeContext } from './prompt';
+import {
+  buildNarrativePrompt,
+  partitionMechanicalFiles,
+  type PreviousNarrativeContext,
+  type PromptCapStats,
+} from './prompt';
 import type { NarrativeResponse } from './types';
 
 const DEFAULT_ANTHROPIC_MODEL = 'claude-sonnet-4-6';
@@ -302,6 +307,38 @@ function extractJson(text: string): string {
 
 export type NarrativeProgressHandler = (info: { delta: string; chars: number }) => void;
 
+const DIM = '\x1b[2m';
+const YELLOW = '\x1b[38;5;221m';
+const RESET = '\x1b[0m';
+
+function logPromptStats(stats: PromptCapStats, mechanicalSkipped: number): void {
+  const lines: string[] = [];
+  lines.push(
+    `${DIM}Prompt: ${stats.narratedFileCount}/${stats.inputFileCount + mechanicalSkipped} files, ${stats.narratedLineCount.toLocaleString()}/${stats.inputLineCount.toLocaleString()} lines (caps: ${stats.perFileCap}/file, ${stats.globalCap.toLocaleString()} total)${RESET}`,
+  );
+  if (mechanicalSkipped > 0) {
+    lines.push(`${DIM}  • Skipped ${mechanicalSkipped} mechanical file(s) (lockfiles, generated, minified)${RESET}`);
+  }
+  if (stats.truncatedFiles.length > 0) {
+    const totalDroppedLines = stats.truncatedFiles.reduce((s, t) => s + t.linesDropped, 0);
+    lines.push(
+      `${YELLOW}  ⚠ Per-file cap hit on ${stats.truncatedFiles.length} file(s): ${totalDroppedLines.toLocaleString()} line(s) truncated${RESET}`,
+    );
+    for (const t of stats.truncatedFiles) {
+      lines.push(`${DIM}      ${t.file}: dropped ${t.hunksDropped} hunk(s), ${t.linesDropped.toLocaleString()} line(s)${RESET}`);
+    }
+  }
+  if (stats.droppedFiles.length > 0) {
+    lines.push(
+      `${YELLOW}  ⚠ Global cap exhausted: ${stats.droppedFiles.length} file(s) dropped entirely${RESET}`,
+    );
+    for (const f of stats.droppedFiles) {
+      lines.push(`${DIM}      ${f}${RESET}`);
+    }
+  }
+  for (const l of lines) console.error(`  ${l}`);
+}
+
 export async function generateNarrative(
   pr: PRMetadata,
   files: DiffFile[],
@@ -311,7 +348,7 @@ export async function generateNarrative(
   onProgress?: NarrativeProgressHandler,
 ): Promise<{ narrative: NarrativeResponse; provider: string }> {
   const { narrate, skipped } = partitionMechanicalFiles(files);
-  const { system, user } = buildNarrativePrompt({
+  const { system, user, stats } = buildNarrativePrompt({
     title: pr.title,
     description: pr.body,
     labels: pr.labels,
@@ -320,6 +357,7 @@ export async function generateNarrative(
     skippedFiles: skipped.map((f) => f.file),
     previousContext,
   });
+  logPromptStats(stats, skipped.length);
 
   const MAX_RETRIES = 2;
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {

--- a/packages/cli/src/narrative/engine.ts
+++ b/packages/cli/src/narrative/engine.ts
@@ -145,7 +145,7 @@ async function callClaude(
     '--disable-slash-commands',
     '--strict-mcp-config',
     '--mcp-config',
-    '{}',
+    '{"mcpServers":{}}',
     '--setting-sources',
     '',
     '--no-session-persistence',

--- a/packages/cli/src/narrative/engine.ts
+++ b/packages/cli/src/narrative/engine.ts
@@ -7,7 +7,7 @@ import type { LanguageModelV1 } from 'ai';
 export type AiChunkHandler = (delta: string) => void;
 import { DEFAULT_CLI_MODELS, LOCAL_CLIS, type DiffDadConfig, type LocalCli } from '../config';
 import type { DiffFile, PRMetadata } from '../github/types';
-import { buildNarrativePrompt, type PreviousNarrativeContext } from './prompt';
+import { buildNarrativePrompt, partitionMechanicalFiles, type PreviousNarrativeContext } from './prompt';
 import type { NarrativeResponse } from './types';
 
 const DEFAULT_ANTHROPIC_MODEL = 'claude-sonnet-4-6';
@@ -305,12 +305,14 @@ export async function generateNarrative(
   previousContext?: PreviousNarrativeContext,
   onProgress?: NarrativeProgressHandler,
 ): Promise<{ narrative: NarrativeResponse; provider: string }> {
+  const { narrate, skipped } = partitionMechanicalFiles(files);
   const { system, user } = buildNarrativePrompt({
     title: pr.title,
     description: pr.body,
     labels: pr.labels,
-    files,
+    files: narrate,
     fileTree,
+    skippedFiles: skipped.map((f) => f.file),
     previousContext,
   });
 

--- a/packages/cli/src/narrative/engine.ts
+++ b/packages/cli/src/narrative/engine.ts
@@ -330,7 +330,7 @@ export async function generateNarrative(
           onProgress({ delta, chars });
         }
       : undefined;
-    const result = await callAi(config, system, user, 4096, onChunk);
+    const result = await callAi(config, system, user, 16384, onChunk);
 
     const json = extractJson(result.text);
     try {

--- a/packages/cli/src/narrative/engine.ts
+++ b/packages/cli/src/narrative/engine.ts
@@ -7,12 +7,7 @@ import type { LanguageModelV1 } from 'ai';
 export type AiChunkHandler = (delta: string) => void;
 import { DEFAULT_CLI_MODELS, LOCAL_CLIS, type DiffDadConfig, type LocalCli } from '../config';
 import type { DiffFile, PRMetadata } from '../github/types';
-import {
-  NARRATIVE_JSON_SCHEMA,
-  buildNarrativePrompt,
-  partitionMechanicalFiles,
-  type PreviousNarrativeContext,
-} from './prompt';
+import { buildNarrativePrompt, partitionMechanicalFiles, type PreviousNarrativeContext } from './prompt';
 import type { NarrativeResponse } from './types';
 
 const DEFAULT_ANTHROPIC_MODEL = 'claude-sonnet-4-6';
@@ -335,7 +330,7 @@ export async function generateNarrative(
           onProgress({ delta, chars });
         }
       : undefined;
-    const result = await callAi(config, system, user, 4096, onChunk, NARRATIVE_JSON_SCHEMA);
+    const result = await callAi(config, system, user, 4096, onChunk);
 
     const json = extractJson(result.text);
     try {

--- a/packages/cli/src/narrative/prompt.ts
+++ b/packages/cli/src/narrative/prompt.ts
@@ -15,9 +15,21 @@ export interface NarrativePromptInput {
   previousContext?: PreviousNarrativeContext;
 }
 
+export interface PromptCapStats {
+  perFileCap: number;
+  globalCap: number;
+  inputFileCount: number;
+  inputLineCount: number;
+  narratedFileCount: number;
+  narratedLineCount: number;
+  truncatedFiles: { file: string; hunksDropped: number; linesDropped: number }[];
+  droppedFiles: string[];
+}
+
 export interface NarrativePrompt {
   system: string;
   user: string;
+  stats: PromptCapStats;
 }
 
 const FILE_TREE_LIMIT = 200;
@@ -274,7 +286,10 @@ function formatHunk(hunk: DiffHunk, index: number): string {
 
 const MAX_LINES_PER_FILE = 800;
 
-function formatFile(file: DiffFile, lineBudget: number): { text: string; linesUsed: number; truncated: boolean } {
+function formatFile(
+  file: DiffFile,
+  lineBudget: number,
+): { text: string; linesUsed: number; truncated: boolean; hunksDropped: number; linesDropped: number } {
   const header = `diff --git a/${file.file} b/${file.file}`;
   const fromPath = file.isNewFile ? '/dev/null' : `a/${file.file}`;
   const toPath = file.isDeleted ? '/dev/null' : `b/${file.file}`;
@@ -308,7 +323,7 @@ function formatFile(file: DiffFile, lineBudget: number): { text: string; linesUs
   if (truncated) {
     body += `\n[FILE TRUNCATED: ${omittedHunks} more hunk(s), ${omittedLines} more line(s) omitted to fit prompt budget]`;
   }
-  return { text: `${meta.join('\n')}\n${body}`, linesUsed, truncated };
+  return { text: `${meta.join('\n')}\n${body}`, linesUsed, truncated, hunksDropped: omittedHunks, linesDropped: omittedLines };
 }
 
 export function buildNarrativePrompt(input: NarrativePromptInput): NarrativePrompt {
@@ -320,10 +335,15 @@ export function buildNarrativePrompt(input: NarrativePromptInput): NarrativeProm
   const treeBlock = truncatedTree.length > 0 ? truncatedTree.join('\n') : '(empty)';
 
   let lineBudget = MAX_TOTAL_DIFF_LINES;
+  const truncatedFileDetails: { file: string; hunksDropped: number; linesDropped: number }[] = [];
   const truncatedFiles: string[] = [];
   const fileBlocks: string[] = [];
   const droppedFiles: string[] = [];
+  let inputLineCount = 0;
+  let narratedLineCount = 0;
   for (const file of files) {
+    const fileLineCount = file.hunks.reduce((sum, h) => sum + h.lines.length, 0);
+    inputLineCount += fileLineCount;
     if (lineBudget <= 0) {
       droppedFiles.push(file.file);
       continue;
@@ -331,7 +351,15 @@ export function buildNarrativePrompt(input: NarrativePromptInput): NarrativeProm
     const formatted = formatFile(file, lineBudget);
     fileBlocks.push(formatted.text);
     lineBudget -= formatted.linesUsed;
-    if (formatted.truncated) truncatedFiles.push(file.file);
+    narratedLineCount += formatted.linesUsed;
+    if (formatted.truncated) {
+      truncatedFiles.push(file.file);
+      truncatedFileDetails.push({
+        file: file.file,
+        hunksDropped: formatted.hunksDropped,
+        linesDropped: formatted.linesDropped,
+      });
+    }
   }
   const diffBlock = fileBlocks.length > 0 ? fileBlocks.join('\n') : '(no file changes)';
 
@@ -388,5 +416,15 @@ export function buildNarrativePrompt(input: NarrativePromptInput): NarrativeProm
   }
 
   const user = parts.join('\n');
-  return { system: SYSTEM_PROMPT, user };
+  const stats: PromptCapStats = {
+    perFileCap: MAX_LINES_PER_FILE,
+    globalCap: MAX_TOTAL_DIFF_LINES,
+    inputFileCount: files.length,
+    inputLineCount,
+    narratedFileCount: fileBlocks.length,
+    narratedLineCount,
+    truncatedFiles: truncatedFileDetails,
+    droppedFiles,
+  };
+  return { system: SYSTEM_PROMPT, user, stats };
 }

--- a/packages/cli/src/narrative/prompt.ts
+++ b/packages/cli/src/narrative/prompt.ts
@@ -21,6 +21,7 @@ export interface NarrativePrompt {
 }
 
 const FILE_TREE_LIMIT = 200;
+const MAX_TOTAL_DIFF_LINES = 12000;
 
 const MECHANICAL_BASENAMES = new Set([
   'package-lock.json',
@@ -267,7 +268,9 @@ function formatHunk(hunk: DiffHunk, index: number): string {
   return `[hunkIndex=${index}]\n${hunk.header}\n${body}`;
 }
 
-function formatFile(file: DiffFile): string {
+const MAX_LINES_PER_FILE = 800;
+
+function formatFile(file: DiffFile, lineBudget: number): { text: string; linesUsed: number; truncated: boolean } {
   const header = `diff --git a/${file.file} b/${file.file}`;
   const fromPath = file.isNewFile ? '/dev/null' : `a/${file.file}`;
   const toPath = file.isDeleted ? '/dev/null' : `b/${file.file}`;
@@ -277,8 +280,31 @@ function formatFile(file: DiffFile): string {
   const meta = [header];
   if (fileMarkers) meta.push(fileMarkers);
   meta.push(`--- ${fromPath}`, `+++ ${toPath}`);
-  const hunks = file.hunks.map((h, i) => formatHunk(h, i)).join('\n');
-  return `${meta.join('\n')}\n${hunks}`;
+
+  const cap = Math.min(MAX_LINES_PER_FILE, lineBudget);
+  let linesUsed = 0;
+  let truncated = false;
+  const includedHunks: string[] = [];
+  let omittedHunks = 0;
+  let omittedLines = 0;
+
+  for (let i = 0; i < file.hunks.length; i++) {
+    const h = file.hunks[i];
+    if (linesUsed + h.lines.length > cap) {
+      truncated = true;
+      omittedHunks = file.hunks.length - i;
+      for (let j = i; j < file.hunks.length; j++) omittedLines += file.hunks[j].lines.length;
+      break;
+    }
+    includedHunks.push(formatHunk(h, i));
+    linesUsed += h.lines.length;
+  }
+
+  let body = includedHunks.join('\n');
+  if (truncated) {
+    body += `\n[FILE TRUNCATED: ${omittedHunks} more hunk(s), ${omittedLines} more line(s) omitted to fit prompt budget]`;
+  }
+  return { text: `${meta.join('\n')}\n${body}`, linesUsed, truncated };
 }
 
 export function buildNarrativePrompt(input: NarrativePromptInput): NarrativePrompt {
@@ -288,7 +314,22 @@ export function buildNarrativePrompt(input: NarrativePromptInput): NarrativeProm
   const labelLine = labels.length > 0 ? labels.join(', ') : '(none)';
   const descriptionBlock = description.trim().length > 0 ? description : '(no description provided)';
   const treeBlock = truncatedTree.length > 0 ? truncatedTree.join('\n') : '(empty)';
-  const diffBlock = files.length > 0 ? files.map(formatFile).join('\n') : '(no file changes)';
+
+  let lineBudget = MAX_TOTAL_DIFF_LINES;
+  const truncatedFiles: string[] = [];
+  const fileBlocks: string[] = [];
+  const droppedFiles: string[] = [];
+  for (const file of files) {
+    if (lineBudget <= 0) {
+      droppedFiles.push(file.file);
+      continue;
+    }
+    const formatted = formatFile(file, lineBudget);
+    fileBlocks.push(formatted.text);
+    lineBudget -= formatted.linesUsed;
+    if (formatted.truncated) truncatedFiles.push(file.file);
+  }
+  const diffBlock = fileBlocks.length > 0 ? fileBlocks.join('\n') : '(no file changes)';
 
   const parts = [
     `PR title: ${title}`,
@@ -309,6 +350,20 @@ export function buildNarrativePrompt(input: NarrativePromptInput): NarrativeProm
     parts.push(
       '',
       `Mechanical files omitted from the diff above (lockfiles, generated, minified — do not narrate, but mention briefly if relevant): ${skippedFiles.join(', ')}`,
+    );
+  }
+
+  if (truncatedFiles.length > 0) {
+    parts.push(
+      '',
+      `Files truncated to fit prompt budget (later hunks omitted; the [FILE TRUNCATED: ...] marker shows what was cut): ${truncatedFiles.join(', ')}`,
+    );
+  }
+
+  if (droppedFiles.length > 0) {
+    parts.push(
+      '',
+      `Files entirely omitted because the prompt budget was exhausted before reaching them. Mention them in your narrative without trying to describe specific changes: ${droppedFiles.join(', ')}`,
     );
   }
 

--- a/packages/cli/src/narrative/prompt.ts
+++ b/packages/cli/src/narrative/prompt.ts
@@ -11,6 +11,7 @@ export interface NarrativePromptInput {
   labels: string[];
   files: DiffFile[];
   fileTree: string[];
+  skippedFiles?: string[];
   previousContext?: PreviousNarrativeContext;
 }
 
@@ -20,6 +21,48 @@ export interface NarrativePrompt {
 }
 
 const FILE_TREE_LIMIT = 200;
+
+const MECHANICAL_BASENAMES = new Set([
+  'package-lock.json',
+  'pnpm-lock.yaml',
+  'yarn.lock',
+  'bun.lock',
+  'bun.lockb',
+  'composer.lock',
+  'Gemfile.lock',
+  'Pipfile.lock',
+  'poetry.lock',
+  'uv.lock',
+  'cargo.lock',
+  'go.sum',
+]);
+
+const MECHANICAL_PATH_REGEXES: RegExp[] = [
+  /\.min\.(js|css|mjs)$/i,
+  /\.map$/i,
+  /(^|\/)dist\//,
+  /(^|\/)build\//,
+  /(^|\/)\.next\//,
+  /(^|\/)node_modules\//,
+  /(^|\/)vendor\//,
+];
+
+export function isMechanicalFile(path: string): boolean {
+  const basename = path.split('/').pop() ?? path;
+  if (MECHANICAL_BASENAMES.has(basename)) return true;
+  if (basename.toLowerCase() === 'cargo.lock') return true;
+  return MECHANICAL_PATH_REGEXES.some((re) => re.test(path));
+}
+
+export function partitionMechanicalFiles(files: DiffFile[]): { narrate: DiffFile[]; skipped: DiffFile[] } {
+  const narrate: DiffFile[] = [];
+  const skipped: DiffFile[] = [];
+  for (const f of files) {
+    if (isMechanicalFile(f.file)) skipped.push(f);
+    else narrate.push(f);
+  }
+  return { narrate, skipped };
+}
 
 const RESPONSE_SCHEMA = `{
   "title": "string — overall narrative title for the PR",
@@ -155,7 +198,7 @@ function formatFile(file: DiffFile): string {
 }
 
 export function buildNarrativePrompt(input: NarrativePromptInput): NarrativePrompt {
-  const { title, description, labels, files, fileTree, previousContext } = input;
+  const { title, description, labels, files, fileTree, skippedFiles, previousContext } = input;
 
   const truncatedTree = fileTree.slice(0, FILE_TREE_LIMIT);
   const labelLine = labels.length > 0 ? labels.join(', ') : '(none)';
@@ -177,6 +220,13 @@ export function buildNarrativePrompt(input: NarrativePromptInput): NarrativeProm
     'Unified diff:',
     diffBlock,
   ];
+
+  if (skippedFiles && skippedFiles.length > 0) {
+    parts.push(
+      '',
+      `Mechanical files omitted from the diff above (lockfiles, generated, minified — do not narrate, but mention briefly if relevant): ${skippedFiles.join(', ')}`,
+    );
+  }
 
   if (previousContext?.previousTldr || previousContext?.previousChapterTitles?.length) {
     parts.push(

--- a/packages/cli/src/narrative/prompt.ts
+++ b/packages/cli/src/narrative/prompt.ts
@@ -64,6 +64,90 @@ export function partitionMechanicalFiles(files: DiffFile[]): { narrate: DiffFile
   return { narrate, skipped };
 }
 
+export const NARRATIVE_JSON_SCHEMA = {
+  type: 'object',
+  required: ['title', 'chapters'],
+  properties: {
+    title: { type: 'string' },
+    tldr: { type: 'string' },
+    verdict: { type: 'string', enum: ['safe', 'caution', 'risky'] },
+    chapters: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['title', 'summary', 'risk', 'sections'],
+        properties: {
+          title: { type: 'string' },
+          summary: { type: 'string' },
+          risk: { type: 'string', enum: ['low', 'medium', 'high'] },
+          sections: {
+            type: 'array',
+            items: {
+              oneOf: [
+                {
+                  type: 'object',
+                  required: ['type', 'content'],
+                  properties: {
+                    type: { type: 'string', enum: ['narrative'] },
+                    content: { type: 'string' },
+                  },
+                },
+                {
+                  type: 'object',
+                  required: ['type', 'file', 'startLine', 'endLine', 'hunkIndex'],
+                  properties: {
+                    type: { type: 'string', enum: ['diff'] },
+                    file: { type: 'string' },
+                    startLine: { type: 'number' },
+                    endLine: { type: 'number' },
+                    hunkIndex: { type: 'number' },
+                  },
+                },
+              ],
+            },
+          },
+          callouts: {
+            type: 'array',
+            items: {
+              type: 'object',
+              required: ['file', 'line', 'level', 'message'],
+              properties: {
+                file: { type: 'string' },
+                line: { type: 'number' },
+                level: { type: 'string', enum: ['nit', 'concern', 'warning'] },
+                message: { type: 'string' },
+              },
+            },
+          },
+          reshow: {
+            type: 'array',
+            items: {
+              type: 'object',
+              required: ['ref'],
+              properties: {
+                ref: { type: 'number' },
+                file: { type: 'string' },
+                framing: { type: 'string' },
+                highlight: {
+                  type: 'object',
+                  required: ['from', 'to'],
+                  properties: { from: { type: 'number' }, to: { type: 'number' } },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    missing: { type: 'array', items: { type: 'string' } },
+    suggestedStart: {
+      type: 'object',
+      required: ['chapter', 'reason'],
+      properties: { chapter: { type: 'number' }, reason: { type: 'string' } },
+    },
+  },
+} as const;
+
 const RESPONSE_SCHEMA = `{
   "title": "string — overall narrative title for the PR",
   "tldr": "string — 1-2 sentence plain-language summary: what this PR does and why",

--- a/packages/cli/src/narrative/prompt.ts
+++ b/packages/cli/src/narrative/prompt.ts
@@ -255,6 +255,10 @@ Assign an overall verdict:
 
 Pick the chapter that best anchors the rest of the change. Often this is the core behavioral change, not the first file alphabetically.
 
+## Brevity
+
+You are output-token-bound. Every chapter and sentence costs the reader real wait time. Aim for **3–6 chapters total**, not more, even on large PRs — group aggressively. Keep each narrative section to **1–3 sentences**. Use callouts and the missing array only when they add real value; omit them when they don't. Cut anything restating what the diff already shows.
+
 Output format — return ONLY valid JSON, no prose around it, matching this schema:
 ${RESPONSE_SCHEMA}`;
 

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -299,10 +299,17 @@ export function createServer(ctx: ServerContext) {
                   console.log(`  \x1b[38;5;78m✓\x1b[0m Using cached narrative \x1b[2m(${newSha})\x1b[0m`);
                 } else {
                   const config = await readConfig();
-                  const { narrative: generated, provider } = await generateNarrative(ctx.pr, freshFiles, [], config, {
-                    previousTldr: prevTldr,
-                    previousChapterTitles: prevChapterTitles,
-                  });
+                  const { narrative: generated, provider } = await generateNarrative(
+                    ctx.pr,
+                    freshFiles,
+                    [],
+                    config,
+                    {
+                      previousTldr: prevTldr,
+                      previousChapterTitles: prevChapterTitles,
+                    },
+                    ({ chars }) => broadcast('narrative-progress', { chars }),
+                  );
                   ctx.narrative = generated;
                   await cacheNarrative(ctx.owner, ctx.repo, ctx.pr.number, ctx.headSha, generated);
                   console.log(

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -39,7 +39,14 @@ export function createServer(ctx: ServerContext) {
   let hadClients = false;
   let exitTimer: ReturnType<typeof setTimeout> | null = null;
 
+  let narrativeProgressChars = 0;
+
   function broadcast(event: string, data: unknown) {
+    if (event === 'narrative-progress') {
+      narrativeProgressChars = (data as { chars?: number }).chars ?? 0;
+    } else if (event === 'regenerating' || event === 'narrative') {
+      narrativeProgressChars = 0;
+    }
     for (const send of sseClients) {
       send(event, data);
     }
@@ -235,6 +242,7 @@ export function createServer(ctx: ServerContext) {
         };
 
         send('connected', { timestamp: Date.now() });
+        if (narrativeProgressChars > 0) send('narrative-progress', { chars: narrativeProgressChars });
         sseClients.add(send);
         hadClients = true;
         if (exitTimer) {

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -307,21 +307,51 @@ export function createServer(ctx: ServerContext) {
                   console.log(`  \x1b[38;5;78m✓\x1b[0m Using cached narrative \x1b[2m(${newSha})\x1b[0m`);
                 } else {
                   const config = await readConfig();
-                  const { narrative: generated, provider } = await generateNarrative(
-                    ctx.pr,
-                    freshFiles,
-                    [],
-                    config,
-                    {
-                      previousTldr: prevTldr,
-                      previousChapterTitles: prevChapterTitles,
-                    },
-                    ({ chars }) => broadcast('narrative-progress', { chars }),
-                  );
+                  const regenStartedAt = Date.now();
+                  const isTty = Boolean(process.stdout.isTTY);
+                  const spinnerFrames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+                  let spinnerFrame = 0;
+                  let totalChars = 0;
+                  const fmtRegenElapsed = () => {
+                    const s = Math.floor((Date.now() - regenStartedAt) / 1000);
+                    const m = Math.floor(s / 60);
+                    return m > 0 ? `${m}m${String(s % 60).padStart(2, '0')}s` : `${s}s`;
+                  };
+                  const renderRegen = () => {
+                    if (!isTty) return;
+                    const frame = spinnerFrames[spinnerFrame++ % spinnerFrames.length];
+                    const chars = totalChars > 0 ? `\x1b[2m — ${totalChars.toLocaleString()} chars\x1b[0m` : '';
+                    process.stdout.write(`\r  \x1b[2m${frame} ${fmtRegenElapsed()} elapsed\x1b[0m${chars}`);
+                  };
+                  renderRegen();
+                  const heartbeat = setInterval(renderRegen, 250);
+                  let generated;
+                  let provider: string;
+                  try {
+                    const result = await generateNarrative(
+                      ctx.pr,
+                      freshFiles,
+                      [],
+                      config,
+                      {
+                        previousTldr: prevTldr,
+                        previousChapterTitles: prevChapterTitles,
+                      },
+                      ({ chars }) => {
+                        totalChars = chars;
+                        broadcast('narrative-progress', { chars });
+                      },
+                    );
+                    generated = result.narrative;
+                    provider = result.provider;
+                  } finally {
+                    clearInterval(heartbeat);
+                    if (isTty) process.stdout.write('\r\x1b[2K');
+                  }
                   ctx.narrative = generated;
                   await cacheNarrative(ctx.owner, ctx.repo, ctx.pr.number, ctx.headSha, generated);
                   console.log(
-                    `  \x1b[38;5;78m✓\x1b[0m ${generated.chapters.length} chapters regenerated \x1b[2mvia ${provider}\x1b[0m`,
+                    `  \x1b[38;5;78m✓\x1b[0m ${generated.chapters.length} chapters regenerated \x1b[2mvia ${provider} in ${fmtRegenElapsed()}\x1b[0m`,
                   );
                 }
 

--- a/packages/web/src/components/GeneratingScreen.tsx
+++ b/packages/web/src/components/GeneratingScreen.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { useReviewStore } from '../state/review-store';
 import { DadMark } from './DadMark';
 import { getAccentMeta } from '../lib/accents';
@@ -6,12 +7,25 @@ type Props = {
   message: string;
 };
 
+function formatElapsed(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  const m = Math.floor(s / 60);
+  return m > 0 ? `${m}m ${String(s % 60).padStart(2, '0')}s` : `${s}s`;
+}
+
 export function GeneratingScreen({ message }: Props) {
   const pr = useReviewStore((s) => s.pr);
   const files = useReviewStore((s) => s.files);
   const accent = useReviewStore((s) => s.accent);
   const progressChars = useReviewStore((s) => s.narrativeProgressChars);
   const { markBg } = getAccentMeta(accent);
+
+  const [elapsedMs, setElapsedMs] = useState(0);
+  useEffect(() => {
+    const startedAt = Date.now();
+    const id = setInterval(() => setElapsedMs(Date.now() - startedAt), 500);
+    return () => clearInterval(id);
+  }, []);
 
   return (
     <main className="flex min-h-screen flex-col items-center justify-center bg-[var(--bg-page)] px-6">
@@ -59,11 +73,10 @@ export function GeneratingScreen({ message }: Props) {
           </p>
         </div>
 
-        {progressChars > 0 && (
-          <div className="text-[12px] tabular-nums text-[var(--fg-3)]">
-            {progressChars.toLocaleString()} characters generated
-          </div>
-        )}
+        <div className="text-[12px] tabular-nums text-[var(--fg-3)]">
+          {formatElapsed(elapsedMs)} elapsed
+          {progressChars > 0 ? ` — ${progressChars.toLocaleString()} characters` : ''}
+        </div>
       </div>
     </main>
   );

--- a/packages/web/src/components/GeneratingScreen.tsx
+++ b/packages/web/src/components/GeneratingScreen.tsx
@@ -10,6 +10,7 @@ export function GeneratingScreen({ message }: Props) {
   const pr = useReviewStore((s) => s.pr);
   const files = useReviewStore((s) => s.files);
   const accent = useReviewStore((s) => s.accent);
+  const progressChars = useReviewStore((s) => s.narrativeProgressChars);
   const { markBg } = getAccentMeta(accent);
 
   return (
@@ -57,6 +58,12 @@ export function GeneratingScreen({ message }: Props) {
             {message}
           </p>
         </div>
+
+        {progressChars > 0 && (
+          <div className="text-[12px] tabular-nums text-[var(--fg-3)]">
+            {progressChars.toLocaleString()} characters generated
+          </div>
+        )}
       </div>
     </main>
   );

--- a/packages/web/src/components/StoryView.tsx
+++ b/packages/web/src/components/StoryView.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useScrollTracker } from '../hooks/useScrollTracker';
 import { normalizePath } from '../lib/paths';
 import { useReviewStore } from '../state/review-store';
@@ -164,8 +164,28 @@ function Discussion() {
   );
 }
 
+function formatElapsed(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  const m = Math.floor(s / 60);
+  return m > 0 ? `${m}m ${String(s % 60).padStart(2, '0')}s` : `${s}s`;
+}
+
 function RegeneratingBanner() {
   const regenerating = useReviewStore((s) => s.regenerating);
+  const progressChars = useReviewStore((s) => s.narrativeProgressChars);
+  const [elapsedMs, setElapsedMs] = useState(0);
+
+  useEffect(() => {
+    if (!regenerating) {
+      setElapsedMs(0);
+      return;
+    }
+    const startedAt = Date.now();
+    setElapsedMs(0);
+    const id = setInterval(() => setElapsedMs(Date.now() - startedAt), 500);
+    return () => clearInterval(id);
+  }, [regenerating]);
+
   if (!regenerating) return null;
   return (
     <div
@@ -180,6 +200,10 @@ function RegeneratingBanner() {
       </span>
       <span className="text-[13.5px] font-medium" style={{ color: 'var(--purple-12)' }}>
         New commits detected — regenerating narrative...
+      </span>
+      <span className="ml-auto text-[12px] tabular-nums" style={{ color: 'var(--purple-11)' }}>
+        {formatElapsed(elapsedMs)}
+        {progressChars > 0 ? ` — ${progressChars.toLocaleString()} chars` : ''}
       </span>
     </div>
   );

--- a/packages/web/src/hooks/useLiveStream.ts
+++ b/packages/web/src/hooks/useLiveStream.ts
@@ -103,6 +103,17 @@ export function useLiveStream() {
           makeEvent('system', `New commits detected (${data.previousSha} → ${data.newSha}). Regenerating narrative...`),
         );
         useReviewStore.getState().setRegenerating(true);
+        useReviewStore.getState().setNarrativeProgressChars(0);
+      } catch {
+        // ignore
+      }
+    };
+
+    const onNarrativeProgress = (e: MessageEvent) => {
+      try {
+        const data = JSON.parse(e.data) as { chars: number };
+        useReviewStore.getState().setNarrativeProgressChars(data.chars);
+        setLastEventAt(Date.now());
       } catch {
         // ignore
       }
@@ -128,6 +139,7 @@ export function useLiveStream() {
           state.reviews,
         );
         useReviewStore.getState().setRegenerating(false);
+        useReviewStore.getState().setNarrativeProgressChars(0);
         setLastEventAt(Date.now());
         addLiveEvent(makeEvent('system', `Narrative updated (${data.narrative.chapters.length} chapters)`));
       } catch {
@@ -142,6 +154,7 @@ export function useLiveStream() {
     es.addEventListener('reviews', onReviews as EventListener);
     es.addEventListener('pr', onPr as EventListener);
     es.addEventListener('regenerating', onRegenerating as EventListener);
+    es.addEventListener('narrative-progress', onNarrativeProgress as EventListener);
     es.addEventListener('narrative', onNarrative as EventListener);
 
     es.onopen = () => {
@@ -160,6 +173,7 @@ export function useLiveStream() {
       es.removeEventListener('reviews', onReviews as EventListener);
       es.removeEventListener('pr', onPr as EventListener);
       es.removeEventListener('regenerating', onRegenerating as EventListener);
+      es.removeEventListener('narrative-progress', onNarrativeProgress as EventListener);
       es.removeEventListener('narrative', onNarrative as EventListener);
       es.close();
     };

--- a/packages/web/src/state/review-store.ts
+++ b/packages/web/src/state/review-store.ts
@@ -136,9 +136,7 @@ function isSubmittableDraft(d: DraftComment): d is DraftComment & { path: string
 }
 
 export function pendingReviewComments(drafts: DraftComment[]): InlineComment[] {
-  return drafts
-    .filter(isSubmittableDraft)
-    .map((d) => ({ path: d.path, line: d.line, body: d.body, side: d.side }));
+  return drafts.filter(isSubmittableDraft).map((d) => ({ path: d.path, line: d.line, body: d.body, side: d.side }));
 }
 
 export const useReviewStore = create<ReviewState>((set) => ({

--- a/packages/web/src/state/review-store.ts
+++ b/packages/web/src/state/review-store.ts
@@ -59,6 +59,7 @@ type ReviewState = {
   collapseNarration: boolean;
   clusterBots: boolean;
   regenerating: boolean;
+  narrativeProgressChars: number;
 
   setData: (
     pr: PRData,
@@ -96,6 +97,7 @@ type ReviewState = {
   setCollapseNarration: (v: boolean) => void;
   setClusterBots: (v: boolean) => void;
   setRegenerating: (v: boolean) => void;
+  setNarrativeProgressChars: (chars: number) => void;
   setPr: (pr: PRData) => void;
 };
 
@@ -167,6 +169,7 @@ export const useReviewStore = create<ReviewState>((set) => ({
   collapseNarration: false,
   clusterBots: true,
   regenerating: false,
+  narrativeProgressChars: 0,
   narrationOverrides: {} as Record<string, string>,
 
   setData: (pr, narrative, files, comments, repoUrl = null, checkRuns = [], config = null, reviews = []) => {
@@ -296,6 +299,7 @@ export const useReviewStore = create<ReviewState>((set) => ({
   setCollapseNarration: (collapseNarration) => set({ collapseNarration }),
   setClusterBots: (clusterBots) => set({ clusterBots }),
   setRegenerating: (regenerating) => set({ regenerating }),
+  setNarrativeProgressChars: (narrativeProgressChars) => set({ narrativeProgressChars }),
   setPr: (pr) => set({ pr }),
   setNarrationOverride: (chapterKey: string, text: string) =>
     set((s) => ({ narrationOverrides: { ...s.narrationOverrides, [chapterKey]: text } })),


### PR DESCRIPTION
Live progress feedback during narrative generation, better narrative quality, and defensive caps for very large PRs.

## What this actually delivers

- **Live progress feedback.** The terminal now shows a spinner with elapsed time + chars-generated counter while `dad <pr>` is working. The web `GeneratingScreen` shows elapsed time too. Eliminates the "is it dead?" problem when generation runs long.
- **Better narrative quality.** A "Brevity" section in the system prompt tells the model to aim for 3-6 chapters with 1-3 sentences per narrative section, and to omit `callouts`/`missing` when they don't add real value.
- **Skip mechanical files.** Lockfiles, minified bundles, sourcemaps, and contents of `dist/`, `build/`, `node_modules/`, `vendor/`, `.next/` are filtered out of the LLM prompt. They still appear in the UI's file list — only the prompt skips them.
- **Defensive caps for huge PRs.** Per-file 800-line cap with `[FILE TRUNCATED: ...]` markers, and a global 12000-line budget for the whole diff. Files past the budget are listed but not described. Prevents pathological PRs from inflating prompt size without bound.
- **Stripped agent-loop overhead from `claude -p`.** Pass `--tools ""`, `--disable-slash-commands`, `--strict-mcp-config`, `--setting-sources ""`, `--no-session-persistence`, `--exclude-dynamic-system-prompt-sections`. Single-shot text generation doesn't need any of that machinery loaded.
- **SDK-path improvements.** Anthropic prompt caching on the system prompt; `streamText` instead of `generateText` (so chunk-by-chunk progress events fire when the SDK actually streams).
- **Streaming primitives in place.** `spawnCli` reads stdout incrementally and forwards chunks via callback. Currently silenced by `claude -p`'s stdout buffering when piped, but ready if upstream ever line-buffers (or if anyone wires up a PTY shim).

## What this does NOT deliver

**A measured latency improvement.** The original "10-15 minutes" report was a perception during a hang-like state with no progress feedback. With the heartbeat in place, real generations measured at ~6 minutes. We don't have a clean before/after on the same PR, so any speedup claim would be speculative. The agent-overhead flags *should* help, but I can't prove they did on the PR I tested.

If perf is the goal, the data we now have (heartbeat + final `in Xm Ys` log line) is the right starting point for further work.

## Things explicitly tried and reverted

- `--json-schema` on `claude -p` — measured 2.3x slowdown on the same prompt and shorter output. Combined with the retry-on-parse-failure loop, caused 8+ minute hangs.
- `--effort low` — saved ~1s on a small prompt; not worth the unmeasured quality risk on real narratives.
- Lower `maxTokens` (4096 / 8192) — a cap is only consequential when hit, and when hit it triggers the retry loop. Restored to the original 16384.

## Test plan

- [ ] `bun run lint` clean (verified)
- [ ] `bun run test` 21/21 pass (verified)
- [ ] `bun run build` succeeds (verified)
- [ ] Run `dad <pr>` against a real PR — confirm the spinner ticks elapsed time, completion log shows `in Xm Ys`, and the narrative still parses cleanly
- [ ] Run against a PR with a lockfile change — confirm lockfile is listed in the UI but not narrated as a chapter
- [ ] Run against a very large PR — confirm files past the 12000-line budget show up in the prompt's "Files entirely omitted" note rather than blowing up