### PR TITLE
feat: Add multi-line comments, concern dismissal, and AI summary drafting

### DIFF
--- a/packages/cli/src/github/client.ts
+++ b/packages/cli/src/github/client.ts
@@ -7,6 +7,8 @@ export type PostCommentOptions = {
   path?: string;
   line?: number;
   side?: 'LEFT' | 'RIGHT';
+  startLine?: number;
+  startSide?: 'LEFT' | 'RIGHT';
   commitId?: string;
   inReplyToId?: number;
 };
@@ -43,6 +45,9 @@ type GhReviewComment = {
   original_line: number | null;
   position: number | null;
   side: 'LEFT' | 'RIGHT' | null;
+  start_line: number | null;
+  original_start_line: number | null;
+  start_side: 'LEFT' | 'RIGHT' | null;
   in_reply_to_id?: number;
   diff_hunk: string;
 };
@@ -127,6 +132,8 @@ export class GitHubClient {
       path: c.path,
       line: c.line ?? c.original_line ?? undefined,
       side: c.side ?? undefined,
+      startLine: c.start_line ?? c.original_start_line ?? undefined,
+      startSide: c.start_side ?? undefined,
       inReplyToId: c.in_reply_to_id,
       diffHunk: c.diff_hunk,
     }));
@@ -185,13 +192,31 @@ export class GitHubClient {
     const isReply = !isInline && opts.inReplyToId !== undefined;
 
     if (isInline) {
+      // GitHub requires start_line < line for multi-line comments. Normalize
+      // so callers can pass either endpoint of the range as start vs end.
+      let endLine = opts.line!;
+      let endSide = opts.side ?? 'RIGHT';
+      let startLine = opts.startLine;
+      let startSide = opts.startSide;
+      if (startLine !== undefined && startLine !== endLine && startLine > endLine) {
+        const tmpLine = endLine;
+        const tmpSide = endSide;
+        endLine = startLine;
+        endSide = startSide ?? endSide;
+        startLine = tmpLine;
+        startSide = tmpSide;
+      }
       const payload: Record<string, unknown> = {
         body,
         commit_id: opts.commitId,
         path: opts.path,
-        line: opts.line,
-        side: opts.side ?? 'RIGHT',
+        line: endLine,
+        side: endSide,
       };
+      if (startLine !== undefined && startLine !== endLine) {
+        payload.start_line = startLine;
+        payload.start_side = startSide ?? endSide;
+      }
       if (opts.inReplyToId !== undefined) {
         payload.in_reply_to = opts.inReplyToId;
       }
@@ -211,6 +236,8 @@ export class GitHubClient {
         path: data.path,
         line: data.line ?? undefined,
         side: data.side ?? undefined,
+        startLine: data.start_line ?? undefined,
+        startSide: data.start_side ?? undefined,
         inReplyToId: data.in_reply_to_id,
         diffHunk: data.diff_hunk,
       };
@@ -233,6 +260,8 @@ export class GitHubClient {
         path: data.path,
         line: data.line ?? undefined,
         side: data.side ?? undefined,
+        startLine: data.start_line ?? undefined,
+        startSide: data.start_side ?? undefined,
         inReplyToId: data.in_reply_to_id,
         diffHunk: data.diff_hunk,
       };
@@ -284,15 +313,47 @@ export class GitHubClient {
     number: number,
     event: 'COMMENT' | 'APPROVE' | 'REQUEST_CHANGES',
     body?: string,
-    comments?: { path: string; line: number; body: string; side?: 'LEFT' | 'RIGHT' }[],
+    comments?: {
+      path: string;
+      line: number;
+      body: string;
+      side?: 'LEFT' | 'RIGHT';
+      startLine?: number;
+      startSide?: 'LEFT' | 'RIGHT';
+    }[],
   ): Promise<void> {
+    const ghComments = comments?.map((cm) => {
+      let endLine = cm.line;
+      let endSide: 'LEFT' | 'RIGHT' | undefined = cm.side;
+      let startLine = cm.startLine;
+      let startSide = cm.startSide;
+      if (startLine !== undefined && startLine !== endLine && startLine > endLine) {
+        const tmpLine = endLine;
+        const tmpSide = endSide;
+        endLine = startLine;
+        endSide = startSide ?? endSide;
+        startLine = tmpLine;
+        startSide = tmpSide;
+      }
+      const out: Record<string, unknown> = {
+        path: cm.path,
+        line: endLine,
+        body: cm.body,
+      };
+      if (endSide) out.side = endSide;
+      if (startLine !== undefined && startLine !== endLine) {
+        out.start_line = startLine;
+        out.start_side = startSide ?? endSide ?? 'RIGHT';
+      }
+      return out;
+    });
     await this.fetch(`/repos/${owner}/${repo}/pulls/${number}/reviews`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         event,
         body: body || undefined,
-        comments: comments?.length ? comments : undefined,
+        comments: ghComments?.length ? ghComments : undefined,
       }),
     });
   }

--- a/packages/cli/src/github/types.ts
+++ b/packages/cli/src/github/types.ts
@@ -27,6 +27,8 @@ export type PRComment = {
   path?: string;
   line?: number;
   side?: 'LEFT' | 'RIGHT';
+  startLine?: number;
+  startSide?: 'LEFT' | 'RIGHT';
   inReplyToId?: number;
   diffHunk?: string;
 };

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -28,6 +28,8 @@ type PostCommentBody = {
   path?: string;
   line?: number;
   side?: 'LEFT' | 'RIGHT';
+  startLine?: number;
+  startSide?: 'LEFT' | 'RIGHT';
   commitId?: string;
   inReplyToId?: number;
 };
@@ -139,6 +141,9 @@ export function createServer(ctx: ServerContext) {
       chapterIndex?: number;
       question?: string;
       lens?: string;
+      resolution?: 'comment' | 'approve' | 'request_changes';
+      reviewedChapters?: number[];
+      pendingComments?: { path?: string; line?: number; body?: string }[];
     };
     try {
       body = await c.req.json();
@@ -146,7 +151,61 @@ export function createServer(ctx: ServerContext) {
       return c.json({ error: 'invalid JSON body' }, 400);
     }
 
-    const { action, chapterIndex, question, lens } = body;
+    const { action } = body;
+    const config = await readConfig();
+
+    if (action === 'summarize') {
+      if (!ctx.narrative) return c.json({ error: 'narrative still generating' }, 503);
+      const resolution = body.resolution ?? 'comment';
+      const reviewed = Array.isArray(body.reviewedChapters)
+        ? body.reviewedChapters.filter((i): i is number => typeof i === 'number')
+        : [];
+      const drafts = Array.isArray(body.pendingComments) ? body.pendingComments : [];
+
+      const reviewedSection =
+        reviewed.length > 0
+          ? reviewed
+              .map((idx) => {
+                const ch = ctx.narrative!.chapters[idx];
+                if (!ch) return '';
+                return `- Chapter ${idx + 1} — ${ch.title}: ${ch.summary}`;
+              })
+              .filter(Boolean)
+              .join('\n')
+          : '(no chapters explicitly marked reviewed)';
+
+      const draftSection =
+        drafts.length > 0
+          ? drafts
+              .filter((d) => d.body)
+              .map((d) => `- ${d.path ?? 'general'}${d.line ? `:L${d.line}` : ''} — ${(d.body ?? '').slice(0, 240)}`)
+              .join('\n')
+          : '(no inline comments drafted)';
+
+      const tldr = ctx.narrative.tldr ?? '';
+      const concerns = (ctx.narrative.concerns ?? [])
+        .map((cn) => `- ${cn.category}: ${cn.question} (${cn.file}:${cn.line})`)
+        .join('\n');
+
+      const stance =
+        resolution === 'approve'
+          ? 'You are approving this PR. Open with confident endorsement, then briefly highlight the strengths the reviewer noted. If there are any minor comments, frame them as nits, not blockers.'
+          : resolution === 'request_changes'
+            ? 'You are requesting changes. Lead with the specific blockers the reviewer raised (drawn from inline comments). Be direct but constructive.'
+            : 'You are leaving general feedback without a verdict. Summarize what was reviewed and the open questions the reviewer raised.';
+
+      const systemPrompt = `You are drafting the summary comment for a GitHub PR review. ${stance} Write 2–4 sentences. First-person ("I"). Plain markdown. No headings. No bullet lists. No greetings or sign-offs.`;
+      const userPrompt = `PR TLDR:\n${tldr}\n\nReviewed chapters:\n${reviewedSection}\n\nDrafted inline comments:\n${draftSection}\n\nConcerns the narrative raised:\n${concerns || '(none)'}`;
+
+      try {
+        const result = await callAi(config, systemPrompt, userPrompt);
+        return c.json({ text: result.text.trim() });
+      } catch (err) {
+        return c.json({ error: `AI request failed: ${(err as Error).message}` }, 500);
+      }
+    }
+
+    const { chapterIndex, question, lens } = body;
 
     if (typeof chapterIndex !== 'number') {
       return c.json({ error: 'missing chapterIndex' }, 400);
@@ -177,8 +236,6 @@ export function createServer(ctx: ServerContext) {
         );
       })
       .join('\n\n');
-
-    const config = await readConfig();
 
     let systemPrompt: string;
     let userPrompt: string;
@@ -443,6 +500,8 @@ export function createServer(ctx: ServerContext) {
             path: payload.path,
             line: payload.line,
             side: payload.side ?? ('RIGHT' as const),
+            startLine: payload.startLine,
+            startSide: payload.startSide,
             commitId: payload.commitId ?? ctx.headSha,
             inReplyToId: payload.inReplyToId,
           }
@@ -460,7 +519,14 @@ export function createServer(ctx: ServerContext) {
     let payload: {
       event?: string;
       body?: string;
-      comments?: { path: string; line: number; body: string; side?: 'LEFT' | 'RIGHT' }[];
+      comments?: {
+        path: string;
+        line: number;
+        body: string;
+        side?: 'LEFT' | 'RIGHT';
+        startLine?: number;
+        startSide?: 'LEFT' | 'RIGHT';
+      }[];
     };
     try {
       payload = (await c.req.json()) as typeof payload;

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -144,6 +144,7 @@ export function createServer(ctx: ServerContext) {
       resolution?: 'comment' | 'approve' | 'request_changes';
       reviewedChapters?: number[];
       pendingComments?: { path?: string; line?: number; body?: string }[];
+      userDraft?: string;
     };
     try {
       body = await c.req.json();
@@ -194,8 +195,17 @@ export function createServer(ctx: ServerContext) {
             ? 'You are requesting changes. Lead with the specific blockers the reviewer raised (drawn from inline comments). Be direct but constructive.'
             : 'You are leaving general feedback without a verdict. Summarize what was reviewed and the open questions the reviewer raised.';
 
-      const systemPrompt = `You are drafting the summary comment for a GitHub PR review. ${stance} Write 2–4 sentences. First-person ("I"). Plain markdown. No headings. No bullet lists. No greetings or sign-offs.`;
-      const userPrompt = `PR TLDR:\n${tldr}\n\nReviewed chapters:\n${reviewedSection}\n\nDrafted inline comments:\n${draftSection}\n\nConcerns the narrative raised:\n${concerns || '(none)'}`;
+      const userDraft = typeof body.userDraft === 'string' ? body.userDraft.trim() : '';
+      const polishing = userDraft.length > 0;
+
+      // When the reviewer has already typed something, preserve their voice
+      // and points; we polish their draft. Otherwise, generate from scratch.
+      const systemPrompt = polishing
+        ? `You are polishing a reviewer's draft of a GitHub PR review summary. ${stance} Keep the reviewer's voice, structure, and any specific points they made. Tighten prose, fix grammar, and fold in 1–2 supporting details from the review context only if they directly reinforce what the reviewer wrote — do not introduce unrelated topics. Return only the polished text. 2–4 sentences. First-person ("I"). Plain markdown. No headings. No bullet lists. No greetings or sign-offs.`
+        : `You are drafting the summary comment for a GitHub PR review. ${stance} Write 2–4 sentences. First-person ("I"). Plain markdown. No headings. No bullet lists. No greetings or sign-offs.`;
+      const userPrompt = polishing
+        ? `Reviewer's draft (polish this — preserve their voice and points):\n"""\n${userDraft}\n"""\n\nReview context (use only for grammar/wording cues; do not introduce new topics):\n\nPR TLDR:\n${tldr}\n\nReviewed chapters:\n${reviewedSection}\n\nDrafted inline comments:\n${draftSection}\n\nConcerns the narrative raised:\n${concerns || '(none)'}`
+        : `PR TLDR:\n${tldr}\n\nReviewed chapters:\n${reviewedSection}\n\nDrafted inline comments:\n${draftSection}\n\nConcerns the narrative raised:\n${concerns || '(none)'}`;
 
       try {
         const result = await callAi(config, systemPrompt, userPrompt);

--- a/packages/web/src/components/Chapter.tsx
+++ b/packages/web/src/components/Chapter.tsx
@@ -336,7 +336,7 @@ export function Chapter({ index, chapter }: Props) {
   // OUTLINE STRUCTURE
   if (storyStructure === 'outline') {
     return (
-      <section data-chid={id} className={compact ? 'mb-[18px]' : 'mb-[28px]'}>
+      <section data-chid={id} className={`scroll-mt-[168px] ${compact ? 'mb-[18px]' : 'mb-[28px]'}`}>
         <button
           type="button"
           onClick={() => setOutlineOpen((v) => !v)}
@@ -375,7 +375,7 @@ export function Chapter({ index, chapter }: Props) {
   // LINEAR STRUCTURE
   if (storyStructure === 'linear') {
     return (
-      <section data-chid={id} className={compact ? 'mb-[18px]' : 'mb-[32px]'}>
+      <section data-chid={id} className={`scroll-mt-[168px] ${compact ? 'mb-[18px]' : 'mb-[32px]'}`}>
         <div className="mb-[16px] mt-[32px] grid grid-cols-[1fr_auto_1fr] items-center gap-4">
           <span className="h-px" style={{ background: 'var(--gray-a4)' }} />
           <h2 className="m-0 inline-flex items-center gap-[10px] whitespace-nowrap text-[17px] font-semibold tracking-[-0.005em] text-[var(--fg-1)]">
@@ -409,7 +409,7 @@ export function Chapter({ index, chapter }: Props) {
 
   // CHAPTERS (default) — collapsible, auto-collapses on review.
   return (
-    <section data-chid={id} className={compact ? 'mb-[18px]' : 'mb-[28px]'}>
+    <section data-chid={id} className={`scroll-mt-[168px] ${compact ? 'mb-[18px]' : 'mb-[28px]'}`}>
       <div
         className="flex cursor-pointer items-start gap-2.5 rounded-lg p-2 -ml-2 transition-colors hover:bg-[var(--gray-2)]"
         onClick={() => setCollapsed((v) => !v)}

--- a/packages/web/src/components/CodeLine.tsx
+++ b/packages/web/src/components/CodeLine.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, type MouseEvent as ReactMouseEvent } from 'react';
 import { useResolvedTheme, useReviewStore } from '../state/review-store';
 import type { DiffLine } from '../state/types';
 import { highlightLine } from '../lib/shiki';
@@ -16,10 +16,66 @@ type Props = {
   inExistingRange?: boolean;
 };
 
+/** Resolves a viewport point to the lineKey of the diff row underneath it.
+ * Used to track click-and-drag selection across the diff gutter. */
+function lineKeyAtPoint(x: number, y: number): string | null {
+  const el = document.elementFromPoint(x, y);
+  if (!el || !(el instanceof Element)) return null;
+  const row = el.closest('[data-line-key]');
+  return row?.getAttribute('data-line-key') ?? null;
+}
+
 export function CodeLine({ line, lineKey, lang, dimmed, inSelection, inExistingRange }: Props) {
   const openCommentAt = useReviewStore((s) => s.openCommentAt);
+  const startCommentDrag = useReviewStore((s) => s.startCommentDrag);
+  const updateCommentDrag = useReviewStore((s) => s.updateCommentDrag);
+  const endCommentDrag = useReviewStore((s) => s.endCommentDrag);
+  const cancelCommentDrag = useReviewStore((s) => s.cancelCommentDrag);
   const theme = useResolvedTheme();
   const ready = useHighlighter();
+
+  function onPlusMouseDown(e: ReactMouseEvent<HTMLButtonElement>) {
+    if (e.button !== 0) return; // left-click only
+    e.preventDefault();
+    if (e.shiftKey) {
+      // Keep keyboard-ish parity: shift-click still extends from openLine.
+      openCommentAt(lineKey, true);
+      return;
+    }
+    startCommentDrag(lineKey);
+    const prevUserSelect = document.body.style.userSelect;
+    document.body.style.userSelect = 'none';
+
+    function onMove(ev: MouseEvent) {
+      const key = lineKeyAtPoint(ev.clientX, ev.clientY);
+      if (key) updateCommentDrag(key);
+    }
+    function cleanup() {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+      document.removeEventListener('keydown', onKey);
+      window.removeEventListener('blur', onCancel);
+      document.body.style.userSelect = prevUserSelect;
+    }
+    function onUp() {
+      cleanup();
+      endCommentDrag();
+    }
+    function onCancel() {
+      cleanup();
+      cancelCommentDrag();
+    }
+    function onKey(ev: KeyboardEvent) {
+      if (ev.key === 'Escape') {
+        ev.preventDefault();
+        onCancel();
+      }
+    }
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+    document.addEventListener('keydown', onKey);
+    window.addEventListener('blur', onCancel);
+  }
 
   const isAdd = line.type === 'add';
   const isRem = line.type === 'remove';
@@ -98,14 +154,15 @@ export function CodeLine({ line, lineKey, lang, dimmed, inSelection, inExistingR
       {(line.lineNumber.new !== undefined || line.lineNumber.old !== undefined) && (
         <button
           type="button"
-          aria-label="Comment on line (shift-click to extend selection)"
-          title="Click to comment · Shift-click to extend selection"
-          onClick={(e) => openCommentAt(lineKey, e.shiftKey)}
+          aria-label="Comment on line (drag to select multiple lines)"
+          title="Click to comment · Drag to select multiple lines"
+          onMouseDown={onPlusMouseDown}
           className="ln-comment absolute z-10 flex h-[17px] w-[17px] items-center justify-center rounded-[4px] text-white"
           style={{
             left: '76px',
             top: '1px',
             background: 'var(--purple-9)',
+            cursor: 'grab',
           }}
         >
           <IconPlus className="h-[10px] w-[10px]" />

--- a/packages/web/src/components/CodeLine.tsx
+++ b/packages/web/src/components/CodeLine.tsx
@@ -10,10 +10,14 @@ type Props = {
   lineKey: string;
   lang: string;
   dimmed?: boolean;
+  /** True when this line falls within an in-progress multi-line selection. */
+  inSelection?: boolean;
+  /** True when this line is covered by an existing multi-line comment. */
+  inExistingRange?: boolean;
 };
 
-export function CodeLine({ line, lineKey, lang, dimmed }: Props) {
-  const setOpenLine = useReviewStore((s) => s.setOpenLine);
+export function CodeLine({ line, lineKey, lang, dimmed, inSelection, inExistingRange }: Props) {
+  const openCommentAt = useReviewStore((s) => s.openCommentAt);
   const theme = useResolvedTheme();
   const ready = useHighlighter();
 
@@ -25,7 +29,13 @@ export function CodeLine({ line, lineKey, lang, dimmed }: Props) {
   const highlighted = useMemo(() => highlightLine(line.content, lang, theme), [line.content, lang, theme, ready]);
 
   // Row background tints (matching design CSS: rgba(41,163,131,0.08) / rgba(229,70,102,0.08))
-  const rowBg = isAdd ? 'rgba(41, 163, 131, 0.08)' : isRem ? 'rgba(229, 70, 102, 0.08)' : 'var(--bg-panel)';
+  const rowBg = inSelection
+    ? 'var(--purple-a3)'
+    : isAdd
+      ? 'rgba(41, 163, 131, 0.08)'
+      : isRem
+        ? 'rgba(229, 70, 102, 0.08)'
+        : 'var(--bg-panel)';
 
   // Line number tints (slightly more saturated)
   const lnBg = isAdd ? 'rgba(41, 163, 131, 0.16)' : isRem ? 'rgba(229, 70, 102, 0.16)' : 'var(--gray-1)';
@@ -46,6 +56,7 @@ export function CodeLine({ line, lineKey, lang, dimmed }: Props) {
         background: rowBg,
         color: 'var(--gray-12)',
         minWidth: 'max-content',
+        boxShadow: inExistingRange ? 'inset 3px 0 0 var(--purple-9)' : undefined,
       }}
     >
       <span
@@ -87,8 +98,9 @@ export function CodeLine({ line, lineKey, lang, dimmed }: Props) {
       {(line.lineNumber.new !== undefined || line.lineNumber.old !== undefined) && (
         <button
           type="button"
-          aria-label="Comment on line"
-          onClick={() => setOpenLine(lineKey)}
+          aria-label="Comment on line (shift-click to extend selection)"
+          title="Click to comment · Shift-click to extend selection"
+          onClick={(e) => openCommentAt(lineKey, e.shiftKey)}
           className="ln-comment absolute z-10 flex h-[17px] w-[17px] items-center justify-center rounded-[4px] text-white"
           style={{
             left: '76px',

--- a/packages/web/src/components/CodeLine.tsx
+++ b/packages/web/src/components/CodeLine.tsx
@@ -37,7 +37,8 @@ export function CodeLine({ line, lineKey, lang, dimmed }: Props) {
 
   return (
     <div
-      className={`code-line group relative grid items-stretch font-mono text-[12.75px] leading-[19px] hover:bg-[var(--gray-2)]${
+      data-line-key={lineKey}
+      className={`code-line group relative grid items-stretch font-mono text-[12.75px] leading-[19px] scroll-mt-[180px] hover:bg-[var(--gray-2)]${
         dimmed ? ' opacity-40' : ''
       }`}
       style={{

--- a/packages/web/src/components/Comment.tsx
+++ b/packages/web/src/components/Comment.tsx
@@ -201,7 +201,23 @@ export function Comment({ comment, replies = [], isReply = false, showFilePath =
             style={{ background: 'var(--gray-3)', color: 'var(--fg-3)' }}
           >
             {comment.path}
-            {comment.line !== undefined && <span>:L{comment.line}</span>}
+            {comment.line !== undefined &&
+              (comment.startLine !== undefined && comment.startLine !== comment.line ? (
+                <span>
+                  :L{Math.min(comment.startLine, comment.line)}–L{Math.max(comment.startLine, comment.line)}
+                </span>
+              ) : (
+                <span>:L{comment.line}</span>
+              ))}
+          </div>
+        )}
+        {!showFilePath && comment.startLine !== undefined && comment.line !== undefined && comment.startLine !== comment.line && (
+          <div
+            className="mt-1 mb-1 inline-flex items-center gap-1 rounded-[3px] px-1.5 py-px font-mono text-[11px]"
+            style={{ background: 'var(--purple-3)', color: 'var(--purple-11)' }}
+            title="Multi-line comment"
+          >
+            L{Math.min(comment.startLine, comment.line)}–L{Math.max(comment.startLine, comment.line)}
           </div>
         )}
         <div className="mt-[3px] text-[13.5px] leading-[19px] text-[var(--fg-1)]">

--- a/packages/web/src/components/Comment.tsx
+++ b/packages/web/src/components/Comment.tsx
@@ -211,15 +211,18 @@ export function Comment({ comment, replies = [], isReply = false, showFilePath =
               ))}
           </div>
         )}
-        {!showFilePath && comment.startLine !== undefined && comment.line !== undefined && comment.startLine !== comment.line && (
-          <div
-            className="mt-1 mb-1 inline-flex items-center gap-1 rounded-[3px] px-1.5 py-px font-mono text-[11px]"
-            style={{ background: 'var(--purple-3)', color: 'var(--purple-11)' }}
-            title="Multi-line comment"
-          >
-            L{Math.min(comment.startLine, comment.line)}–L{Math.max(comment.startLine, comment.line)}
-          </div>
-        )}
+        {!showFilePath &&
+          comment.startLine !== undefined &&
+          comment.line !== undefined &&
+          comment.startLine !== comment.line && (
+            <div
+              className="mt-1 mb-1 inline-flex items-center gap-1 rounded-[3px] px-1.5 py-px font-mono text-[11px]"
+              style={{ background: 'var(--purple-3)', color: 'var(--purple-11)' }}
+              title="Multi-line comment"
+            >
+              L{Math.min(comment.startLine, comment.line)}–L{Math.max(comment.startLine, comment.line)}
+            </div>
+          )}
         <div className="mt-[3px] text-[13.5px] leading-[19px] text-[var(--fg-1)]">
           <Markdown source={comment.body} />
         </div>

--- a/packages/web/src/components/CommentThread.tsx
+++ b/packages/web/src/components/CommentThread.tsx
@@ -204,9 +204,13 @@ export function CommentThread({
       })}
       <div className="rounded-lg border border-[var(--border)] bg-[var(--bg-panel)] p-2">
         {startLine !== undefined && line !== undefined && startLine !== line && (
-          <div className="mb-2 inline-flex items-center gap-1.5 rounded-[4px] px-2 py-0.5 font-mono text-[11px]"
-               style={{ background: 'var(--purple-3)', color: 'var(--purple-11)' }}>
-            <span>L{Math.min(startLine, line)}–L{Math.max(startLine, line)}</span>
+          <div
+            className="mb-2 inline-flex items-center gap-1.5 rounded-[4px] px-2 py-0.5 font-mono text-[11px]"
+            style={{ background: 'var(--purple-3)', color: 'var(--purple-11)' }}
+          >
+            <span>
+              L{Math.min(startLine, line)}–L{Math.max(startLine, line)}
+            </span>
             <span className="font-sans text-[10.5px] uppercase tracking-[0.05em]">multi-line</span>
           </div>
         )}

--- a/packages/web/src/components/CommentThread.tsx
+++ b/packages/web/src/components/CommentThread.tsx
@@ -10,6 +10,8 @@ type Props = {
   path?: string;
   line?: number;
   side?: 'LEFT' | 'RIGHT';
+  startLine?: number;
+  startSide?: 'LEFT' | 'RIGHT';
   chapterIndex?: number;
   inReplyToId?: number;
   onClose?: () => void;
@@ -59,7 +61,18 @@ function draftKeyFor(path?: string, line?: number, chapterIndex?: number): strin
   return null;
 }
 
-export function CommentThread({ comments, path, line, side, chapterIndex, inReplyToId, onClose, autoFocus }: Props) {
+export function CommentThread({
+  comments,
+  path,
+  line,
+  side,
+  startLine,
+  startSide,
+  chapterIndex,
+  inReplyToId,
+  onClose,
+  autoFocus,
+}: Props) {
   const { postComment } = useComments();
   const drafts = useReviewStore((s) => s.drafts);
   const addDraft = useReviewStore((s) => s.addDraft);
@@ -135,6 +148,8 @@ export function CommentThread({ comments, path, line, side, chapterIndex, inRepl
       path,
       line,
       side,
+      startLine,
+      startSide,
       chapterIndex,
     });
     setDraftSavedAt(Date.now());
@@ -155,7 +170,7 @@ export function CommentThread({ comments, path, line, side, chapterIndex, inRepl
     setSubmitting(true);
     setError(null);
     try {
-      await postComment(trimmed, { path, line, side, inReplyToId: replyTarget });
+      await postComment(trimmed, { path, line, side, startLine, startSide, inReplyToId: replyTarget });
       setBody('');
       clearDraftForKey();
       onClose?.();
@@ -188,6 +203,13 @@ export function CommentThread({ comments, path, line, side, chapterIndex, inRepl
         );
       })}
       <div className="rounded-lg border border-[var(--border)] bg-[var(--bg-panel)] p-2">
+        {startLine !== undefined && line !== undefined && startLine !== line && (
+          <div className="mb-2 inline-flex items-center gap-1.5 rounded-[4px] px-2 py-0.5 font-mono text-[11px]"
+               style={{ background: 'var(--purple-3)', color: 'var(--purple-11)' }}>
+            <span>L{Math.min(startLine, line)}–L{Math.max(startLine, line)}</span>
+            <span className="font-sans text-[10.5px] uppercase tracking-[0.05em]">multi-line</span>
+          </div>
+        )}
         {hasConflict && (
           <div className="mb-2 flex items-center justify-between gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-900/30 dark:text-amber-200">
             <span>

--- a/packages/web/src/components/ConcernsList.tsx
+++ b/packages/web/src/components/ConcernsList.tsx
@@ -234,7 +234,10 @@ function ConcernRow({ concern, onDismiss }: { concern: Concern; onDismiss: () =>
           {error && <div className="mt-1 text-sm text-red-600 dark:text-red-400">{error}</div>}
           <div className="mt-2 flex items-center justify-between gap-2">
             <span className="text-[11px] text-[var(--fg-3)]">
-              Will post inline at <span className="font-mono">{concern.file}:{concern.line}</span>
+              Will post inline at{' '}
+              <span className="font-mono">
+                {concern.file}:{concern.line}
+              </span>
             </span>
             <div className="flex items-center gap-2">
               <button
@@ -341,11 +344,7 @@ export function ConcernsList() {
           const key = concernKey(concern);
           const isDismissed = dismissed.has(key);
           return (
-            <div
-              key={key}
-              className="transition-opacity"
-              style={{ opacity: isDismissed ? 0.45 : 1 }}
-            >
+            <div key={key} className="transition-opacity" style={{ opacity: isDismissed ? 0.45 : 1 }}>
               <ConcernRow concern={concern} onDismiss={() => dismiss(concern)} />
             </div>
           );

--- a/packages/web/src/components/ConcernsList.tsx
+++ b/packages/web/src/components/ConcernsList.tsx
@@ -86,7 +86,7 @@ function findHunkForConcern(files: DiffFile[], file: string, line: number) {
   return null;
 }
 
-function ConcernRow({ concern, onDismiss }: { concern: Concern; onDismiss: () => void }) {
+function ConcernRow({ concern, onDismiss, dimmed }: { concern: Concern; onDismiss: () => void; dimmed?: boolean }) {
   const files = useReviewStore((s) => s.files);
   const addDraft = useReviewStore((s) => s.addDraft);
   const drafts = useReviewStore((s) => s.drafts);
@@ -166,8 +166,12 @@ function ConcernRow({ concern, onDismiss }: { concern: Concern; onDismiss: () =>
 
   return (
     <li
-      className="flex flex-col gap-1.5 rounded-[8px] px-3.5 py-3"
-      style={{ background: 'var(--bg-panel)', boxShadow: 'inset 0 0 0 1px var(--gray-a5)' }}
+      className="flex flex-col gap-1.5 rounded-[8px] px-3.5 py-3 transition-opacity"
+      style={{
+        background: 'var(--bg-panel)',
+        boxShadow: 'inset 0 0 0 1px var(--gray-a5)',
+        opacity: dimmed ? 0.45 : 1,
+      }}
     >
       <div className="flex flex-wrap items-center gap-2">
         <CategoryBadge category={concern.category} />
@@ -343,11 +347,7 @@ export function ConcernsList() {
         {renderList.map((concern) => {
           const key = concernKey(concern);
           const isDismissed = dismissed.has(key);
-          return (
-            <div key={key} className="transition-opacity" style={{ opacity: isDismissed ? 0.45 : 1 }}>
-              <ConcernRow concern={concern} onDismiss={() => dismiss(concern)} />
-            </div>
-          );
+          return <ConcernRow key={key} concern={concern} onDismiss={() => dismiss(concern)} dimmed={isDismissed} />;
         })}
       </ul>
     </section>

--- a/packages/web/src/components/ConcernsList.tsx
+++ b/packages/web/src/components/ConcernsList.tsx
@@ -1,6 +1,9 @@
+import { useEffect, useMemo, useState, type KeyboardEvent } from 'react';
+import { useComments } from '../hooks/useComments';
+import { normalizePath } from '../lib/paths';
 import { useReviewStore } from '../state/review-store';
-import type { Concern, ConcernCategory } from '../state/types';
-import { IconChat } from './Icons';
+import type { Concern, ConcernCategory, DiffFile } from '../state/types';
+import { IconChat, IconCheck, IconX } from './Icons';
 
 const CATEGORY_LABELS: Record<ConcernCategory, string> = {
   logic: 'Logic',
@@ -37,7 +40,130 @@ function CategoryBadge({ category }: { category: ConcernCategory }) {
   );
 }
 
-function ConcernRow({ concern }: { concern: Concern }) {
+function dismissedKey(prNumber: number | undefined): string | null {
+  if (prNumber == null) return null;
+  return `diffdad.concernsDismissed.${prNumber}`;
+}
+
+function loadDismissed(prNumber: number | undefined): Set<string> {
+  const key = dismissedKey(prNumber);
+  if (!key) return new Set();
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw) {
+      const arr = JSON.parse(raw);
+      if (Array.isArray(arr)) return new Set(arr.filter((x): x is string => typeof x === 'string'));
+    }
+  } catch {}
+  return new Set();
+}
+
+function saveDismissed(prNumber: number | undefined, set: Set<string>) {
+  const key = dismissedKey(prNumber);
+  if (!key) return;
+  try {
+    localStorage.setItem(key, JSON.stringify([...set]));
+  } catch {}
+}
+
+function concernKey(c: Concern): string {
+  return `${c.file}:${c.line}:${c.question.slice(0, 80)}`;
+}
+
+function findHunkForConcern(files: DiffFile[], file: string, line: number) {
+  const norm = normalizePath(file);
+  const diffFile = files.find((f) => normalizePath(f.file) === norm);
+  if (!diffFile) return null;
+  for (let i = 0; i < diffFile.hunks.length; i++) {
+    const h = diffFile.hunks[i]!;
+    const start = h.newStart;
+    const end = start + Math.max(h.newCount - 1, 0);
+    if (line >= start && line <= end) {
+      const lineIdx = h.lines.findIndex((l) => l.lineNumber.new === line);
+      return { file: diffFile.file, hunkIndex: i, lineIdx: lineIdx >= 0 ? lineIdx : 0 };
+    }
+  }
+  return null;
+}
+
+function ConcernRow({ concern, onDismiss }: { concern: Concern; onDismiss: () => void }) {
+  const files = useReviewStore((s) => s.files);
+  const addDraft = useReviewStore((s) => s.addDraft);
+  const drafts = useReviewStore((s) => s.drafts);
+  const setOpenLine = useReviewStore((s) => s.setOpenLine);
+  const { postComment } = useComments();
+
+  const [open, setOpen] = useState(false);
+  const [body, setBody] = useState(`${concern.question}`);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [posted, setPosted] = useState(false);
+  const [drafted, setDrafted] = useState(false);
+
+  const hunkRef = useMemo(
+    () => findHunkForConcern(files, concern.file, concern.line),
+    [files, concern.file, concern.line],
+  );
+
+  const draftKey = `${concern.file}:${concern.line}`;
+  const hasDraftForLine = useMemo(
+    () => drafts.some((d) => d.path === concern.file && d.line === concern.line),
+    [drafts, concern.file, concern.line],
+  );
+
+  function jumpToLine() {
+    if (!hunkRef) return;
+    const lineKey = `${hunkRef.file}:${hunkRef.hunkIndex}:${hunkRef.lineIdx}`;
+    setOpenLine(lineKey);
+    // Defer scrolling so the thread mounts before we measure.
+    requestAnimationFrame(() => {
+      const lineEl = document.querySelector(`[data-line-key="${CSS.escape(lineKey)}"]`);
+      if (lineEl) lineEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    });
+  }
+
+  async function handlePost() {
+    if (submitting) return;
+    const trimmed = body.trim();
+    if (!trimmed) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await postComment(trimmed, { path: concern.file, line: concern.line, side: 'RIGHT' });
+      setPosted(true);
+      setOpen(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to post');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function handleAddToReview() {
+    const trimmed = body.trim();
+    if (!trimmed) return;
+    addDraft({
+      id: `draft-concern-${draftKey}-${Date.now()}`,
+      body: trimmed,
+      path: concern.file,
+      line: concern.line,
+      side: 'RIGHT',
+    });
+    setDrafted(true);
+    setOpen(false);
+  }
+
+  function onKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+      e.preventDefault();
+      void handlePost();
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      setOpen(false);
+    }
+  }
+
   return (
     <li
       className="flex flex-col gap-1.5 rounded-[8px] px-3.5 py-3"
@@ -45,20 +171,130 @@ function ConcernRow({ concern }: { concern: Concern }) {
     >
       <div className="flex flex-wrap items-center gap-2">
         <CategoryBadge category={concern.category} />
-        <span className="font-mono text-[11.5px] text-[var(--fg-3)]">
+        <button
+          type="button"
+          onClick={jumpToLine}
+          disabled={!hunkRef}
+          className="font-mono text-[11.5px] text-[var(--fg-3)] transition-colors enabled:hover:text-[var(--brand)] disabled:cursor-default"
+          title={hunkRef ? 'Jump to line' : 'Line not found in diff'}
+        >
           {concern.file}:{concern.line}
+        </button>
+        <span className="ml-auto inline-flex items-center gap-1">
+          {(posted || drafted) && (
+            <span
+              className="inline-flex items-center gap-1 rounded-[4px] px-1.5 py-0.5 text-[10.5px] font-medium"
+              style={{ background: 'var(--green-3)', color: 'var(--green-11)' }}
+            >
+              <IconCheck className="h-[10px] w-[10px]" />
+              {posted ? 'Posted' : 'Added to review'}
+            </span>
+          )}
+          {!posted && hasDraftForLine && !drafted && (
+            <span
+              className="inline-flex items-center gap-1 rounded-[4px] px-1.5 py-0.5 text-[10.5px] font-medium"
+              style={{ background: 'var(--gray-3)', color: 'var(--fg-2)' }}
+            >
+              draft on this line
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            className="inline-flex items-center gap-1 rounded-[4px] px-1.5 py-0.5 text-[11px] font-medium hover:bg-[var(--gray-a3)]"
+            style={open ? { background: 'var(--gray-a3)', color: 'var(--fg-1)' } : { color: 'var(--fg-3)' }}
+          >
+            <IconChat className="h-[10px] w-[10px]" />
+            {open ? 'Cancel' : 'Comment'}
+          </button>
+          <button
+            type="button"
+            onClick={onDismiss}
+            title="Dismiss this concern"
+            aria-label="Dismiss"
+            className="inline-flex items-center justify-center rounded-[4px] p-1 text-[var(--fg-3)] hover:bg-[var(--gray-a3)] hover:text-[var(--fg-1)]"
+          >
+            <IconX className="h-[11px] w-[11px]" />
+          </button>
         </span>
       </div>
       <div className="text-[14px] font-medium leading-[20px] text-[var(--fg-1)]">{concern.question}</div>
       {concern.why ? <div className="text-[12.5px] leading-[18px] text-[var(--fg-3)]">{concern.why}</div> : null}
+      {open && (
+        <div className="mt-2 rounded-md border border-[var(--border)] bg-[var(--bg-panel)] p-2">
+          <textarea
+            autoFocus
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            onKeyDown={onKeyDown}
+            placeholder="Write a comment..."
+            className="block w-full resize-y rounded-md border border-[var(--border)] bg-transparent px-3 py-2 text-sm text-[var(--fg-1)] outline-none focus:border-[var(--brand)]"
+            rows={3}
+          />
+          {error && <div className="mt-1 text-sm text-red-600 dark:text-red-400">{error}</div>}
+          <div className="mt-2 flex items-center justify-between gap-2">
+            <span className="text-[11px] text-[var(--fg-3)]">
+              Will post inline at <span className="font-mono">{concern.file}:{concern.line}</span>
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                disabled={!body.trim()}
+                onClick={handleAddToReview}
+                className="rounded-md border border-[var(--border-strong)] bg-[var(--bg-panel)] px-3 py-1 text-sm font-medium text-[var(--fg-1)] shadow-sm hover:bg-[var(--bg-subtle)] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Add to review
+              </button>
+              <button
+                type="button"
+                disabled={!body.trim() || submitting}
+                onClick={() => void handlePost()}
+                className="rounded-md bg-[var(--brand)] px-3 py-1 text-sm font-semibold text-white shadow-sm hover:bg-[var(--brand-hover)] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {submitting ? 'Posting...' : 'Post comment'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </li>
   );
 }
 
 export function ConcernsList() {
   const narrative = useReviewStore((s) => s.narrative);
+  const prNumber = useReviewStore((s) => s.pr?.number);
   const concerns = narrative?.concerns ?? [];
+
+  const [dismissed, setDismissed] = useState<Set<string>>(() => loadDismissed(prNumber));
+  const [showDismissed, setShowDismissed] = useState(false);
+
+  useEffect(() => {
+    setDismissed(loadDismissed(prNumber));
+  }, [prNumber]);
+
+  function dismiss(c: Concern) {
+    setDismissed((prev) => {
+      const next = new Set(prev);
+      next.add(concernKey(c));
+      saveDismissed(prNumber, next);
+      return next;
+    });
+  }
+
+  function undismissAll() {
+    setDismissed(() => {
+      const next = new Set<string>();
+      saveDismissed(prNumber, next);
+      return next;
+    });
+  }
+
   if (concerns.length === 0) return null;
+
+  const visible = concerns.filter((c) => !dismissed.has(concernKey(c)));
+  const dismissedCount = concerns.length - visible.length;
+  const renderList = showDismissed ? concerns : visible;
 
   return (
     <section className="mb-[28px]">
@@ -72,14 +308,48 @@ export function ConcernsList() {
         <div className="min-w-0 flex-1">
           <h2 className="m-0 text-[18px] font-bold leading-6 tracking-[-0.01em] text-[var(--fg-1)]">Things to check</h2>
           <p className="mt-[2px] text-[12.5px] text-[var(--fg-3)]">
-            {concerns.length} {concerns.length === 1 ? 'question' : 'questions'} a careful reviewer would ask
+            {visible.length} {visible.length === 1 ? 'question' : 'questions'} a careful reviewer would ask
+            {dismissedCount > 0 && (
+              <>
+                {' · '}
+                <button
+                  type="button"
+                  onClick={() => setShowDismissed((v) => !v)}
+                  className="underline-offset-2 hover:text-[var(--fg-1)] hover:underline"
+                >
+                  {showDismissed ? 'Hide' : 'Show'} {dismissedCount} dismissed
+                </button>
+                {showDismissed && (
+                  <>
+                    {' · '}
+                    <button
+                      type="button"
+                      onClick={undismissAll}
+                      className="underline-offset-2 hover:text-[var(--fg-1)] hover:underline"
+                    >
+                      Restore all
+                    </button>
+                  </>
+                )}
+              </>
+            )}
           </p>
         </div>
       </div>
       <ul className="ml-[34px] list-none space-y-2 p-0">
-        {concerns.map((concern, i) => (
-          <ConcernRow key={i} concern={concern} />
-        ))}
+        {renderList.map((concern) => {
+          const key = concernKey(concern);
+          const isDismissed = dismissed.has(key);
+          return (
+            <div
+              key={key}
+              className="transition-opacity"
+              style={{ opacity: isDismissed ? 0.45 : 1 }}
+            >
+              <ConcernRow concern={concern} onDismiss={() => dismiss(concern)} />
+            </div>
+          );
+        })}
       </ul>
     </section>
   );

--- a/packages/web/src/components/ErrorBoundary.tsx
+++ b/packages/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,60 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+type Props = {
+  children: ReactNode;
+};
+
+type State = {
+  error: Error | null;
+};
+
+/** Backstop for render errors thrown anywhere below it. Without this, an
+ * unhandled error during render unmounts the entire React tree and the user
+ * sees a blank white page — most often during narrative streaming when a
+ * partial chapter object is missing a field a renderer expected. We catch,
+ * log, and offer a "try again" affordance so the user never has to hard
+ * refresh to recover. */
+export class ErrorBoundary extends Component<Props, State> {
+  override state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    // eslint-disable-next-line no-console
+    console.error('Diff Dad render error:', error, info);
+  }
+
+  reset = () => {
+    this.setState({ error: null });
+  };
+
+  override render() {
+    if (!this.state.error) return this.props.children;
+
+    const message = this.state.error.message || String(this.state.error);
+    return (
+      <main
+        role="alert"
+        className="flex min-h-screen items-center justify-center bg-[var(--bg-page)] px-6 text-[var(--fg-2)]"
+      >
+        <div className="max-w-[420px] text-center">
+          <p className="text-base font-semibold text-[var(--fg-1)]">Something glitched while rendering.</p>
+          <p className="mt-2 text-sm text-[var(--fg-3)]">{message}</p>
+          <p className="mt-4 text-xs text-[var(--fg-3)]">
+            Your data is fine — this happens occasionally during narrative streaming. Try again, or refresh if it
+            persists.
+          </p>
+          <button
+            type="button"
+            onClick={this.reset}
+            className="mt-5 inline-flex items-center gap-1.5 rounded-[6px] bg-[var(--brand)] px-3 py-1.5 text-[12.5px] font-bold text-white hover:bg-[var(--brand-hover)]"
+          >
+            Try again
+          </button>
+        </div>
+      </main>
+    );
+  }
+}

--- a/packages/web/src/components/Hunk.tsx
+++ b/packages/web/src/components/Hunk.tsx
@@ -390,8 +390,7 @@ function HunkLines({
       const line = hunk.lines[i]!;
       const lineKey = `${file}:${hunkIndex}:${i}`;
       const lineComments: PRComment[] = comments.filter((c) => commentLineMap.get(c.id) === i);
-      const inSelection =
-        rangeStartIdx !== null && rangeEndIdx !== null && i >= rangeStartIdx && i <= rangeEndIdx;
+      const inSelection = rangeStartIdx !== null && rangeEndIdx !== null && i >= rangeStartIdx && i <= rangeEndIdx;
       const isOpenLine = openLine === lineKey;
       // The thread anchors wherever the user just clicked (`openLine`). When a
       // multi-line range exists, the OTHER end of the range becomes the

--- a/packages/web/src/components/Hunk.tsx
+++ b/packages/web/src/components/Hunk.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useReviewStore } from '../state/review-store';
 import type { DiffHunk, PRComment } from '../state/types';
 import { CodeLine } from './CodeLine';
@@ -479,6 +479,7 @@ export function Hunk({ file, hunk, isNewFile, hunkIndex, highlight }: Props) {
   const commentRangeStart = useReviewStore((s) => s.commentRangeStart);
   const comments = useReviewStore((s) => s.comments);
   const setOpenLine = useReviewStore((s) => s.setOpenLine);
+  const clearCommentRange = useReviewStore((s) => s.clearCommentRange);
   const repoUrl = useReviewStore((s) => s.repoUrl);
   const headSha = useReviewStore((s) => s.pr?.headSha ?? null);
   const clusterBots = useReviewStore((s) => s.clusterBots);
@@ -486,7 +487,11 @@ export function Hunk({ file, hunk, isNewFile, hunkIndex, highlight }: Props) {
 
   // Resolve a multi-line selection to local indices within this hunk.
   // `openLine` and `commentRangeStart` are line keys; we match by file +
-  // hunkIndex to ignore selections in other hunks.
+  // hunkIndex to ignore selections in other hunks. Multi-line comments must
+  // live on a single diff side (LEFT/old or RIGHT/new) — GitHub stores
+  // start_line/line on the same side and old vs new line numbers aren't
+  // comparable. If the user shift-clicks across sides, drop the range and
+  // fall back to a single-line comment at the most recently clicked line.
   const { rangeStartIdx, rangeEndIdx } = useMemo(() => {
     const myPrefix = `${file}:${hunkIndex}:`;
     if (!openLine || !openLine.startsWith(myPrefix)) {
@@ -500,8 +505,27 @@ export function Hunk({ file, hunk, isNewFile, hunkIndex, highlight }: Props) {
     if (Number.isNaN(a) || Number.isNaN(b)) {
       return { rangeStartIdx: null, rangeEndIdx: null };
     }
+    const lineA = hunk.lines[a];
+    const lineB = hunk.lines[b];
+    if (!lineA || !lineB) {
+      return { rangeStartIdx: null, rangeEndIdx: null };
+    }
+    const sideOf = (t: typeof lineA.type): 'LEFT' | 'RIGHT' => (t === 'remove' ? 'LEFT' : 'RIGHT');
+    if (sideOf(lineA.type) !== sideOf(lineB.type)) {
+      return { rangeStartIdx: null, rangeEndIdx: null };
+    }
     return { rangeStartIdx: Math.min(a, b), rangeEndIdx: Math.max(a, b) };
-  }, [openLine, commentRangeStart, file, hunkIndex]);
+  }, [openLine, commentRangeStart, file, hunkIndex, hunk.lines]);
+
+  // If the user shift-clicked across sides we silently dropped the range
+  // above. Clear the stale anchor so a subsequent same-side shift-click
+  // starts fresh from the visible openLine, not the now-invisible anchor.
+  useEffect(() => {
+    if (!openLine || !commentRangeStart) return;
+    const myPrefix = `${file}:${hunkIndex}:`;
+    if (!openLine.startsWith(myPrefix) || !commentRangeStart.startsWith(myPrefix)) return;
+    if (rangeStartIdx === null) clearCommentRange();
+  }, [openLine, commentRangeStart, rangeStartIdx, file, hunkIndex, clearCommentRange]);
 
   const rangeStart = hunk.oldStart;
   const rangeEnd = hunk.oldStart + Math.max(hunk.oldCount, 0);

--- a/packages/web/src/components/Hunk.tsx
+++ b/packages/web/src/components/Hunk.tsx
@@ -22,6 +22,8 @@ function CollapsibleThread({
   file,
   lineNumber,
   side,
+  startLineNumber,
+  startSide,
   isNewThread,
   onClose,
 }: {
@@ -29,6 +31,8 @@ function CollapsibleThread({
   file: string;
   lineNumber: number | undefined;
   side: 'LEFT' | 'RIGHT';
+  startLineNumber?: number;
+  startSide?: 'LEFT' | 'RIGHT';
   isNewThread: boolean;
   onClose: () => void;
 }) {
@@ -72,6 +76,8 @@ function CollapsibleThread({
         path={file}
         line={lineNumber}
         side={side}
+        startLine={startLineNumber}
+        startSide={startSide}
         onClose={onClose}
         autoFocus={isNewThread}
       />
@@ -280,6 +286,8 @@ function HunkLines({
   openLine,
   setOpenLine,
   clusteredIds,
+  rangeStartIdx,
+  rangeEndIdx,
 }: {
   file: string;
   hunk: DiffHunk;
@@ -290,6 +298,8 @@ function HunkLines({
   openLine: string | null;
   setOpenLine: (key: string | null) => void;
   clusteredIds: Set<number>;
+  rangeStartIdx: number | null;
+  rangeEndIdx: number | null;
 }) {
   const normFile = normalizePath(file);
 
@@ -324,7 +334,35 @@ function HunkLines({
     return map;
   }, [hunk.lines, comments, normFile, clusteredIds]);
 
-  const commentLineIndices = useMemo(() => new Set(commentLineMap.values()), [commentLineMap]);
+  // Indices covered by an existing multi-line comment (start..end). Used to
+  // pin those lines in the fold builder and to show a subtle left-border tint
+  // so reviewers see the original range without needing to expand context.
+  const existingMultiLineRanges = useMemo(() => {
+    const set = new Set<number>();
+    for (const c of comments) {
+      if (normalizePath(c.path) !== normFile) continue;
+      if (c.startLine === undefined || c.line === undefined) continue;
+      if (c.startLine === c.line) continue;
+      const lo = Math.min(c.startLine, c.line);
+      const hi = Math.max(c.startLine, c.line);
+      const onLeft = c.side === 'LEFT';
+      for (let i = 0; i < hunk.lines.length; i++) {
+        const ln = hunk.lines[i]!.lineNumber;
+        const num = onLeft ? ln.old : ln.new;
+        if (num !== undefined && num >= lo && num <= hi) set.add(i);
+      }
+    }
+    return set;
+  }, [comments, hunk.lines, normFile]);
+
+  const commentLineIndices = useMemo(() => {
+    const set = new Set(commentLineMap.values());
+    if (rangeStartIdx !== null && rangeEndIdx !== null) {
+      for (let i = rangeStartIdx; i <= rangeEndIdx; i++) set.add(i);
+    }
+    for (const i of existingMultiLineRanges) set.add(i);
+    return set;
+  }, [commentLineMap, rangeStartIdx, rangeEndIdx, existingMultiLineRanges]);
 
   const openLineKeys = useMemo(() => {
     const set = new Set<string>();
@@ -352,10 +390,40 @@ function HunkLines({
       const line = hunk.lines[i]!;
       const lineKey = `${file}:${hunkIndex}:${i}`;
       const lineComments: PRComment[] = comments.filter((c) => commentLineMap.get(c.id) === i);
-      const hasThread = openLine === lineKey || lineComments.length > 0;
+      const inSelection =
+        rangeStartIdx !== null && rangeEndIdx !== null && i >= rangeStartIdx && i <= rangeEndIdx;
+      const isOpenLine = openLine === lineKey;
+      // The thread anchors wherever the user just clicked (`openLine`). When a
+      // multi-line range exists, the OTHER end of the range becomes the
+      // `startLine` so GitHub gets a valid (start_line, line) pair.
+      const oppositeIdx =
+        isOpenLine && rangeStartIdx !== null && rangeEndIdx !== null
+          ? i === rangeEndIdx
+            ? rangeStartIdx
+            : rangeEndIdx
+          : null;
+      const oppositeLine = oppositeIdx !== null ? hunk.lines[oppositeIdx] : undefined;
+      const startLineNumber = oppositeLine
+        ? oppositeLine.type === 'remove'
+          ? oppositeLine.lineNumber.old
+          : oppositeLine.lineNumber.new
+        : undefined;
+      const startSideForThread = oppositeLine
+        ? oppositeLine.type === 'remove'
+          ? ('LEFT' as const)
+          : ('RIGHT' as const)
+        : undefined;
+      const hasThread = isOpenLine || lineComments.length > 0;
       return (
         <div key={lineKey}>
-          <CodeLine line={line} lineKey={lineKey} lang={lang} dimmed={dimmed} />
+          <CodeLine
+            line={line}
+            lineKey={lineKey}
+            lang={lang}
+            dimmed={dimmed}
+            inSelection={inSelection}
+            inExistingRange={existingMultiLineRanges.has(i)}
+          />
           {hasThread && (
             <div className="sticky left-0" style={{ width: '100cqw' }}>
               <CollapsibleThread
@@ -363,6 +431,8 @@ function HunkLines({
                 file={file}
                 lineNumber={line.type === 'remove' ? line.lineNumber.old : line.lineNumber.new}
                 side={line.type === 'remove' ? 'LEFT' : 'RIGHT'}
+                startLineNumber={startLineNumber}
+                startSide={startSideForThread}
                 isNewThread={openLine === lineKey && lineComments.length === 0}
                 onClose={() => (openLine === lineKey ? setOpenLine(null) : undefined)}
               />
@@ -371,7 +441,19 @@ function HunkLines({
         </div>
       );
     },
-    [hunk.lines, file, hunkIndex, comments, commentLineMap, openLine, setOpenLine, lang],
+    [
+      hunk.lines,
+      file,
+      hunkIndex,
+      comments,
+      commentLineMap,
+      openLine,
+      setOpenLine,
+      lang,
+      rangeStartIdx,
+      rangeEndIdx,
+      existingMultiLineRanges,
+    ],
   );
 
   return (
@@ -395,12 +477,32 @@ function HunkLines({
 
 export function Hunk({ file, hunk, isNewFile, hunkIndex, highlight }: Props) {
   const openLine = useReviewStore((s) => s.openLine);
+  const commentRangeStart = useReviewStore((s) => s.commentRangeStart);
   const comments = useReviewStore((s) => s.comments);
   const setOpenLine = useReviewStore((s) => s.setOpenLine);
   const repoUrl = useReviewStore((s) => s.repoUrl);
   const headSha = useReviewStore((s) => s.pr?.headSha ?? null);
   const clusterBots = useReviewStore((s) => s.clusterBots);
   const lang = guessLang(file);
+
+  // Resolve a multi-line selection to local indices within this hunk.
+  // `openLine` and `commentRangeStart` are line keys; we match by file +
+  // hunkIndex to ignore selections in other hunks.
+  const { rangeStartIdx, rangeEndIdx } = useMemo(() => {
+    const myPrefix = `${file}:${hunkIndex}:`;
+    if (!openLine || !openLine.startsWith(myPrefix)) {
+      return { rangeStartIdx: null, rangeEndIdx: null };
+    }
+    if (!commentRangeStart || !commentRangeStart.startsWith(myPrefix)) {
+      return { rangeStartIdx: null, rangeEndIdx: null };
+    }
+    const a = Number(openLine.slice(myPrefix.length));
+    const b = Number(commentRangeStart.slice(myPrefix.length));
+    if (Number.isNaN(a) || Number.isNaN(b)) {
+      return { rangeStartIdx: null, rangeEndIdx: null };
+    }
+    return { rangeStartIdx: Math.min(a, b), rangeEndIdx: Math.max(a, b) };
+  }, [openLine, commentRangeStart, file, hunkIndex]);
 
   const rangeStart = hunk.oldStart;
   const rangeEnd = hunk.oldStart + Math.max(hunk.oldCount, 0);
@@ -544,6 +646,8 @@ export function Hunk({ file, hunk, isNewFile, hunkIndex, highlight }: Props) {
           openLine={openLine}
           setOpenLine={setOpenLine}
           clusteredIds={clusteredIds}
+          rangeStartIdx={rangeStartIdx}
+          rangeEndIdx={rangeEndIdx}
         />
       </div>
     </div>

--- a/packages/web/src/components/Hunk.tsx
+++ b/packages/web/src/components/Hunk.tsx
@@ -79,20 +79,24 @@ function CollapsibleThread({
   );
 }
 
-function BotCluster({ comments }: { comments: PRComment[] }) {
+type BotThread = { root: PRComment; replies: PRComment[] };
+
+function BotCluster({ threads }: { threads: BotThread[] }) {
   const [expanded, setExpanded] = useState(false);
+
+  const allComments = useMemo(() => threads.flatMap((t) => [t.root, ...t.replies]), [threads]);
 
   const uniqueAuthors = useMemo(() => {
     const seen = new Set<string>();
     const ordered: string[] = [];
-    for (const c of comments) {
+    for (const c of threads.map((t) => t.root)) {
       if (!seen.has(c.author)) {
         seen.add(c.author);
         ordered.push(c.author);
       }
     }
     return ordered;
-  }, [comments]);
+  }, [threads]);
 
   const avatarStack = uniqueAuthors.slice(0, 3);
   const displayNames = uniqueAuthors.map((a) => getAuthorInfo(a).displayName);
@@ -100,7 +104,8 @@ function BotCluster({ comments }: { comments: PRComment[] }) {
     displayNames.length <= 2
       ? displayNames.join(', ')
       : `${displayNames.slice(0, 2).join(', ')} +${displayNames.length - 2}`;
-  const count = comments.length;
+  const count = threads.length;
+  const replyCount = allComments.length - count;
 
   return (
     <div
@@ -138,6 +143,11 @@ function BotCluster({ comments }: { comments: PRComment[] }) {
         <span className="flex flex-col text-[13px] leading-tight">
           <b className="font-medium">
             {count} bot {count === 1 ? 'suggestion' : 'suggestions'}
+            {replyCount > 0 && (
+              <span className="ml-1.5 font-normal text-[var(--fg-3)]">
+                · {replyCount} {replyCount === 1 ? 'reply' : 'replies'}
+              </span>
+            )}
           </b>
           <span className="text-[11.5px] font-normal text-[var(--fg-3)]">from {namesLabel}</span>
         </span>
@@ -159,12 +169,12 @@ function BotCluster({ comments }: { comments: PRComment[] }) {
       </button>
       {expanded && (
         <div className="border-t border-dashed bg-[var(--bg-panel)] py-1.5" style={{ borderColor: 'var(--purple-a5)' }}>
-          {comments.map((c) => (
-            <div key={c.id} className="grid grid-cols-[56px_minmax(0,1fr)] items-start gap-2.5 px-3 py-1.5">
+          {threads.map((t) => (
+            <div key={t.root.id} className="grid grid-cols-[56px_minmax(0,1fr)] items-start gap-2.5 px-3 py-1.5">
               <div className="pt-1.5 text-right font-mono text-[11.5px] font-medium" style={{ color: 'var(--fg-3)' }}>
-                L{c.line ?? ''}
+                L{t.root.line ?? ''}
               </div>
-              <Comment comment={c} />
+              <Comment comment={t.root} replies={t.replies} />
             </div>
           ))}
         </div>
@@ -269,7 +279,7 @@ function HunkLines({
   comments,
   openLine,
   setOpenLine,
-  clusterBots,
+  clusteredIds,
 }: {
   file: string;
   hunk: DiffHunk;
@@ -279,7 +289,7 @@ function HunkLines({
   comments: PRComment[];
   openLine: string | null;
   setOpenLine: (key: string | null) => void;
-  clusterBots: boolean;
+  clusteredIds: Set<number>;
 }) {
   const normFile = normalizePath(file);
 
@@ -293,7 +303,7 @@ function HunkLines({
     for (const c of comments) {
       if (normalizePath(c.path) !== normFile) continue;
       if (c.line === undefined) continue;
-      if (clusterBots && c.author.endsWith('[bot]')) continue;
+      if (clusteredIds.has(c.id)) continue;
       const isLeft = c.side === 'LEFT';
       let matchIdx = -1;
       for (let i = 0; i < hunk.lines.length; i++) {
@@ -312,7 +322,7 @@ function HunkLines({
       if (matchIdx !== -1) map.set(c.id, matchIdx);
     }
     return map;
-  }, [hunk.lines, comments, normFile, clusterBots]);
+  }, [hunk.lines, comments, normFile, clusteredIds]);
 
   const commentLineIndices = useMemo(() => new Set(commentLineMap.values()), [commentLineMap]);
 
@@ -399,16 +409,64 @@ export function Hunk({ file, hunk, isNewFile, hunkIndex, highlight }: Props) {
   const hunkStart = hunk.newStart;
   const hunkEnd = hunk.newStart + Math.max(hunk.newCount - 1, 0);
 
-  // Bot comments scoped to this hunk's line range and file
-  const botComments = useMemo(() => {
+  // Bot threads scoped to this hunk's line range and file. A "thread" is a
+  // bot's root comment plus any human/bot replies that descend from it. Without
+  // gathering replies, a human reply to a bot comment would render as a
+  // disconnected thread on the same line — visually orphaned from the bot
+  // suggestion that prompted it.
+  const { botThreads, clusteredIds } = useMemo(() => {
     const normFile = normalizePath(file);
-    return comments.filter((c) => {
+    const inHunk = comments.filter((c) => {
       if (normalizePath(c.path) !== normFile) return false;
-      if (!c.author.endsWith('[bot]')) return false;
       if (c.line === undefined) return false;
       return c.line >= hunkStart && c.line <= hunkEnd;
     });
-  }, [comments, file, hunkStart, hunkEnd]);
+
+    if (!clusterBots) {
+      return { botThreads: [] as BotThread[], clusteredIds: new Set<number>() };
+    }
+
+    const inHunkById = new Map(inHunk.map((c) => [c.id, c]));
+    const botRoots = inHunk.filter((c) => c.inReplyToId == null && c.author.endsWith('[bot]'));
+    const repliesByParent = new Map<number, PRComment[]>();
+    for (const c of inHunk) {
+      if (c.inReplyToId != null && inHunkById.has(c.inReplyToId)) {
+        const list = repliesByParent.get(c.inReplyToId) ?? [];
+        list.push(c);
+        repliesByParent.set(c.inReplyToId, list);
+      }
+    }
+
+    const cluster = new Set<number>();
+    const threads: BotThread[] = botRoots.map((root) => {
+      const replies: PRComment[] = [];
+      const stack = [root.id];
+      while (stack.length > 0) {
+        const parentId = stack.pop()!;
+        const children = repliesByParent.get(parentId) ?? [];
+        for (const child of children) {
+          replies.push(child);
+          cluster.add(child.id);
+          stack.push(child.id);
+        }
+      }
+      cluster.add(root.id);
+      replies.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+      return { root, replies };
+    });
+
+    // Also pull in any orphan reply (parent missing from this hunk) authored by
+    // a bot, so they aren't stranded.
+    for (const c of inHunk) {
+      if (cluster.has(c.id)) continue;
+      if (c.inReplyToId != null && !inHunkById.has(c.inReplyToId) && c.author.endsWith('[bot]')) {
+        threads.push({ root: c, replies: [] });
+        cluster.add(c.id);
+      }
+    }
+
+    return { botThreads: threads, clusteredIds: cluster };
+  }, [comments, file, hunkStart, hunkEnd, clusterBots]);
 
   const githubUrl =
     repoUrl && headSha
@@ -474,7 +532,7 @@ export function Hunk({ file, hunk, isNewFile, hunkIndex, highlight }: Props) {
           )}
         </div>
       </div>
-      {clusterBots && botComments.length > 0 && <BotCluster comments={botComments} />}
+      {botThreads.length > 0 && <BotCluster threads={botThreads} />}
       <div className="overflow-x-auto" style={{ containerType: 'inline-size' }}>
         <HunkLines
           file={file}
@@ -485,7 +543,7 @@ export function Hunk({ file, hunk, isNewFile, hunkIndex, highlight }: Props) {
           comments={comments}
           openLine={openLine}
           setOpenLine={setOpenLine}
-          clusterBots={clusterBots}
+          clusteredIds={clusteredIds}
         />
       </div>
     </div>

--- a/packages/web/src/components/Hunk.tsx
+++ b/packages/web/src/components/Hunk.tsx
@@ -288,6 +288,7 @@ function HunkLines({
   clusteredIds,
   rangeStartIdx,
   rangeEndIdx,
+  isDragging,
 }: {
   file: string;
   hunk: DiffHunk;
@@ -300,6 +301,7 @@ function HunkLines({
   clusteredIds: Set<number>;
   rangeStartIdx: number | null;
   rangeEndIdx: number | null;
+  isDragging: boolean;
 }) {
   const normFile = normalizePath(file);
 
@@ -391,7 +393,9 @@ function HunkLines({
       const lineKey = `${file}:${hunkIndex}:${i}`;
       const lineComments: PRComment[] = comments.filter((c) => commentLineMap.get(c.id) === i);
       const inSelection = rangeStartIdx !== null && rangeEndIdx !== null && i >= rangeStartIdx && i <= rangeEndIdx;
-      const isOpenLine = openLine === lineKey;
+      // Hide the in-progress composer while a click-and-drag is live; we only
+      // want the highlight to track the cursor, not a flickering textarea.
+      const isOpenLine = openLine === lineKey && !isDragging;
       // The thread anchors wherever the user just clicked (`openLine`). When a
       // multi-line range exists, the OTHER end of the range becomes the
       // `startLine` so GitHub gets a valid (start_line, line) pair.
@@ -451,6 +455,7 @@ function HunkLines({
       lang,
       rangeStartIdx,
       rangeEndIdx,
+      isDragging,
       existingMultiLineRanges,
     ],
   );
@@ -477,6 +482,7 @@ function HunkLines({
 export function Hunk({ file, hunk, isNewFile, hunkIndex, highlight }: Props) {
   const openLine = useReviewStore((s) => s.openLine);
   const commentRangeStart = useReviewStore((s) => s.commentRangeStart);
+  const commentDrag = useReviewStore((s) => s.commentDrag);
   const comments = useReviewStore((s) => s.comments);
   const setOpenLine = useReviewStore((s) => s.setOpenLine);
   const clearCommentRange = useReviewStore((s) => s.clearCommentRange);
@@ -485,47 +491,64 @@ export function Hunk({ file, hunk, isNewFile, hunkIndex, highlight }: Props) {
   const clusterBots = useReviewStore((s) => s.clusterBots);
   const lang = guessLang(file);
 
-  // Resolve a multi-line selection to local indices within this hunk.
-  // `openLine` and `commentRangeStart` are line keys; we match by file +
-  // hunkIndex to ignore selections in other hunks. Multi-line comments must
-  // live on a single diff side (LEFT/old or RIGHT/new) — GitHub stores
-  // start_line/line on the same side and old vs new line numbers aren't
-  // comparable. If the user shift-clicks across sides, drop the range and
-  // fall back to a single-line comment at the most recently clicked line.
-  const { rangeStartIdx, rangeEndIdx } = useMemo(() => {
+  // Resolve a multi-line selection to local indices within this hunk. While
+  // a click-and-drag is in flight (`commentDrag` set), the live drag wins so
+  // the range highlight follows the cursor without prematurely opening the
+  // composer. Otherwise we read from `openLine` / `commentRangeStart` which
+  // are committed state. Multi-line comments must live on a single diff
+  // side — old and new line numbers are not comparable — so cross-side
+  // ranges are dropped to a single-line comment at the active line.
+  const { rangeStartIdx, rangeEndIdx, isDragging } = useMemo(() => {
     const myPrefix = `${file}:${hunkIndex}:`;
-    if (!openLine || !openLine.startsWith(myPrefix)) {
-      return { rangeStartIdx: null, rangeEndIdx: null };
+    let aKey: string | null = null;
+    let bKey: string | null = null;
+    let dragging = false;
+    if (commentDrag) {
+      aKey = commentDrag.endKey;
+      bKey = commentDrag.startKey;
+      dragging = true;
+    } else {
+      aKey = openLine;
+      bKey = commentRangeStart;
     }
-    if (!commentRangeStart || !commentRangeStart.startsWith(myPrefix)) {
-      return { rangeStartIdx: null, rangeEndIdx: null };
+    if (!aKey || !aKey.startsWith(myPrefix)) {
+      return { rangeStartIdx: null, rangeEndIdx: null, isDragging: dragging };
     }
-    const a = Number(openLine.slice(myPrefix.length));
-    const b = Number(commentRangeStart.slice(myPrefix.length));
+    if (!bKey || !bKey.startsWith(myPrefix)) {
+      return { rangeStartIdx: null, rangeEndIdx: null, isDragging: dragging };
+    }
+    const a = Number(aKey.slice(myPrefix.length));
+    const b = Number(bKey.slice(myPrefix.length));
     if (Number.isNaN(a) || Number.isNaN(b)) {
-      return { rangeStartIdx: null, rangeEndIdx: null };
+      return { rangeStartIdx: null, rangeEndIdx: null, isDragging: dragging };
+    }
+    if (a === b) {
+      return { rangeStartIdx: null, rangeEndIdx: null, isDragging: dragging };
     }
     const lineA = hunk.lines[a];
     const lineB = hunk.lines[b];
     if (!lineA || !lineB) {
-      return { rangeStartIdx: null, rangeEndIdx: null };
+      return { rangeStartIdx: null, rangeEndIdx: null, isDragging: dragging };
     }
     const sideOf = (t: typeof lineA.type): 'LEFT' | 'RIGHT' => (t === 'remove' ? 'LEFT' : 'RIGHT');
     if (sideOf(lineA.type) !== sideOf(lineB.type)) {
-      return { rangeStartIdx: null, rangeEndIdx: null };
+      return { rangeStartIdx: null, rangeEndIdx: null, isDragging: dragging };
     }
-    return { rangeStartIdx: Math.min(a, b), rangeEndIdx: Math.max(a, b) };
-  }, [openLine, commentRangeStart, file, hunkIndex, hunk.lines]);
+    return { rangeStartIdx: Math.min(a, b), rangeEndIdx: Math.max(a, b), isDragging: dragging };
+  }, [openLine, commentRangeStart, commentDrag, file, hunkIndex, hunk.lines]);
 
-  // If the user shift-clicked across sides we silently dropped the range
-  // above. Clear the stale anchor so a subsequent same-side shift-click
-  // starts fresh from the visible openLine, not the now-invisible anchor.
+  // If a shift-click extended a range across diff sides we silently dropped
+  // it above. Clear the stale anchor so the next same-side shift-click
+  // starts fresh from the visible openLine. Skipped while a drag is in
+  // flight — the live drag derives its own range and we'd otherwise clobber
+  // committed state mid-drag.
   useEffect(() => {
+    if (commentDrag) return;
     if (!openLine || !commentRangeStart) return;
     const myPrefix = `${file}:${hunkIndex}:`;
     if (!openLine.startsWith(myPrefix) || !commentRangeStart.startsWith(myPrefix)) return;
     if (rangeStartIdx === null) clearCommentRange();
-  }, [openLine, commentRangeStart, rangeStartIdx, file, hunkIndex, clearCommentRange]);
+  }, [openLine, commentRangeStart, commentDrag, rangeStartIdx, file, hunkIndex, clearCommentRange]);
 
   const rangeStart = hunk.oldStart;
   const rangeEnd = hunk.oldStart + Math.max(hunk.oldCount, 0);
@@ -671,6 +694,7 @@ export function Hunk({ file, hunk, isNewFile, hunkIndex, highlight }: Props) {
           clusteredIds={clusteredIds}
           rangeStartIdx={rangeStartIdx}
           rangeEndIdx={rangeEndIdx}
+          isDragging={isDragging}
         />
       </div>
     </div>

--- a/packages/web/src/components/ShortcutsHelp.tsx
+++ b/packages/web/src/components/ShortcutsHelp.tsx
@@ -10,6 +10,8 @@ const SHORTCUTS: { keys: string; desc: string }[] = [
   { keys: 'j / k', desc: 'Next / previous chapter' },
   { keys: 'r', desc: 'Toggle reviewed on current chapter' },
   { keys: 'c', desc: 'Open comment on current chapter' },
+  { keys: 's', desc: 'Open the submit-review dialog' },
+  { keys: 'Shift-click +', desc: 'Extend a comment to span multiple lines' },
   { keys: '?', desc: 'Show this help' },
   { keys: 'Esc', desc: 'Close overlays' },
 ];

--- a/packages/web/src/components/ShortcutsHelp.tsx
+++ b/packages/web/src/components/ShortcutsHelp.tsx
@@ -11,7 +11,7 @@ const SHORTCUTS: { keys: string; desc: string }[] = [
   { keys: 'r', desc: 'Toggle reviewed on current chapter' },
   { keys: 'c', desc: 'Open comment on current chapter' },
   { keys: 's', desc: 'Open the submit-review dialog' },
-  { keys: 'Shift-click +', desc: 'Extend a comment to span multiple lines' },
+  { keys: 'Drag +', desc: 'Click and drag the + gutter button to comment on a range of lines' },
   { keys: '?', desc: 'Show this help' },
   { keys: 'Esc', desc: 'Close overlays' },
 ];

--- a/packages/web/src/components/StoryView.tsx
+++ b/packages/web/src/components/StoryView.tsx
@@ -135,7 +135,7 @@ function Discussion() {
   }
 
   return (
-    <section data-chid="discussion" className="mb-[28px]">
+    <section data-chid="discussion" className="scroll-mt-[168px] mb-[28px]">
       <div className="mb-[14px] flex items-start gap-2.5">
         <div
           className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-[7px] text-[var(--fg-3)]"

--- a/packages/web/src/components/SubmitBar.tsx
+++ b/packages/web/src/components/SubmitBar.tsx
@@ -1,25 +1,42 @@
 import { useState } from 'react';
-import { copy } from '../lib/microcopy';
 import { pendingReviewComments, useReviewStore } from '../state/review-store';
 import { ApprovalCelebration } from './ApprovalCelebration';
 import { SubmitDialog } from './SubmitDialog';
 import { Toast } from './Toast';
+import { copy } from '../lib/microcopy';
 
 export function SubmitBar() {
   const narrative = useReviewStore((s) => s.narrative);
   const chapterStates = useReviewStore((s) => s.chapterStates);
   const drafts = useReviewStore((s) => s.drafts);
   const clearDrafts = useReviewStore((s) => s.clearDrafts);
+  const submitOpen = useReviewStore((s) => s.submitOpen);
+  const setSubmitOpen = useReviewStore((s) => s.setSubmitOpen);
 
-  const [open, setOpen] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
   const [celebrating, setCelebrating] = useState(false);
+
+  const open = submitOpen;
+  const setOpen = setSubmitOpen;
 
   if (!narrative) return null;
 
   const total = narrative.chapters.length;
   const reviewedCount = Object.values(chapterStates).filter((s) => s === 'reviewed').length;
   const progress = total === 0 ? 0 : (reviewedCount / total) * 100;
+  const draftCount = drafts.length;
+  const allReviewed = total > 0 && reviewedCount === total;
+  const ready = allReviewed; // primary callout: every chapter signed off
+
+  // CTA evolves with reviewer progress so the bar feels alive.
+  const ctaLabel =
+    draftCount > 0 && ready
+      ? `Ship ${draftCount} ${draftCount === 1 ? 'comment' : 'comments'} →`
+      : draftCount > 0
+        ? `Submit ${draftCount} ${draftCount === 1 ? 'comment' : 'comments'} →`
+        : ready
+          ? 'Approve & ship →'
+          : 'Submit review';
 
   async function handleSubmit(resolution: string, summary: string) {
     try {
@@ -80,10 +97,26 @@ export function SubmitBar() {
         <button
           type="button"
           onClick={() => setOpen(true)}
-          className="inline-flex h-[30px] items-center gap-1.5 rounded-[6px] bg-[var(--brand)] px-3 text-[12.5px] font-bold text-white hover:bg-[var(--brand-hover)]"
-          style={{ boxShadow: '0 1px 2px rgba(3,2,13,0.08)' }}
+          aria-keyshortcuts="s"
+          className="inline-flex h-[30px] items-center gap-1.5 rounded-[6px] px-3 text-[12.5px] font-bold text-white transition-colors"
+          style={{
+            background: ready ? 'var(--green-9)' : 'var(--brand)',
+            boxShadow: '0 1px 2px rgba(3,2,13,0.08)',
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.background = ready ? 'var(--green-10)' : 'var(--brand-hover)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.background = ready ? 'var(--green-9)' : 'var(--brand)';
+          }}
         >
-          Submit review
+          {ctaLabel}
+          <kbd
+            className="ml-1 hidden rounded-[3px] px-1 text-[10px] font-mono font-medium sm:inline"
+            style={{ background: 'rgba(255,255,255,0.2)', color: 'rgba(255,255,255,0.85)' }}
+          >
+            s
+          </kbd>
         </button>
       </div>
       <SubmitDialog open={open} onClose={() => setOpen(false)} onSubmit={handleSubmit} />

--- a/packages/web/src/components/SubmitDialog.tsx
+++ b/packages/web/src/components/SubmitDialog.tsx
@@ -49,6 +49,7 @@ export function SubmitDialog({ open, onClose, onSubmit }: Props) {
         ? narrative.chapters.map((_, idx) => idx).filter((idx) => chapterStates[`ch-${idx}`] === 'reviewed')
         : [];
       const pendingComments = drafts.map((d) => ({ path: d.path, line: d.line, body: d.body }));
+      const trimmedDraft = summary.trim();
       const res = await fetch('/api/ai', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -57,6 +58,7 @@ export function SubmitDialog({ open, onClose, onSubmit }: Props) {
           resolution,
           reviewedChapters,
           pendingComments,
+          userDraft: trimmedDraft || undefined,
         }),
       });
       if (!res.ok) {
@@ -168,10 +170,20 @@ export function SubmitDialog({ open, onClose, onSubmit }: Props) {
               disabled={drafting}
               className="inline-flex items-center gap-1 rounded-[5px] px-2 py-[3px] text-[11.5px] font-medium hover:bg-[var(--gray-a3)] disabled:cursor-not-allowed disabled:opacity-60"
               style={{ color: 'var(--brand)' }}
-              title="Generate a summary from your reviewed chapters and drafts"
+              title={
+                summary.trim()
+                  ? 'Polish the text you wrote, keeping your voice and points'
+                  : 'Draft a summary from your reviewed chapters and inline comments'
+              }
             >
               <IconSpark className="h-[11px] w-[11px]" />
-              {drafting ? 'Drafting…' : summary.trim() ? 'Re-draft with AI' : 'Draft with AI'}
+              {drafting
+                ? summary.trim()
+                  ? 'Polishing…'
+                  : 'Drafting…'
+                : summary.trim()
+                  ? 'Polish my draft'
+                  : 'Draft with AI'}
             </button>
             {draftError && (
               <span className="text-[11px] text-red-600 dark:text-red-400" title={draftError}>

--- a/packages/web/src/components/SubmitDialog.tsx
+++ b/packages/web/src/components/SubmitDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { pendingReviewComments, useReviewStore } from '../state/review-store';
+import { IconSpark } from './Icons';
 
 type Resolution = 'comment' | 'approve' | 'request_changes';
 
@@ -30,9 +31,48 @@ const OPTIONS: { value: Resolution; label: string; desc: string }[] = [
 export function SubmitDialog({ open, onClose, onSubmit }: Props) {
   const [resolution, setResolution] = useState<Resolution>('comment');
   const [summary, setSummary] = useState('');
+  const [drafting, setDrafting] = useState(false);
+  const [draftError, setDraftError] = useState<string | null>(null);
   const draftCount = useReviewStore((s) => pendingReviewComments(s.drafts).length);
+  const drafts = useReviewStore((s) => s.drafts);
+  const chapterStates = useReviewStore((s) => s.chapterStates);
+  const narrative = useReviewStore((s) => s.narrative);
 
   if (!open) return null;
+
+  async function autoDraftSummary() {
+    if (drafting) return;
+    setDrafting(true);
+    setDraftError(null);
+    try {
+      const reviewedChapters = narrative
+        ? narrative.chapters
+            .map((_, idx) => idx)
+            .filter((idx) => chapterStates[`ch-${idx}`] === 'reviewed')
+        : [];
+      const pendingComments = drafts.map((d) => ({ path: d.path, line: d.line, body: d.body }));
+      const res = await fetch('/api/ai', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'summarize',
+          resolution,
+          reviewedChapters,
+          pendingComments,
+        }),
+      });
+      if (!res.ok) {
+        const err = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(err.error ?? `HTTP ${res.status}`);
+      }
+      const data = (await res.json()) as { text: string };
+      setSummary(data.text);
+    } catch (err) {
+      setDraftError(err instanceof Error ? err.message : 'Failed to draft summary');
+    } finally {
+      setDrafting(false);
+    }
+  }
 
   const submitLabel =
     resolution === 'approve' ? 'Approve' : resolution === 'request_changes' ? 'Request changes' : 'Submit comment';
@@ -103,19 +143,45 @@ export function SubmitDialog({ open, onClose, onSubmit }: Props) {
             );
           })}
         </div>
-        <textarea
-          value={summary}
-          onChange={(e) => setSummary(e.target.value)}
-          placeholder="Leave a summary comment (optional)…"
-          className="block w-full resize-y px-3 py-2.5 text-[13.5px] leading-[19px] text-[var(--fg-1)] outline-none"
+        <div
+          className="relative"
           style={{
-            minHeight: 80,
-            border: 0,
             borderRadius: 8,
             boxShadow: 'inset 0 0 0 1px var(--gray-a5)',
-            background: 'transparent',
           }}
-        />
+        >
+          <textarea
+            value={summary}
+            onChange={(e) => setSummary(e.target.value)}
+            placeholder="Leave a summary comment (optional)…"
+            disabled={drafting}
+            className="block w-full resize-y px-3 py-2.5 pr-3 pb-9 text-[13.5px] leading-[19px] text-[var(--fg-1)] outline-none disabled:opacity-60"
+            style={{
+              minHeight: 96,
+              border: 0,
+              borderRadius: 8,
+              background: 'transparent',
+            }}
+          />
+          <div className="absolute bottom-1.5 left-1.5 right-1.5 flex items-center justify-between">
+            <button
+              type="button"
+              onClick={() => void autoDraftSummary()}
+              disabled={drafting}
+              className="inline-flex items-center gap-1 rounded-[5px] px-2 py-[3px] text-[11.5px] font-medium hover:bg-[var(--gray-a3)] disabled:cursor-not-allowed disabled:opacity-60"
+              style={{ color: 'var(--brand)' }}
+              title="Generate a summary from your reviewed chapters and drafts"
+            >
+              <IconSpark className="h-[11px] w-[11px]" />
+              {drafting ? 'Drafting…' : summary.trim() ? 'Re-draft with AI' : 'Draft with AI'}
+            </button>
+            {draftError && (
+              <span className="text-[11px] text-red-600 dark:text-red-400" title={draftError}>
+                {draftError.length > 60 ? `${draftError.slice(0, 60)}…` : draftError}
+              </span>
+            )}
+          </div>
+        </div>
         <div className="mt-3.5 flex justify-end gap-2">
           <button
             type="button"

--- a/packages/web/src/components/SubmitDialog.tsx
+++ b/packages/web/src/components/SubmitDialog.tsx
@@ -46,9 +46,7 @@ export function SubmitDialog({ open, onClose, onSubmit }: Props) {
     setDraftError(null);
     try {
       const reviewedChapters = narrative
-        ? narrative.chapters
-            .map((_, idx) => idx)
-            .filter((idx) => chapterStates[`ch-${idx}`] === 'reviewed')
+        ? narrative.chapters.map((_, idx) => idx).filter((idx) => chapterStates[`ch-${idx}`] === 'reviewed')
         : [];
       const pendingComments = drafts.map((d) => ({ path: d.path, line: d.line, body: d.body }));
       const res = await fetch('/api/ai', {

--- a/packages/web/src/hooks/useComments.ts
+++ b/packages/web/src/hooks/useComments.ts
@@ -6,6 +6,8 @@ type PostCommentOpts = {
   path?: string;
   line?: number;
   side?: string;
+  startLine?: number;
+  startSide?: string;
   inReplyToId?: number;
 };
 

--- a/packages/web/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/web/src/hooks/useKeyboardShortcuts.ts
@@ -30,6 +30,8 @@ export function useKeyboardShortcuts() {
   const shortcutsHelpOpen = useReviewStore((s) => s.shortcutsHelpOpen);
   const setShortcutsHelpOpen = useReviewStore((s) => s.setShortcutsHelpOpen);
   const openLine = useReviewStore((s) => s.openLine);
+  const submitOpen = useReviewStore((s) => s.submitOpen);
+  const setSubmitOpen = useReviewStore((s) => s.setSubmitOpen);
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -44,6 +46,11 @@ export function useKeyboardShortcuts() {
           setShortcutsHelpOpen(false);
           return;
         }
+        if (submitOpen) {
+          e.preventDefault();
+          setSubmitOpen(false);
+          return;
+        }
         if (openLine) {
           e.preventDefault();
           setOpenLine(null);
@@ -55,6 +62,12 @@ export function useKeyboardShortcuts() {
       if (key === '?') {
         e.preventDefault();
         setShortcutsHelpOpen(!shortcutsHelpOpen);
+        return;
+      }
+
+      if (key === 's') {
+        e.preventDefault();
+        setSubmitOpen(!submitOpen);
         return;
       }
 
@@ -122,5 +135,7 @@ export function useKeyboardShortcuts() {
     shortcutsHelpOpen,
     setShortcutsHelpOpen,
     openLine,
+    submitOpen,
+    setSubmitOpen,
   ]);
 }

--- a/packages/web/src/hooks/useScrollTracker.ts
+++ b/packages/web/src/hooks/useScrollTracker.ts
@@ -10,7 +10,7 @@ export function useScrollTracker() {
 
     function onScroll() {
       if (!narrative) return;
-      const offset = window.scrollY + 120;
+      const offset = window.scrollY + 180;
       const discussionEl = document.querySelector('[data-chid="discussion"]');
       if (discussionEl && (discussionEl as HTMLElement).offsetTop <= offset) {
         setActiveChapter('discussion');

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import './index.css';
 
 const container = document.getElementById('root');
@@ -10,6 +11,8 @@ if (!container) {
 
 createRoot(container).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </StrictMode>,
 );

--- a/packages/web/src/state/review-store.ts
+++ b/packages/web/src/state/review-store.ts
@@ -86,6 +86,9 @@ type ReviewState = {
    * already set within the same hunk, anchor a range from the current
    * `openLine` to `key`. */
   openCommentAt: (key: string, extend?: boolean) => void;
+  /** Drop the multi-line range anchor without closing the active thread.
+   * Used when a range becomes invalid (e.g. user extended across diff sides). */
+  clearCommentRange: () => void;
   addComment: (comment: PRComment) => void;
   setComments: (comments: PRComment[]) => void;
   addDraft: (draft: DraftComment) => void;
@@ -259,6 +262,8 @@ export const useReviewStore = create<ReviewState>((set) => ({
     }),
 
   setOpenLine: (key) => set({ openLine: key, commentRangeStart: null }),
+
+  clearCommentRange: () => set({ commentRangeStart: null }),
 
   openCommentAt: (key, extend = false) =>
     set((state) => {

--- a/packages/web/src/state/review-store.ts
+++ b/packages/web/src/state/review-store.ts
@@ -48,6 +48,11 @@ type ReviewState = {
    * effective range is min..max of these two by line index within the same
    * hunk. Null when the active comment is single-line. */
   commentRangeStart: string | null;
+  /** Live state of a click-and-drag from a `+` gutter button. While set, the
+   * range between `startKey` and `endKey` is highlighted but the comment
+   * composer is NOT opened — that happens on mouseup, when the drag is
+   * committed to `openLine` / `commentRangeStart`. */
+  commentDrag: { startKey: string; endKey: string } | null;
   theme: Theme;
   accent: AccentId;
   density: Density;
@@ -89,6 +94,15 @@ type ReviewState = {
   /** Drop the multi-line range anchor without closing the active thread.
    * Used when a range becomes invalid (e.g. user extended across diff sides). */
   clearCommentRange: () => void;
+  /** Begin a click-and-drag selection. */
+  startCommentDrag: (key: string) => void;
+  /** Update the drag end as the mouse moves. */
+  updateCommentDrag: (key: string) => void;
+  /** Commit the current drag: a same-key drag becomes a single-line click;
+   * a cross-key drag becomes a multi-line range with the composer opened. */
+  endCommentDrag: () => void;
+  /** Discard the in-progress drag without opening a composer. */
+  cancelCommentDrag: () => void;
   addComment: (comment: PRComment) => void;
   setComments: (comments: PRComment[]) => void;
   addDraft: (draft: DraftComment) => void;
@@ -187,6 +201,7 @@ export const useReviewStore = create<ReviewState>((set) => ({
   drafts: [],
   openLine: null,
   commentRangeStart: null,
+  commentDrag: null,
   theme: (localStorage.getItem('diffdad.theme') as Theme) || 'auto',
   accent: (localStorage.getItem('diffdad.accent') as AccentId) || 'classic',
   density: 'normal',
@@ -264,6 +279,27 @@ export const useReviewStore = create<ReviewState>((set) => ({
   setOpenLine: (key) => set({ openLine: key, commentRangeStart: null }),
 
   clearCommentRange: () => set({ commentRangeStart: null }),
+
+  startCommentDrag: (key) => set({ commentDrag: { startKey: key, endKey: key } }),
+
+  updateCommentDrag: (key) =>
+    set((state) => {
+      if (!state.commentDrag) return state;
+      if (state.commentDrag.endKey === key) return state;
+      return { commentDrag: { startKey: state.commentDrag.startKey, endKey: key } };
+    }),
+
+  endCommentDrag: () =>
+    set((state) => {
+      const drag = state.commentDrag;
+      if (!drag) return state;
+      if (drag.startKey === drag.endKey) {
+        return { commentDrag: null, openLine: drag.startKey, commentRangeStart: null };
+      }
+      return { commentDrag: null, openLine: drag.endKey, commentRangeStart: drag.startKey };
+    }),
+
+  cancelCommentDrag: () => set({ commentDrag: null }),
 
   openCommentAt: (key, extend = false) =>
     set((state) => {

--- a/packages/web/src/state/review-store.ts
+++ b/packages/web/src/state/review-store.ts
@@ -43,6 +43,11 @@ type ReviewState = {
   activeChapterId: string | null;
   drafts: DraftComment[];
   openLine: string | null;
+  /** Anchor of an in-progress multi-line selection. `lineKey` of the first
+   * line clicked; `openLine` is the most recently shift-clicked line. The
+   * effective range is min..max of these two by line index within the same
+   * hunk. Null when the active comment is single-line. */
+  commentRangeStart: string | null;
   theme: Theme;
   accent: AccentId;
   density: Density;
@@ -52,6 +57,7 @@ type ReviewState = {
   liveEvents: LiveEvent[];
   lastEventAt: number;
   shortcutsHelpOpen: boolean;
+  submitOpen: boolean;
   storyStructure: StoryStructure;
   visualStyle: VisualStyle;
   layoutMode: LayoutMode;
@@ -76,6 +82,10 @@ type ReviewState = {
   setActiveChapter: (id: string) => void;
   toggleReviewed: (idx: number) => void;
   setOpenLine: (key: string | null) => void;
+  /** Open a comment thread on `key`. When `extend` is true and `openLine` is
+   * already set within the same hunk, anchor a range from the current
+   * `openLine` to `key`. */
+  openCommentAt: (key: string, extend?: boolean) => void;
   addComment: (comment: PRComment) => void;
   setComments: (comments: PRComment[]) => void;
   addDraft: (draft: DraftComment) => void;
@@ -92,6 +102,7 @@ type ReviewState = {
   setCheckRuns: (checkRuns: CheckRun[]) => void;
   setReviews: (reviews: PRReview[]) => void;
   setShortcutsHelpOpen: (open: boolean) => void;
+  setSubmitOpen: (open: boolean) => void;
   setStoryStructure: (s: StoryStructure) => void;
   setVisualStyle: (s: VisualStyle) => void;
   setLayoutMode: (m: LayoutMode) => void;
@@ -136,14 +147,28 @@ function loadDrafts(prNumber: number): DraftComment[] {
   return [];
 }
 
-type InlineComment = { path: string; line: number; body: string; side?: 'LEFT' | 'RIGHT' };
+type InlineComment = {
+  path: string;
+  line: number;
+  body: string;
+  side?: 'LEFT' | 'RIGHT';
+  startLine?: number;
+  startSide?: 'LEFT' | 'RIGHT';
+};
 
 function isSubmittableDraft(d: DraftComment): d is DraftComment & { path: string; line: number } {
   return !!d.path && d.line !== undefined;
 }
 
 export function pendingReviewComments(drafts: DraftComment[]): InlineComment[] {
-  return drafts.filter(isSubmittableDraft).map((d) => ({ path: d.path, line: d.line, body: d.body, side: d.side }));
+  return drafts.filter(isSubmittableDraft).map((d) => ({
+    path: d.path,
+    line: d.line,
+    body: d.body,
+    side: d.side,
+    startLine: d.startLine,
+    startSide: d.startSide,
+  }));
 }
 
 export const useReviewStore = create<ReviewState>((set) => ({
@@ -158,6 +183,7 @@ export const useReviewStore = create<ReviewState>((set) => ({
   activeChapterId: null,
   drafts: [],
   openLine: null,
+  commentRangeStart: null,
   theme: (localStorage.getItem('diffdad.theme') as Theme) || 'auto',
   accent: (localStorage.getItem('diffdad.accent') as AccentId) || 'classic',
   density: 'normal',
@@ -167,6 +193,7 @@ export const useReviewStore = create<ReviewState>((set) => ({
   liveEvents: [],
   lastEventAt: Date.now(),
   shortcutsHelpOpen: false,
+  submitOpen: false,
   storyStructure: 'chapters',
   visualStyle: 'stripe',
   layoutMode: 'toc',
@@ -231,7 +258,22 @@ export const useReviewStore = create<ReviewState>((set) => ({
       return { chapterStates: updated };
     }),
 
-  setOpenLine: (key) => set({ openLine: key }),
+  setOpenLine: (key) => set({ openLine: key, commentRangeStart: null }),
+
+  openCommentAt: (key, extend = false) =>
+    set((state) => {
+      // Only extend within the same hunk. lineKey format: `${file}:${hunkIndex}:${lineIdx}`.
+      function hunkPrefix(k: string): string {
+        const lastColon = k.lastIndexOf(':');
+        return lastColon === -1 ? k : k.slice(0, lastColon);
+      }
+      if (extend && state.openLine && state.openLine !== key && hunkPrefix(state.openLine) === hunkPrefix(key)) {
+        // Anchor the range at whichever side the user already had open.
+        const anchor = state.commentRangeStart ?? state.openLine;
+        return { openLine: key, commentRangeStart: anchor };
+      }
+      return { openLine: key, commentRangeStart: null };
+    }),
 
   addComment: (comment) =>
     set((state) => {
@@ -297,6 +339,7 @@ export const useReviewStore = create<ReviewState>((set) => ({
   setReviews: (reviews) => set({ reviews }),
 
   setShortcutsHelpOpen: (shortcutsHelpOpen) => set({ shortcutsHelpOpen }),
+  setSubmitOpen: (submitOpen) => set({ submitOpen }),
 
   setStoryStructure: (storyStructure) => set({ storyStructure }),
   setVisualStyle: (visualStyle) => set({ visualStyle }),

--- a/packages/web/src/state/review-store.ts
+++ b/packages/web/src/state/review-store.ts
@@ -173,6 +173,32 @@ type InlineComment = {
   startSide?: 'LEFT' | 'RIGHT';
 };
 
+/** Server-streamed narratives can arrive with chapters/sections/etc. still
+ * filling in (especially during live regeneration). Render code assumes the
+ * usual array fields exist, so normalize at the store boundary — if we don't
+ * a `.map` or `.filter` on `undefined` mid-stream will crash the React tree
+ * and the user sees a blank page. */
+function sanitizeNarrative(n: NarrativeResponse): NarrativeResponse {
+  return {
+    ...n,
+    chapters: Array.isArray(n.chapters)
+      ? n.chapters.map((ch) => ({
+          ...ch,
+          title: typeof ch?.title === 'string' ? ch.title : '',
+          summary: typeof ch?.summary === 'string' ? ch.summary : '',
+          whyMatters: typeof ch?.whyMatters === 'string' ? ch.whyMatters : '',
+          risk: ch?.risk === 'high' || ch?.risk === 'medium' ? ch.risk : 'low',
+          sections: Array.isArray(ch?.sections) ? ch.sections : [],
+          callouts: Array.isArray(ch?.callouts) ? ch.callouts : undefined,
+          reshow: Array.isArray(ch?.reshow) ? ch.reshow : undefined,
+        }))
+      : [],
+    concerns: Array.isArray(n.concerns) ? n.concerns : [],
+    readingPlan: Array.isArray(n.readingPlan) ? n.readingPlan : [],
+    missing: Array.isArray(n.missing) ? n.missing : undefined,
+  };
+}
+
 function isSubmittableDraft(d: DraftComment): d is DraftComment & { path: string; line: number } {
   return !!d.path && d.line !== undefined;
 }
@@ -224,6 +250,7 @@ export const useReviewStore = create<ReviewState>((set) => ({
   narrationOverrides: {} as Record<string, string>,
 
   setData: (pr, narrative, files, comments, repoUrl = null, checkRuns = [], config = null, reviews = []) => {
+    const safeNarrative = sanitizeNarrative(narrative);
     const storageKey = `diffdad.reviewed.${pr.number}`;
     let saved: Record<string, ChapterState> = {};
     try {
@@ -231,13 +258,13 @@ export const useReviewStore = create<ReviewState>((set) => ({
       if (raw) saved = JSON.parse(raw);
     } catch {}
     const chapterStates: Record<string, ChapterState> = {};
-    narrative.chapters.forEach((_, idx) => {
+    safeNarrative.chapters.forEach((_, idx) => {
       const key = `ch-${idx}`;
       chapterStates[key] = saved[key] === 'reviewed' ? 'reviewed' : 'reading';
     });
     const next: Partial<ReviewState> = {
       pr,
-      narrative,
+      narrative: safeNarrative,
       files,
       comments,
       checkRuns,
@@ -245,7 +272,7 @@ export const useReviewStore = create<ReviewState>((set) => ({
       repoUrl,
       chapterStates,
       drafts: loadDrafts(pr.number),
-      activeChapterId: narrative.chapters.length > 0 ? 'ch-0' : null,
+      activeChapterId: safeNarrative.chapters.length > 0 ? 'ch-0' : null,
       chapterDensity: {},
     };
     if (config) {
@@ -395,18 +422,19 @@ export const useReviewStore = create<ReviewState>((set) => ({
   setPr: (pr) => set({ pr }),
   applyPartialNarrative: (pr, narrative, files, comments) =>
     set((state) => {
-      const next: Partial<ReviewState> = { pr, narrative };
+      const safeNarrative = sanitizeNarrative(narrative);
+      const next: Partial<ReviewState> = { pr, narrative: safeNarrative };
       if (files) next.files = files;
       if (comments) next.comments = comments;
       // Initialize chapter states for any newly streamed chapters without
       // clobbering ones the user has already marked reviewed.
       const chapterStates: Record<string, ChapterState> = { ...state.chapterStates };
-      narrative.chapters.forEach((_, idx) => {
+      safeNarrative.chapters.forEach((_, idx) => {
         const key = `ch-${idx}`;
         if (!chapterStates[key]) chapterStates[key] = 'reading';
       });
       next.chapterStates = chapterStates;
-      if (state.activeChapterId === null && narrative.chapters.length > 0) {
+      if (state.activeChapterId === null && safeNarrative.chapters.length > 0) {
         next.activeChapterId = 'ch-0';
       }
       return next;

--- a/packages/web/src/state/types.ts
+++ b/packages/web/src/state/types.ts
@@ -115,6 +115,8 @@ export type PRComment = {
   path?: string;
   line?: number;
   side?: string;
+  startLine?: number;
+  startSide?: string;
   inReplyToId?: number;
   diffHunk?: string;
 };
@@ -127,6 +129,8 @@ export type DraftComment = {
   path?: string;
   line?: number;
   side?: 'LEFT' | 'RIGHT';
+  startLine?: number;
+  startSide?: 'LEFT' | 'RIGHT';
   chapterIndex?: number;
 };
 


### PR DESCRIPTION
This PR adds three major features to enhance the code review experience:

## Summary
Extends the review tool with multi-line comment support, persistent concern dismissal, and AI-powered summary generation for review submissions.

## Key Changes

**Multi-line Comments**
- Added `startLine` and `startSide` fields to `PRComment` and `DraftComment` types to support GitHub's multi-line comment API
- Implemented multi-line selection UI in `CodeLine` with visual feedback (purple highlight) for selected ranges
- Added `commentRangeStart` state to track the anchor point of a multi-line selection; `openLine` becomes the active endpoint
- Updated `Hunk` component to resolve line selections to local indices and pass range metadata to `CollapsibleThread`
- Modified `CommentThread` to accept and forward `startLine`/`startSide` when posting comments
- Updated GitHub client to normalize and validate multi-line comment payloads (ensuring `start_line < line`)

**Concern Dismissal**
- Added persistent dismissal tracking using localStorage (keyed by PR number) in `ConcernsList`
- Implemented `dismiss()` and `undismissAll()` functions with visual state management
- Added dismiss button (×) to each concern row with opacity fade for dismissed items
- Added toggle UI to show/hide dismissed concerns with restore option
- Enhanced `ConcernRow` to support jumping to the concern's line in the diff with visual feedback

**Concern Interactivity**
- Converted concern file:line display to a clickable button that jumps to the line in the diff
- Added inline comment composer to `ConcernRow` with "Post comment" and "Add to review" actions
- Integrated with `useComments` hook to post comments directly from concerns
- Added status badges showing "Posted" or "Added to review" state
- Implemented keyboard shortcuts (Cmd/Ctrl+Enter to post, Escape to close)

**AI Summary Drafting**
- Added `/api/ai` endpoint with `summarize` action that generates review summaries
- Collects reviewed chapters, drafted inline comments, and narrative concerns as context
- Generates stance-aware prompts based on review resolution (approve/request_changes/comment)
- Added "Draft with AI" button in `SubmitDialog` with loading state and error handling
- Integrated with existing review state to populate summary field

**UI & State Management**
- Added `submitOpen` state to `ReviewState` for managing submit dialog visibility
- Added `openCommentAt()` method to support shift-click multi-line selection
- Updated `CodeLine` to accept `inSelection` and `inExistingRange` props for visual styling
- Enhanced `BotCluster` to group bot comments with their replies and display reply counts
- Updated keyboard shortcuts to close submit dialog on Escape
- Adjusted scroll tracking offset and added `scroll-mt` to discussion section for better navigation

## Implementation Details

- Multi-line selections are stored as line keys (`file:hunkIndex:lineIdx`) and resolved within each hunk to handle cross-hunk scenarios gracefully
- Dismissed concerns are serialized as an array of concern keys (`file:line:question`) for compact storage
- The AI summarization prompt is context-aware, adapting tone and focus based on the review resolution type
- Comment range normalization ensures GitHub API compatibility regardless of which endpoint the user clicks first
- Existing multi-line comment ranges are visually indicated with subtle left-border tinting to help reviewers understand context without expanding

https://claude.ai/code/session_01JbUv2tVVfrp8s1pqz58RNc