### PR TITLE
test: Add comprehensive test suite for CLI and core modules

### DIFF
--- a/packages/cli/src/__tests__/cli-parse.test.ts
+++ b/packages/cli/src/__tests__/cli-parse.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { parsePrArg } from '../cli';
+
+describe('parsePrArg', () => {
+  describe('full GitHub URLs', () => {
+    it('parses a https URL', () => {
+      expect(parsePrArg('https://github.com/octocat/hello/pull/42')).toEqual({
+        owner: 'octocat',
+        repo: 'hello',
+        number: 42,
+      });
+    });
+
+    it('parses an http URL (case-insensitive)', () => {
+      expect(parsePrArg('HTTP://github.com/Octocat/Hello/PULL/7')).toEqual({
+        owner: 'Octocat',
+        repo: 'Hello',
+        number: 7,
+      });
+    });
+
+    it('tolerates a trailing slash, query string, or fragment', () => {
+      expect(parsePrArg('https://github.com/o/r/pull/1/files')).toEqual({ owner: 'o', repo: 'r', number: 1 });
+      expect(parsePrArg('https://github.com/o/r/pull/1?diff=split')).toEqual({ owner: 'o', repo: 'r', number: 1 });
+      expect(parsePrArg('https://github.com/o/r/pull/1#discussion')).toEqual({ owner: 'o', repo: 'r', number: 1 });
+    });
+
+    it('returns null for non-PR github URLs', () => {
+      expect(parsePrArg('https://github.com/o/r/issues/1')).toBeNull();
+      expect(parsePrArg('https://github.com/o/r')).toBeNull();
+    });
+  });
+
+  describe('owner/repo#N shorthand', () => {
+    it('parses the shorthand', () => {
+      expect(parsePrArg('octocat/hello#42')).toEqual({
+        owner: 'octocat',
+        repo: 'hello',
+        number: 42,
+      });
+    });
+
+    it('rejects extra slashes', () => {
+      expect(parsePrArg('octocat/sub/hello#42')).toBeNull();
+    });
+
+    it('rejects whitespace inside owner/repo', () => {
+      expect(parsePrArg('octo cat/hello#42')).toBeNull();
+    });
+  });
+
+  describe('bare numbers and bad input', () => {
+    it('returns null on a bare number (caller resolves via git remote)', () => {
+      expect(parsePrArg('139')).toBeNull();
+    });
+
+    it('returns null on empty / whitespace input', () => {
+      expect(parsePrArg('')).toBeNull();
+      expect(parsePrArg('   ')).toBeNull();
+    });
+
+    it('trims surrounding whitespace before parsing', () => {
+      expect(parsePrArg('  octocat/hello#42  ')).toEqual({
+        owner: 'octocat',
+        repo: 'hello',
+        number: 42,
+      });
+    });
+
+    it('returns null for unrelated strings', () => {
+      expect(parsePrArg('not-a-pr')).toBeNull();
+      expect(parsePrArg('https://gitlab.com/o/r/-/merge_requests/1')).toBeNull();
+    });
+  });
+});

--- a/packages/cli/src/__tests__/comments-mapping.test.ts
+++ b/packages/cli/src/__tests__/comments-mapping.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import { mapCommentsToChapters } from '../github/comments';
+import type { NarrativeResponse } from '../narrative/types';
+import type { PRComment } from '../github/types';
+
+function mkNarrative(overrides: Partial<NarrativeResponse> = {}): NarrativeResponse {
+  return {
+    title: 't',
+    tldr: '',
+    verdict: 'safe',
+    readingPlan: [],
+    concerns: [],
+    chapters: [
+      {
+        title: 'one',
+        summary: 's',
+        whyMatters: 'w',
+        risk: 'low',
+        sections: [{ type: 'diff', file: 'src/a.ts', startLine: 1, endLine: 5, hunkIndex: 0 }],
+      },
+      {
+        title: 'two',
+        summary: 's',
+        whyMatters: 'w',
+        risk: 'low',
+        sections: [{ type: 'diff', file: 'src/b.ts', startLine: 1, endLine: 5, hunkIndex: 0 }],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function mkComment(over: Partial<PRComment> & { id: number; body?: string }): PRComment {
+  return {
+    id: over.id,
+    author: 'alice',
+    body: over.body ?? '',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    path: over.path,
+    line: over.line,
+  };
+}
+
+describe('mapCommentsToChapters', () => {
+  it('maps inline comments to every chapter that references the file', () => {
+    const narrative = mkNarrative({
+      chapters: [
+        {
+          title: 'A',
+          summary: '',
+          whyMatters: '',
+          risk: 'low',
+          sections: [{ type: 'diff', file: 'src/a.ts', startLine: 1, endLine: 3, hunkIndex: 0 }],
+        },
+        {
+          title: 'A again',
+          summary: '',
+          whyMatters: '',
+          risk: 'low',
+          sections: [{ type: 'diff', file: 'src/a.ts', startLine: 4, endLine: 7, hunkIndex: 1 }],
+        },
+        {
+          title: 'B',
+          summary: '',
+          whyMatters: '',
+          risk: 'low',
+          sections: [{ type: 'diff', file: 'src/b.ts', startLine: 1, endLine: 3, hunkIndex: 0 }],
+        },
+      ],
+    });
+    const comments = [mkComment({ id: 1, path: 'src/a.ts', line: 2 })];
+    const mapped = mapCommentsToChapters(comments, narrative);
+    expect(mapped[0]?.chapterIndices).toEqual([0, 1]);
+    expect(mapped[0]?.isNarrativeComment).toBe(false);
+  });
+
+  it('returns empty chapterIndices when an inline comment references an untouched file', () => {
+    const narrative = mkNarrative();
+    const comments = [mkComment({ id: 9, path: 'src/zzz.ts', line: 1 })];
+    const mapped = mapCommentsToChapters(comments, narrative);
+    expect(mapped[0]?.chapterIndices).toEqual([]);
+    expect(mapped[0]?.isNarrativeComment).toBe(false);
+  });
+
+  it('normalizes a/ b/ prefixes when matching paths', () => {
+    const narrative = mkNarrative({
+      chapters: [
+        {
+          title: 'A',
+          summary: '',
+          whyMatters: '',
+          risk: 'low',
+          sections: [{ type: 'diff', file: 'b/src/a.ts', startLine: 1, endLine: 3, hunkIndex: 0 }],
+        },
+      ],
+    });
+    const mapped = mapCommentsToChapters([mkComment({ id: 1, path: 'a/src/a.ts', line: 2 })], narrative);
+    expect(mapped[0]?.chapterIndices).toEqual([0]);
+  });
+
+  it('treats issue comments without a [diff.dad: Chapter N] tag as unattached', () => {
+    const narrative = mkNarrative();
+    const mapped = mapCommentsToChapters([mkComment({ id: 1, body: 'just a thought' })], narrative);
+    expect(mapped[0]?.chapterIndices).toEqual([]);
+    expect(mapped[0]?.isNarrativeComment).toBe(false);
+    expect(mapped[0]?.narrativeChapter).toBeUndefined();
+  });
+
+  it('extracts narrative chapter from [diff.dad: Chapter N] tag (1-based)', () => {
+    const narrative = mkNarrative();
+    const mapped = mapCommentsToChapters(
+      [mkComment({ id: 1, body: 'great chapter [diff.dad: Chapter 2]' })],
+      narrative,
+    );
+    expect(mapped[0]?.isNarrativeComment).toBe(true);
+    expect(mapped[0]?.narrativeChapter).toBe(2);
+    expect(mapped[0]?.chapterIndices).toEqual([1]); // 0-based
+  });
+
+  it('clamps invalid chapter index in the tag to empty chapterIndices', () => {
+    const narrative = mkNarrative(); // 2 chapters
+    const mapped = mapCommentsToChapters([mkComment({ id: 1, body: '[diff.dad: Chapter 99]' })], narrative);
+    expect(mapped[0]?.isNarrativeComment).toBe(true);
+    expect(mapped[0]?.narrativeChapter).toBe(99);
+    expect(mapped[0]?.chapterIndices).toEqual([]);
+  });
+
+  it('chapterIndices for inline matches are sorted ascending', () => {
+    const narrative = mkNarrative({
+      chapters: [
+        {
+          title: 'B',
+          summary: '',
+          whyMatters: '',
+          risk: 'low',
+          sections: [{ type: 'diff', file: 'src/b.ts', startLine: 1, endLine: 3, hunkIndex: 0 }],
+        },
+        {
+          title: 'A',
+          summary: '',
+          whyMatters: '',
+          risk: 'low',
+          sections: [{ type: 'diff', file: 'src/x.ts', startLine: 1, endLine: 3, hunkIndex: 0 }],
+        },
+        {
+          title: 'B again',
+          summary: '',
+          whyMatters: '',
+          risk: 'low',
+          sections: [{ type: 'diff', file: 'src/b.ts', startLine: 5, endLine: 7, hunkIndex: 1 }],
+        },
+      ],
+    });
+    const mapped = mapCommentsToChapters([mkComment({ id: 1, path: 'src/b.ts', line: 1 })], narrative);
+    expect(mapped[0]?.chapterIndices).toEqual([0, 2]);
+  });
+});

--- a/packages/cli/src/__tests__/diff-parser-edges.test.ts
+++ b/packages/cli/src/__tests__/diff-parser-edges.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { parseDiff } from '../github/diff-parser';
+
+describe('parseDiff edge cases', () => {
+  it('returns [] for empty / whitespace-only input', () => {
+    expect(parseDiff('')).toEqual([]);
+    expect(parseDiff('   \n\n')).toEqual([]);
+  });
+
+  it('handles "\\ No newline at end of file" markers without crashing', () => {
+    const raw = [
+      'diff --git a/x.txt b/x.txt',
+      'index 1..2 100644',
+      '--- a/x.txt',
+      '+++ b/x.txt',
+      '@@ -1,1 +1,1 @@',
+      '-old',
+      '\\ No newline at end of file',
+      '+new',
+      '\\ No newline at end of file',
+      '',
+    ].join('\n');
+    const files = parseDiff(raw);
+    expect(files).toHaveLength(1);
+    expect(files[0]?.hunks[0]?.lines.map((l) => l.type)).toEqual(['remove', 'add']);
+    expect(files[0]?.hunks[0]?.lines[0]?.content).toBe('old');
+    expect(files[0]?.hunks[0]?.lines[1]?.content).toBe('new');
+  });
+
+  it('parses a hunk with default count (omitted, defaults to 1)', () => {
+    const raw = [
+      'diff --git a/x.ts b/x.ts',
+      'index 1..2 100644',
+      '--- a/x.ts',
+      '+++ b/x.ts',
+      '@@ -5 +5 @@',
+      '-a',
+      '+b',
+      '',
+    ].join('\n');
+    const files = parseDiff(raw);
+    const hunk = files[0]?.hunks[0];
+    expect(hunk?.oldStart).toBe(5);
+    expect(hunk?.oldCount).toBe(1);
+    expect(hunk?.newStart).toBe(5);
+    expect(hunk?.newCount).toBe(1);
+  });
+
+  it('handles multiple hunks within a single file', () => {
+    const raw = [
+      'diff --git a/x.ts b/x.ts',
+      'index 1..2 100644',
+      '--- a/x.ts',
+      '+++ b/x.ts',
+      '@@ -1,1 +1,1 @@',
+      '-a',
+      '+b',
+      '@@ -10,1 +10,1 @@',
+      '-c',
+      '+d',
+      '',
+    ].join('\n');
+    const files = parseDiff(raw);
+    expect(files[0]?.hunks).toHaveLength(2);
+    expect(files[0]?.hunks[1]?.oldStart).toBe(10);
+  });
+
+  it('uses the new-side filename in renames', () => {
+    // The b/ side is what we want to attribute changes to.
+    const raw = [
+      'diff --git a/old/path.ts b/new/path.ts',
+      'similarity index 90%',
+      'rename from old/path.ts',
+      'rename to new/path.ts',
+      'index 1..2 100644',
+      '--- a/old/path.ts',
+      '+++ b/new/path.ts',
+      '@@ -1,1 +1,1 @@',
+      '-x',
+      '+y',
+      '',
+    ].join('\n');
+    const files = parseDiff(raw);
+    expect(files[0]?.file).toBe('new/path.ts');
+  });
+
+  it('parses mode-only / no-hunk file entries with hunks=[]', () => {
+    const raw = ['diff --git a/x.sh b/x.sh', 'old mode 100644', 'new mode 100755', ''].join('\n');
+    const files = parseDiff(raw);
+    expect(files).toHaveLength(1);
+    expect(files[0]?.file).toBe('x.sh');
+    expect(files[0]?.hunks).toEqual([]);
+    expect(files[0]?.isNewFile).toBe(false);
+    expect(files[0]?.isDeleted).toBe(false);
+  });
+
+  it('skips a hunk header that does not match the regex', () => {
+    const raw = [
+      'diff --git a/x.ts b/x.ts',
+      'index 1..2 100644',
+      '--- a/x.ts',
+      '+++ b/x.ts',
+      '@@ malformed @@',
+      '@@ -1,1 +1,1 @@',
+      '-a',
+      '+b',
+      '',
+    ].join('\n');
+    const files = parseDiff(raw);
+    expect(files[0]?.hunks).toHaveLength(1);
+    expect(files[0]?.hunks[0]?.oldStart).toBe(1);
+  });
+
+  it('breaks the hunk-line scan on an unrecognized prefix', () => {
+    // Anything other than +/-/space/blank/\\ should terminate the hunk body.
+    const raw = [
+      'diff --git a/x.ts b/x.ts',
+      'index 1..2 100644',
+      '--- a/x.ts',
+      '+++ b/x.ts',
+      '@@ -1,2 +1,2 @@',
+      '-a',
+      '+b',
+      'XJUNK', // unrecognized — parser stops adding lines here
+      ' c',
+      '',
+    ].join('\n');
+    const files = parseDiff(raw);
+    expect(files[0]?.hunks).toHaveLength(1);
+    expect(files[0]?.hunks[0]?.lines).toHaveLength(2);
+  });
+});

--- a/packages/cli/src/__tests__/engine-helpers.test.ts
+++ b/packages/cli/src/__tests__/engine-helpers.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getModel, inferProviderFromEnv, resolveAiPath, setCliOverride } from '../narrative/engine';
+import type { DiffDadConfig } from '../config';
+
+describe('inferProviderFromEnv', () => {
+  let originalAnthropic: string | undefined;
+  let originalOpenAI: string | undefined;
+
+  beforeEach(() => {
+    originalAnthropic = process.env.ANTHROPIC_API_KEY;
+    originalOpenAI = process.env.OPENAI_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  afterEach(() => {
+    if (originalAnthropic === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = originalAnthropic;
+    if (originalOpenAI === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = originalOpenAI;
+  });
+
+  it('returns null when no env keys are present', () => {
+    expect(inferProviderFromEnv()).toBeNull();
+  });
+
+  it('prefers ANTHROPIC_API_KEY when both are present', () => {
+    process.env.ANTHROPIC_API_KEY = 'ant-key';
+    process.env.OPENAI_API_KEY = 'oai-key';
+    expect(inferProviderFromEnv()).toEqual({ aiProvider: 'anthropic', aiApiKey: 'ant-key' });
+  });
+
+  it('falls back to OpenAI when only OPENAI_API_KEY is set', () => {
+    process.env.OPENAI_API_KEY = 'oai-key';
+    expect(inferProviderFromEnv()).toEqual({ aiProvider: 'openai', aiApiKey: 'oai-key' });
+  });
+});
+
+describe('resolveAiPath', () => {
+  let originalAnthropic: string | undefined;
+  let originalOpenAI: string | undefined;
+
+  beforeEach(() => {
+    originalAnthropic = process.env.ANTHROPIC_API_KEY;
+    originalOpenAI = process.env.OPENAI_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    setCliOverride(undefined as unknown as string);
+  });
+
+  afterEach(() => {
+    if (originalAnthropic === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = originalAnthropic;
+    if (originalOpenAI === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = originalOpenAI;
+    setCliOverride(undefined as unknown as string);
+  });
+
+  it('uses local-cli when no provider is configured and no env key is set', () => {
+    const out = resolveAiPath({});
+    expect(out.path).toBe('local-cli');
+    expect(out.effectiveConfig).toEqual({});
+  });
+
+  it('uses api when an aiProvider is explicitly configured', () => {
+    const config: DiffDadConfig = { aiProvider: 'openai', aiApiKey: 'k' };
+    const out = resolveAiPath(config);
+    expect(out.path).toBe('api');
+    expect(out.effectiveConfig.aiProvider).toBe('openai');
+  });
+
+  it('promotes to api and merges inferred env config when no provider is configured', () => {
+    process.env.ANTHROPIC_API_KEY = 'ant-key';
+    const out = resolveAiPath({ theme: 'dark' });
+    expect(out.path).toBe('api');
+    expect(out.effectiveConfig.aiProvider).toBe('anthropic');
+    expect(out.effectiveConfig.aiApiKey).toBe('ant-key');
+    expect(out.effectiveConfig.theme).toBe('dark');
+  });
+
+  it('forces local-cli when --with override is set, even if a provider is configured', () => {
+    setCliOverride('claude');
+    const out = resolveAiPath({ aiProvider: 'anthropic', aiApiKey: 'k' });
+    expect(out.path).toBe('local-cli');
+  });
+});
+
+describe('getModel', () => {
+  it('throws on an unknown provider', () => {
+    const badConfig = { aiProvider: 'mystery' } as unknown as DiffDadConfig;
+    expect(() => getModel(badConfig)).toThrow(/Unsupported aiProvider/);
+  });
+
+  it('returns a LanguageModelV1-shaped object for anthropic without throwing', () => {
+    const m = getModel({ aiProvider: 'anthropic', aiApiKey: 'k' });
+    // We don't want to call the model; just verify it constructed.
+    expect(m).toBeTruthy();
+    expect(typeof (m as unknown as { modelId?: unknown }).modelId).not.toBe('undefined');
+  });
+
+  it('returns a model for openai', () => {
+    const m = getModel({ aiProvider: 'openai', aiApiKey: 'k', aiModel: 'gpt-4o' });
+    expect(m).toBeTruthy();
+  });
+
+  it('returns a model for ollama with a custom base URL', () => {
+    const m = getModel({ aiProvider: 'ollama', aiBaseUrl: 'http://localhost:11434/v1' });
+    expect(m).toBeTruthy();
+  });
+
+  it('returns a model for openai-compatible', () => {
+    const m = getModel({ aiProvider: 'openai-compatible', aiBaseUrl: 'https://example.com/v1' });
+    expect(m).toBeTruthy();
+  });
+});

--- a/packages/cli/src/__tests__/github-client.test.ts
+++ b/packages/cli/src/__tests__/github-client.test.ts
@@ -321,6 +321,80 @@ describe('GitHubClient.postComment', () => {
   });
 });
 
+describe('GitHubClient.submitReview', () => {
+  function emptyResponse() {
+    return jsonResponse({});
+  }
+
+  it('forwards event + body and omits comments when none provided', async () => {
+    setResponder(emptyResponse);
+    await new GitHubClient('t').submitReview('o', 'r', 5, 'APPROVE', 'lgtm');
+    expect(calls[0]?.url).toBe('https://api.github.com/repos/o/r/pulls/5/reviews');
+    const body = JSON.parse(String(calls[0]?.init.body));
+    expect(body).toEqual({ event: 'APPROVE', body: 'lgtm' });
+  });
+
+  it('drops empty body field rather than sending body=""', async () => {
+    setResponder(emptyResponse);
+    await new GitHubClient('t').submitReview('o', 'r', 5, 'COMMENT', '');
+    const body = JSON.parse(String(calls[0]?.init.body));
+    expect(body.body).toBeUndefined();
+  });
+
+  it('forwards inline comments with their path/line/side', async () => {
+    setResponder(emptyResponse);
+    await new GitHubClient('t').submitReview('o', 'r', 5, 'REQUEST_CHANGES', 'see below', [
+      { path: 'a.ts', line: 7, body: 'fix this', side: 'RIGHT' },
+    ]);
+    const body = JSON.parse(String(calls[0]?.init.body));
+    expect(body.comments).toHaveLength(1);
+    expect(body.comments[0]).toMatchObject({
+      path: 'a.ts',
+      line: 7,
+      body: 'fix this',
+      side: 'RIGHT',
+    });
+  });
+
+  it('flips reversed start/end lines so start_line < line and side moves with the line', async () => {
+    setResponder(emptyResponse);
+    await new GitHubClient('t').submitReview('o', 'r', 5, 'COMMENT', undefined, [
+      {
+        path: 'a.ts',
+        // reversed: end < start
+        line: 5,
+        startLine: 10,
+        side: 'RIGHT',
+        startSide: 'LEFT',
+        body: 'r',
+      },
+    ]);
+    const body = JSON.parse(String(calls[0]?.init.body));
+    expect(body.comments[0].line).toBe(10);
+    expect(body.comments[0].start_line).toBe(5);
+    // The end-side (formerly the start side) and vice versa.
+    expect(body.comments[0].side).toBe('LEFT');
+    expect(body.comments[0].start_side).toBe('RIGHT');
+  });
+
+  it('does not include start_line/start_side for single-line comments (start === end)', async () => {
+    setResponder(emptyResponse);
+    await new GitHubClient('t').submitReview('o', 'r', 5, 'COMMENT', undefined, [
+      { path: 'a.ts', line: 7, startLine: 7, body: 'r', side: 'RIGHT' },
+    ]);
+    const body = JSON.parse(String(calls[0]?.init.body));
+    expect(body.comments[0].start_line).toBeUndefined();
+    expect(body.comments[0].start_side).toBeUndefined();
+  });
+
+  it('omits comments array when filtered list is empty', async () => {
+    setResponder(emptyResponse);
+    await new GitHubClient('t').submitReview('o', 'r', 5, 'COMMENT', 'hi', []);
+    const body = JSON.parse(String(calls[0]?.init.body));
+    expect(body.comments).toBeUndefined();
+  });
+});
+
 describe('GitHubClient.getCheckRuns', () => {
   it('maps API response to CheckRun shape', async () => {
     setResponder(() =>

--- a/packages/cli/src/__tests__/github-client.test.ts
+++ b/packages/cli/src/__tests__/github-client.test.ts
@@ -1,0 +1,420 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { GitHubClient } from '../github/client';
+
+type FetchCall = { url: string; init: RequestInit };
+type Responder = (call: FetchCall) => Response | Promise<Response>;
+
+const calls: FetchCall[] = [];
+let responder: Responder = () => new Response('not configured', { status: 500 });
+const realFetch = globalThis.fetch;
+
+function setResponder(fn: Responder) {
+  responder = fn;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  calls.length = 0;
+  globalThis.fetch = (async (input: RequestInfo | URL, init: RequestInit = {}) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    const call: FetchCall = { url, init };
+    calls.push(call);
+    return responder(call);
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  responder = () => new Response('not configured', { status: 500 });
+});
+
+describe('GitHubClient.getPR', () => {
+  it('parses a merged PR into PRMetadata', async () => {
+    setResponder(() =>
+      jsonResponse({
+        number: 42,
+        title: 'Test PR',
+        body: 'desc',
+        state: 'closed',
+        draft: false,
+        merged: true,
+        user: { login: 'octocat', avatar_url: 'https://x/y' },
+        head: { ref: 'feat', sha: 'abc' },
+        base: { ref: 'main' },
+        labels: [{ name: 'bug' }, { name: 'enhancement' }],
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-02T00:00:00Z',
+        additions: 10,
+        deletions: 5,
+        changed_files: 3,
+        commits: 2,
+      }),
+    );
+    const client = new GitHubClient('test-token');
+    const pr = await client.getPR('owner', 'repo', 42);
+    expect(pr.state).toBe('merged');
+    expect(pr.headSha).toBe('abc');
+    expect(pr.author.login).toBe('octocat');
+    expect(pr.labels).toEqual(['bug', 'enhancement']);
+    expect(calls[0]?.url).toBe('https://api.github.com/repos/owner/repo/pulls/42');
+    const headers = new Headers(calls[0]?.init.headers);
+    expect(headers.get('Authorization')).toBe('Bearer test-token');
+    expect(headers.get('Accept')).toBe('application/vnd.github+json');
+  });
+
+  it('maps state="closed" + merged=false to "closed"', async () => {
+    setResponder(() =>
+      jsonResponse({
+        number: 1,
+        title: 't',
+        body: null,
+        state: 'closed',
+        draft: false,
+        merged: false,
+        user: null,
+        head: { ref: 'f', sha: 'h' },
+        base: { ref: 'main' },
+        labels: [],
+        created_at: '',
+        updated_at: '',
+        additions: 0,
+        deletions: 0,
+        changed_files: 0,
+        commits: 0,
+      }),
+    );
+    const pr = await new GitHubClient('t').getPR('o', 'r', 1);
+    expect(pr.state).toBe('closed');
+    expect(pr.author.login).toBe('');
+    expect(pr.body).toBe('');
+  });
+
+  it('throws on non-2xx response with the body included', async () => {
+    setResponder(() => new Response('not found', { status: 404 }));
+    await expect(new GitHubClient('t').getPR('o', 'r', 99)).rejects.toThrow(/404/);
+  });
+});
+
+describe('GitHubClient.getDiff', () => {
+  it('requests the v3.diff accept header and parses the result', async () => {
+    setResponder(
+      () =>
+        new Response(
+          [
+            'diff --git a/src/x.ts b/src/x.ts',
+            'index 1..2 100644',
+            '--- a/src/x.ts',
+            '+++ b/src/x.ts',
+            '@@ -1,1 +1,1 @@',
+            '-old',
+            '+new',
+            '',
+          ].join('\n'),
+        ),
+    );
+    const files = await new GitHubClient('t').getDiff('o', 'r', 1);
+    expect(files).toHaveLength(1);
+    expect(files[0]?.file).toBe('src/x.ts');
+    const headers = new Headers(calls[0]?.init.headers);
+    expect(headers.get('Accept')).toBe('application/vnd.github.v3.diff');
+  });
+});
+
+describe('GitHubClient.getComments', () => {
+  it('merges review + issue comments and sorts by createdAt', async () => {
+    setResponder((call) => {
+      if (call.url.includes('/pulls/1/comments')) {
+        return jsonResponse([
+          {
+            id: 200,
+            user: { login: 'a', avatar_url: 'a-av' },
+            body: 'inline 1',
+            created_at: '2026-01-02T00:00:00Z',
+            updated_at: '2026-01-02T00:00:00Z',
+            path: 'a.ts',
+            line: 5,
+            original_line: null,
+            position: null,
+            side: 'RIGHT',
+            start_line: null,
+            original_start_line: null,
+            start_side: null,
+            in_reply_to_id: undefined,
+            diff_hunk: '',
+          },
+          {
+            // outdated review comment with line=null but original_line set
+            id: 201,
+            user: { login: 'a', avatar_url: 'a-av' },
+            body: 'outdated',
+            created_at: '2026-01-04T00:00:00Z',
+            updated_at: '2026-01-04T00:00:00Z',
+            path: 'a.ts',
+            line: null,
+            original_line: 7,
+            position: null,
+            side: 'RIGHT',
+            start_line: null,
+            original_start_line: null,
+            start_side: null,
+            diff_hunk: '',
+          },
+        ]);
+      }
+      if (call.url.includes('/issues/1/comments')) {
+        return jsonResponse([
+          {
+            id: 100,
+            user: { login: 'b', avatar_url: 'b-av' },
+            body: 'general',
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+        ]);
+      }
+      return new Response('unexpected', { status: 500 });
+    });
+
+    const comments = await new GitHubClient('t').getComments('o', 'r', 1);
+    expect(comments.map((c) => c.id)).toEqual([100, 200, 201]);
+    expect(comments[0]?.path).toBeUndefined(); // issue comment
+    expect(comments[1]?.path).toBe('a.ts');
+    expect(comments[1]?.line).toBe(5);
+    expect(comments[2]?.line).toBe(7); // outdated comment falls back to original_line
+  });
+});
+
+describe('GitHubClient.getReviews', () => {
+  it('keeps only the latest review per user', async () => {
+    setResponder(() =>
+      jsonResponse([
+        { id: 1, user: { login: 'alice', avatar_url: '' }, state: 'COMMENTED', submitted_at: '2026-01-01T00:00:00Z' },
+        { id: 2, user: { login: 'alice', avatar_url: '' }, state: 'APPROVED', submitted_at: '2026-01-02T00:00:00Z' },
+        {
+          id: 3,
+          user: { login: 'bob', avatar_url: '' },
+          state: 'CHANGES_REQUESTED',
+          submitted_at: '2026-01-03T00:00:00Z',
+        },
+        // unrecognized state — should be filtered
+        { id: 4, user: { login: 'carol', avatar_url: '' }, state: 'WAT', submitted_at: '2026-01-04T00:00:00Z' },
+        // null user — should be filtered
+        { id: 5, user: null, state: 'APPROVED', submitted_at: '2026-01-05T00:00:00Z' },
+      ]),
+    );
+    const reviews = await new GitHubClient('t').getReviews('o', 'r', 1);
+    const byUser = new Map(reviews.map((r) => [r.user, r]));
+    expect(byUser.get('alice')?.id).toBe(2);
+    expect(byUser.get('alice')?.state).toBe('APPROVED');
+    expect(byUser.get('bob')?.state).toBe('CHANGES_REQUESTED');
+    expect(byUser.has('carol')).toBe(false);
+    expect(reviews).toHaveLength(2);
+  });
+});
+
+describe('GitHubClient.postComment', () => {
+  it('posts an issue comment when no path/line is provided', async () => {
+    setResponder(() =>
+      jsonResponse({
+        id: 1,
+        user: { login: 'me', avatar_url: '' },
+        body: 'hi',
+        created_at: '',
+        updated_at: '',
+      }),
+    );
+    await new GitHubClient('t').postComment('o', 'r', 5, 'hi');
+    expect(calls[0]?.url).toBe('https://api.github.com/repos/o/r/issues/5/comments');
+    expect(calls[0]?.init.method).toBe('POST');
+    const body = JSON.parse(String(calls[0]?.init.body));
+    expect(body).toEqual({ body: 'hi' });
+  });
+
+  it('posts an inline review comment when path/line/commitId are provided', async () => {
+    setResponder(() =>
+      jsonResponse({
+        id: 9,
+        user: { login: 'me', avatar_url: '' },
+        body: 'inline',
+        created_at: '',
+        updated_at: '',
+        path: 'a.ts',
+        line: 5,
+        side: 'RIGHT',
+        start_line: null,
+        start_side: null,
+        diff_hunk: '',
+      }),
+    );
+    await new GitHubClient('t').postComment('o', 'r', 5, 'inline', {
+      path: 'a.ts',
+      line: 5,
+      commitId: 'sha123',
+    });
+    expect(calls[0]?.url).toBe('https://api.github.com/repos/o/r/pulls/5/comments');
+    const body = JSON.parse(String(calls[0]?.init.body));
+    expect(body).toMatchObject({
+      body: 'inline',
+      commit_id: 'sha123',
+      path: 'a.ts',
+      line: 5,
+      side: 'RIGHT',
+    });
+  });
+
+  it('flips reversed start/end lines so start_line < line', async () => {
+    setResponder(() =>
+      jsonResponse({
+        id: 1,
+        user: { login: 'me', avatar_url: '' },
+        body: 'r',
+        created_at: '',
+        updated_at: '',
+        path: 'a.ts',
+        line: 10,
+        side: 'RIGHT',
+        start_line: 5,
+        start_side: 'RIGHT',
+        diff_hunk: '',
+      }),
+    );
+    await new GitHubClient('t').postComment('o', 'r', 1, 'r', {
+      path: 'a.ts',
+      line: 5, // reversed
+      startLine: 10, // reversed
+      side: 'RIGHT',
+      startSide: 'LEFT',
+      commitId: 'sha',
+    });
+    const body = JSON.parse(String(calls[0]?.init.body));
+    expect(body.line).toBe(10);
+    expect(body.start_line).toBe(5);
+    // sides should swap with their lines
+    expect(body.side).toBe('LEFT');
+    expect(body.start_side).toBe('RIGHT');
+  });
+
+  it('posts a reply when only inReplyToId is provided', async () => {
+    setResponder(() =>
+      jsonResponse({
+        id: 10,
+        user: { login: 'me', avatar_url: '' },
+        body: 'reply',
+        created_at: '',
+        updated_at: '',
+        path: 'a.ts',
+        line: 1,
+        side: 'RIGHT',
+        diff_hunk: '',
+      }),
+    );
+    await new GitHubClient('t').postComment('o', 'r', 5, 'reply', { inReplyToId: 42 });
+    expect(calls[0]?.url).toBe('https://api.github.com/repos/o/r/pulls/5/comments');
+    const body = JSON.parse(String(calls[0]?.init.body));
+    expect(body).toEqual({ body: 'reply', in_reply_to: 42 });
+  });
+});
+
+describe('GitHubClient.getCheckRuns', () => {
+  it('maps API response to CheckRun shape', async () => {
+    setResponder(() =>
+      jsonResponse({
+        check_runs: [
+          {
+            id: 1,
+            name: 'lint',
+            status: 'completed',
+            conclusion: 'success',
+            started_at: 's',
+            completed_at: 'c',
+            details_url: 'http://x',
+            output: { title: 'OK', summary: 'all good' },
+          },
+        ],
+      }),
+    );
+    const runs = await new GitHubClient('t').getCheckRuns('o', 'r', 'sha');
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({
+      id: 1,
+      name: 'lint',
+      status: 'completed',
+      conclusion: 'success',
+      output: { title: 'OK', summary: 'all good' },
+    });
+    expect(calls[0]?.url).toBe('https://api.github.com/repos/o/r/commits/sha/check-runs');
+  });
+});
+
+describe('GitHubClient.getIssue', () => {
+  it('returns null if the issue is actually a PR', async () => {
+    setResponder(() =>
+      jsonResponse({
+        number: 1,
+        title: 't',
+        body: 'b',
+        state: 'open',
+        html_url: 'http://x',
+        pull_request: { url: '...' },
+      }),
+    );
+    const issue = await new GitHubClient('t').getIssue('o', 'r', 1);
+    expect(issue).toBeNull();
+  });
+
+  it('returns the issue when it is a real issue', async () => {
+    setResponder(() =>
+      jsonResponse({
+        number: 7,
+        title: 'bug',
+        body: 'desc',
+        state: 'closed',
+        html_url: 'http://x/7',
+      }),
+    );
+    const issue = await new GitHubClient('t').getIssue('o', 'r', 7);
+    expect(issue).toEqual({
+      number: 7,
+      title: 'bug',
+      body: 'desc',
+      state: 'closed',
+      url: 'http://x/7',
+    });
+  });
+
+  it('returns null on fetch failure', async () => {
+    setResponder(() => new Response('no', { status: 500 }));
+    expect(await new GitHubClient('t').getIssue('o', 'r', 1)).toBeNull();
+  });
+});
+
+describe('GitHubClient.getForcePushEvents', () => {
+  it('only returns head_ref_force_pushed events', async () => {
+    setResponder(() =>
+      jsonResponse([
+        { event: 'commented', actor: { login: 'a' }, created_at: 't' },
+        {
+          event: 'head_ref_force_pushed',
+          actor: { login: 'a' },
+          created_at: '2026-01-01T00:00:00Z',
+          before_commit: { sha: 'before' },
+          after_commit: { sha: 'after' },
+        },
+      ]),
+    );
+    const events = await new GitHubClient('t').getForcePushEvents('o', 'r', 1);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      beforeSha: 'before',
+      afterSha: 'after',
+      actor: 'a',
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+  });
+});

--- a/packages/cli/src/__tests__/narrative-cache.test.ts
+++ b/packages/cli/src/__tests__/narrative-cache.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { homedir } from 'os';
+import { join } from 'path';
+import { rm } from 'fs/promises';
+import { cacheNarrative, getCachedNarrative } from '../narrative/cache';
+import type { NarrativeResponse } from '../narrative/types';
+
+const CACHE_DIR = join(homedir(), '.cache', 'diffdad');
+
+function mkResponse(overrides: Partial<NarrativeResponse> = {}): NarrativeResponse {
+  return {
+    title: 'A PR',
+    tldr: 'Adds X.',
+    verdict: 'safe',
+    readingPlan: [],
+    concerns: [],
+    chapters: [
+      {
+        title: 'Chapter 1',
+        summary: 's',
+        whyMatters: 'w',
+        risk: 'low',
+        sections: [],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+const FIXTURE_OWNER = '__diffdad_test__';
+const FIXTURE_REPO = 'cache';
+
+async function cleanFixture() {
+  try {
+    const { readdir } = await import('fs/promises');
+    const entries = await readdir(CACHE_DIR);
+    for (const e of entries) {
+      if (e.startsWith(`${FIXTURE_OWNER}-`)) {
+        await rm(join(CACHE_DIR, e), { force: true });
+      }
+    }
+  } catch {
+    // dir might not exist
+  }
+}
+
+describe('narrative cache', () => {
+  afterEach(async () => {
+    await cleanFixture();
+  });
+
+  it('returns null when nothing cached', async () => {
+    const out = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 1, 'sha-not-cached');
+    expect(out).toBeNull();
+  });
+
+  it('caches and retrieves a narrative roundtrip', async () => {
+    const narrative = mkResponse({ title: 'Roundtrip' });
+    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 42, 'sha-roundtrip', narrative);
+    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 42, 'sha-roundtrip');
+    expect(got).not.toBeNull();
+    expect(got?.title).toBe('Roundtrip');
+    expect(got?.chapters).toHaveLength(1);
+  });
+
+  it('keys cache by owner/repo/number/sha — different sha returns null', async () => {
+    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 7, 'sha-A', mkResponse({ title: 'A' }));
+    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 7, 'sha-B');
+    expect(got).toBeNull();
+  });
+
+  it('normalizes cached narrative on read (tolerant of older shapes)', async () => {
+    // Write an "old shape" payload bypassing the type — simulate a legacy cache.
+    const sha = 'sha-legacy';
+    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 9, sha, {
+      title: 'Legacy',
+      // missing tldr, verdict, readingPlan, concerns
+      chapters: [{ title: 'X', summary: 's', risk: 'low', sections: [] }],
+    } as unknown as NarrativeResponse);
+    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 9, sha);
+    expect(got).not.toBeNull();
+    expect(got?.title).toBe('Legacy');
+    expect(got?.tldr).toBe('');
+    expect(got?.verdict).toBe('caution');
+    expect(got?.readingPlan).toEqual([]);
+    expect(got?.chapters[0]?.whyMatters).toBe('');
+  });
+
+  it('overwrites a previous cache entry for the same key', async () => {
+    const sha = 'sha-overwrite';
+    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 11, sha, mkResponse({ title: 'first' }));
+    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 11, sha, mkResponse({ title: 'second' }));
+    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 11, sha);
+    expect(got?.title).toBe('second');
+  });
+
+  it('returns null when the cached file is corrupt JSON', async () => {
+    const { mkdir, writeFile } = await import('fs/promises');
+    await mkdir(CACHE_DIR, { recursive: true });
+    // Write a junk file at a key we control. The cache uses schema version v2
+    // — match the format so it's actually picked up.
+    const path = join(CACHE_DIR, `${FIXTURE_OWNER}-${FIXTURE_REPO}-99-sha-corrupt.v2.json`);
+    await writeFile(path, '{ not valid json');
+    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 99, 'sha-corrupt');
+    expect(got).toBeNull();
+  });
+});

--- a/packages/cli/src/__tests__/recap-cache.test.ts
+++ b/packages/cli/src/__tests__/recap-cache.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { homedir } from 'os';
+import { join } from 'path';
+import { mkdir, readdir, rm, writeFile } from 'fs/promises';
+import { cacheRecap, getCachedRecap } from '../recap/cache';
+import type { RecapResponse } from '../recap/types';
+
+const CACHE_DIR = join(homedir(), '.cache', 'diffdad');
+
+const FIXTURE_OWNER = '__diffdad_recap_test__';
+const FIXTURE_REPO = 'cache';
+
+function mkRecap(overrides: Partial<RecapResponse> = {}): RecapResponse {
+  return {
+    goal: 'Add feature X',
+    stateOfPlay: { done: ['parser'], wip: ['UI'], notStarted: ['docs'] },
+    decisions: [],
+    blockers: [],
+    mentalModel: { coreFiles: ['src/x.ts'], touchpoints: [], sketch: '' },
+    howToHelp: [],
+    ...overrides,
+  };
+}
+
+async function cleanFixture() {
+  try {
+    const entries = await readdir(CACHE_DIR);
+    for (const e of entries) {
+      if (e.startsWith(`recap-${FIXTURE_OWNER}-`)) {
+        await rm(join(CACHE_DIR, e), { force: true });
+      }
+    }
+  } catch {
+    // ignore
+  }
+}
+
+describe('recap cache', () => {
+  afterEach(async () => {
+    await cleanFixture();
+  });
+
+  it('returns null when nothing cached', async () => {
+    const out = await getCachedRecap(FIXTURE_OWNER, FIXTURE_REPO, 1, 'sha-missing');
+    expect(out).toBeNull();
+  });
+
+  it('caches and retrieves a recap roundtrip', async () => {
+    const recap = mkRecap({ goal: 'Roundtrip goal' });
+    await cacheRecap(FIXTURE_OWNER, FIXTURE_REPO, 5, 'sha-recap', recap);
+    const got = await getCachedRecap(FIXTURE_OWNER, FIXTURE_REPO, 5, 'sha-recap');
+    expect(got?.goal).toBe('Roundtrip goal');
+    expect(got?.stateOfPlay.done).toEqual(['parser']);
+    expect(got?.mentalModel.coreFiles).toEqual(['src/x.ts']);
+  });
+
+  it('uses a separate keyspace from narrative cache (recap- prefix)', async () => {
+    // Writing a recap and a narrative for the same owner/repo/number/sha
+    // should not collide. We don't directly observe collision here, but a
+    // recap read should round-trip the recap shape, not a narrative.
+    const recap = mkRecap({ goal: 'separate keyspace' });
+    await cacheRecap(FIXTURE_OWNER, FIXTURE_REPO, 7, 'sha-distinct', recap);
+    const got = await getCachedRecap(FIXTURE_OWNER, FIXTURE_REPO, 7, 'sha-distinct');
+    expect(got?.goal).toBe('separate keyspace');
+  });
+
+  it('returns null for corrupt cache file', async () => {
+    await mkdir(CACHE_DIR, { recursive: true });
+    const path = join(CACHE_DIR, `recap-${FIXTURE_OWNER}-${FIXTURE_REPO}-3-sha-bad.v1.json`);
+    await writeFile(path, '{ invalid');
+    const got = await getCachedRecap(FIXTURE_OWNER, FIXTURE_REPO, 3, 'sha-bad');
+    expect(got).toBeNull();
+  });
+
+  it('normalizes legacy/missing fields on read', async () => {
+    await mkdir(CACHE_DIR, { recursive: true });
+    const path = join(CACHE_DIR, `recap-${FIXTURE_OWNER}-${FIXTURE_REPO}-13-sha-legacy.v1.json`);
+    await writeFile(path, JSON.stringify({ goal: 'old' }));
+    const got = await getCachedRecap(FIXTURE_OWNER, FIXTURE_REPO, 13, 'sha-legacy');
+    expect(got?.goal).toBe('old');
+    expect(got?.stateOfPlay).toEqual({ done: [], wip: [], notStarted: [] });
+    expect(got?.decisions).toEqual([]);
+    expect(got?.blockers).toEqual([]);
+    expect(got?.mentalModel).toEqual({ coreFiles: [], touchpoints: [], sketch: '' });
+    expect(got?.howToHelp).toEqual([]);
+  });
+});

--- a/packages/cli/src/__tests__/recap-prompt.test.ts
+++ b/packages/cli/src/__tests__/recap-prompt.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from 'vitest';
+import { buildRecapPrompt } from '../recap/prompt';
+import type { RecapSources } from '../recap/sources';
+import type { CheckRun, DiffFile, ForcePushEvent, IssueRef, PRCommit, PRMetadata, PRReview } from '../github/types';
+
+function mkPR(over: Partial<PRMetadata> = {}): PRMetadata {
+  return {
+    number: 42,
+    title: 'Add feature X',
+    body: 'Fixes #1\n\nAdds feature X to the system.',
+    state: 'open',
+    draft: false,
+    author: { login: 'octocat', avatarUrl: '' },
+    branch: 'feat',
+    base: 'main',
+    labels: [],
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-02T00:00:00Z',
+    additions: 0,
+    deletions: 0,
+    changedFiles: 0,
+    commits: 0,
+    headSha: 'abc',
+    ...over,
+  };
+}
+
+function mkSources(over: Partial<RecapSources> = {}): RecapSources {
+  return {
+    pr: mkPR(),
+    files: [],
+    commits: [],
+    comments: [],
+    reviews: [],
+    checkRuns: [],
+    threads: [],
+    forcePushes: [],
+    linkedIssues: [],
+    ...over,
+  };
+}
+
+describe('buildRecapPrompt', () => {
+  it('produces a system prompt that pins the schema and operating principles', () => {
+    const { system } = buildRecapPrompt(mkSources());
+    expect(system).toContain('recap mode');
+    expect(system).toContain("Orient, don't audit");
+    expect(system).toContain('"goal"');
+    expect(system).toContain('"stateOfPlay"');
+    expect(system).toContain('"decisions"');
+    expect(system).toContain('"blockers"');
+    expect(system).toContain('"mentalModel"');
+    expect(system).toContain('"howToHelp"');
+  });
+
+  it('includes basic PR metadata', () => {
+    const { user } = buildRecapPrompt(mkSources({ pr: mkPR({ title: 'My PR', branch: 'feat-x', base: 'main' }) }));
+    expect(user).toContain('My PR');
+    expect(user).toContain('#42');
+    expect(user).toContain('feat-x → main');
+    expect(user).toContain('@octocat');
+  });
+
+  it('marks the PR as draft when draft=true', () => {
+    const { user } = buildRecapPrompt(mkSources({ pr: mkPR({ draft: true }) }));
+    expect(user).toContain('(draft)');
+  });
+
+  it('falls back to "(no description)" when body is empty', () => {
+    const { user } = buildRecapPrompt(mkSources({ pr: mkPR({ body: '   ' }) }));
+    expect(user).toContain('(no description)');
+  });
+
+  it('truncates very long PR bodies', () => {
+    const longBody = 'Q'.repeat(8000);
+    const { user } = buildRecapPrompt(
+      mkSources({ pr: mkPR({ body: longBody, title: 'plain title', author: { login: 'me', avatarUrl: '' } }) }),
+    );
+    // body is truncated at 4000 chars in the prompt
+    const qCount = (user.match(/Q/g) ?? []).length;
+    expect(qCount).toBeLessThanOrEqual(4000);
+    expect(qCount).toBeGreaterThan(3500);
+  });
+
+  it('lists linked issues with their state and a truncated body', () => {
+    const linkedIssues: IssueRef[] = [
+      {
+        number: 7,
+        title: 'Bug: thing breaks',
+        body: 'Y'.repeat(5000),
+        state: 'open',
+        url: 'https://x/7',
+      },
+    ];
+    const { user } = buildRecapPrompt(mkSources({ linkedIssues }));
+    expect(user).toContain('Linked issues:');
+    expect(user).toContain('#7 Bug: thing breaks (open)');
+    // Linked issue body capped to 2000 chars
+    const ys = (user.match(/Y/g) ?? []).length;
+    expect(ys).toBeLessThanOrEqual(2000);
+  });
+
+  it('caps commits at the 80-commit budget and notes the omission', () => {
+    const commits: PRCommit[] = Array.from({ length: 100 }, (_, i) => ({
+      sha: i.toString().padStart(7, '0'),
+      message: `commit ${i}`,
+      author: 'me',
+      authoredAt: '2026-01-01T00:00:00Z',
+    }));
+    const { user } = buildRecapPrompt(mkSources({ commits }));
+    expect(user).toContain('commit 0');
+    expect(user).toContain('commit 79');
+    expect(user).not.toContain('commit 80');
+    expect(user).toContain('20 earlier commits omitted');
+  });
+
+  it('emits "(no commits)" when commits is empty', () => {
+    const { user } = buildRecapPrompt(mkSources());
+    expect(user).toContain('(no commits)');
+  });
+
+  it('summarizes force pushes with before/after sha7', () => {
+    const forcePushes: ForcePushEvent[] = [
+      {
+        beforeSha: 'aaaaaaa1111111',
+        afterSha: 'bbbbbbb2222222',
+        actor: 'octocat',
+        createdAt: '2026-01-02T00:00:00Z',
+      },
+    ];
+    const { user } = buildRecapPrompt(mkSources({ forcePushes }));
+    expect(user).toContain('Force-pushes (1)');
+    expect(user).toContain('aaaaaaa -> bbbbbbb');
+    expect(user).toContain('@octocat');
+  });
+
+  it('handles initial / unknown force-push commits gracefully', () => {
+    const forcePushes: ForcePushEvent[] = [
+      { beforeSha: null, afterSha: null, actor: '', createdAt: '2026-01-02T00:00:00Z' },
+    ];
+    const { user } = buildRecapPrompt(mkSources({ forcePushes }));
+    expect(user).toContain('(initial) -> (unknown)');
+    expect(user).toContain('@unknown');
+  });
+
+  it('reports failing checks with their output title and summary', () => {
+    const checkRuns: CheckRun[] = [
+      {
+        id: 1,
+        name: 'lint',
+        status: 'completed',
+        conclusion: 'success',
+        startedAt: null,
+        completedAt: null,
+        detailsUrl: null,
+        output: {},
+      },
+      {
+        id: 2,
+        name: 'test',
+        status: 'completed',
+        conclusion: 'failure',
+        startedAt: null,
+        completedAt: null,
+        detailsUrl: null,
+        output: { title: 'tests failed', summary: '3 failures in foo.test.ts' },
+      },
+      {
+        id: 3,
+        name: 'build',
+        status: 'in_progress',
+        conclusion: null,
+        startedAt: null,
+        completedAt: null,
+        detailsUrl: null,
+        output: {},
+      },
+    ];
+    const { user } = buildRecapPrompt(mkSources({ checkRuns }));
+    expect(user).toContain('lint: success');
+    expect(user).toContain('test: failure');
+    expect(user).toContain('tests failed');
+    expect(user).toContain('3 failures in foo.test.ts');
+    // In-progress checks show their status, not a conclusion.
+    expect(user).toContain('build: in_progress');
+  });
+
+  it('summarizes file changes with new/deleted tags and add/del counts', () => {
+    const files: DiffFile[] = [
+      {
+        file: 'src/new.ts',
+        isNewFile: true,
+        isDeleted: false,
+        hunks: [
+          {
+            header: '@@ -0,0 +1,2 @@',
+            oldStart: 0,
+            oldCount: 0,
+            newStart: 1,
+            newCount: 2,
+            lines: [
+              { type: 'add', content: 'a', lineNumber: { new: 1 } },
+              { type: 'add', content: 'b', lineNumber: { new: 2 } },
+            ],
+          },
+        ],
+      },
+      {
+        file: 'src/old.ts',
+        isNewFile: false,
+        isDeleted: true,
+        hunks: [
+          {
+            header: '@@ -1,1 +0,0 @@',
+            oldStart: 1,
+            oldCount: 1,
+            newStart: 0,
+            newCount: 0,
+            lines: [{ type: 'remove', content: 'gone', lineNumber: { old: 1 } }],
+          },
+        ],
+      },
+    ];
+    const { user } = buildRecapPrompt(mkSources({ files }));
+    expect(user).toContain('src/new.ts [new]  +2 -0');
+    expect(user).toContain('src/old.ts [deleted]  +0 -1');
+  });
+
+  it('listing reviews only when there is at least one', () => {
+    const withReview: PRReview[] = [
+      {
+        id: 1,
+        user: 'alice',
+        avatarUrl: '',
+        state: 'APPROVED',
+        submittedAt: '2026-01-01T00:00:00Z',
+      },
+    ];
+    const withoutReview = buildRecapPrompt(mkSources()).user;
+    const withReviewUser = buildRecapPrompt(mkSources({ reviews: withReview })).user;
+    expect(withoutReview).not.toContain('Reviews (latest per user)');
+    expect(withReviewUser).toContain('Reviews (latest per user)');
+    expect(withReviewUser).toContain('@alice: APPROVED');
+  });
+});

--- a/packages/cli/src/__tests__/recap-sources.test.ts
+++ b/packages/cli/src/__tests__/recap-sources.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { buildThreads, parseLinkedIssues } from '../recap/sources';
+import type { PRComment } from '../github/types';
+
+describe('parseLinkedIssues', () => {
+  it('parses unqualified linking keywords as belonging to the PR repo', () => {
+    const refs = parseLinkedIssues('Fixes #42 and closes #100', 'octocat', 'hello');
+    expect(refs).toEqual([
+      { owner: 'octocat', repo: 'hello', number: 42 },
+      { owner: 'octocat', repo: 'hello', number: 100 },
+    ]);
+  });
+
+  it('parses qualified owner/repo refs', () => {
+    const refs = parseLinkedIssues('Resolves other/repo#7', 'me', 'mine');
+    expect(refs).toEqual([{ owner: 'other', repo: 'repo', number: 7 }]);
+  });
+
+  it('accepts the full set of linking keywords case-insensitively', () => {
+    const body = 'fix #1, Fixes #2, fixed #3, close #4, Closes #5, closed #6, Resolve #7, resolves #8, Resolved #9';
+    const refs = parseLinkedIssues(body, 'a', 'b');
+    expect(refs.map((r) => r.number)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+
+  it('dedupes repeated references', () => {
+    const refs = parseLinkedIssues('Fixes #1. Closes #1. Fixes a/b#1', 'me', 'mine');
+    expect(refs).toEqual([
+      { owner: 'me', repo: 'mine', number: 1 },
+      { owner: 'a', repo: 'b', number: 1 },
+    ]);
+  });
+
+  it('returns [] when nothing matches', () => {
+    expect(parseLinkedIssues('See #42 (no keyword)', 'me', 'mine')).toEqual([]);
+    expect(parseLinkedIssues('', 'me', 'mine')).toEqual([]);
+  });
+
+  it('does not match the keyword without an issue number', () => {
+    expect(parseLinkedIssues('Fixes nothing here', 'me', 'mine')).toEqual([]);
+  });
+});
+
+function mkComment(over: Partial<PRComment> & Pick<PRComment, 'id' | 'createdAt'>): PRComment {
+  return {
+    id: over.id,
+    author: over.author ?? 'alice',
+    body: over.body ?? '',
+    createdAt: over.createdAt,
+    updatedAt: over.updatedAt ?? over.createdAt,
+    path: over.path,
+    line: over.line,
+    inReplyToId: over.inReplyToId,
+    side: over.side,
+    startLine: over.startLine,
+    startSide: over.startSide,
+    diffHunk: over.diffHunk,
+    avatarUrl: over.avatarUrl,
+  };
+}
+
+describe('buildThreads', () => {
+  it('groups inline comments into threads keyed by root id', () => {
+    const root = mkComment({ id: 1, createdAt: '2026-01-01T00:00:00Z', path: 'a.ts', line: 10 });
+    const reply1 = mkComment({
+      id: 2,
+      createdAt: '2026-01-01T01:00:00Z',
+      path: 'a.ts',
+      line: 10,
+      inReplyToId: 1,
+    });
+    const reply2 = mkComment({
+      id: 3,
+      createdAt: '2026-01-01T02:00:00Z',
+      path: 'a.ts',
+      line: 10,
+      inReplyToId: 1,
+    });
+    const threads = buildThreads([reply2, root, reply1]);
+    expect(threads).toHaveLength(1);
+    expect(threads[0]?.rootId).toBe(1);
+    expect(threads[0]?.comments.map((c) => c.id)).toEqual([1, 2, 3]);
+    expect(threads[0]?.path).toBe('a.ts');
+    expect(threads[0]?.line).toBe(10);
+  });
+
+  it('produces a separate thread per root comment', () => {
+    const t1 = mkComment({ id: 1, createdAt: '2026-01-01T00:00:00Z', path: 'a.ts', line: 1 });
+    const t2 = mkComment({ id: 5, createdAt: '2026-01-01T00:00:01Z', path: 'b.ts', line: 9 });
+    const threads = buildThreads([t1, t2]);
+    expect(threads).toHaveLength(2);
+    expect(threads.map((t) => t.rootId).sort((a, b) => a - b)).toEqual([1, 5]);
+  });
+
+  it('ignores issue comments (no path)', () => {
+    const issueLevel = mkComment({ id: 99, createdAt: '2026-01-01T00:00:00Z', body: 'general' });
+    const inline = mkComment({ id: 1, createdAt: '2026-01-01T00:00:00Z', path: 'a.ts', line: 2 });
+    const threads = buildThreads([issueLevel, inline]);
+    expect(threads).toHaveLength(1);
+    expect(threads[0]?.rootId).toBe(1);
+  });
+
+  it('sorts comments within a thread oldest-first', () => {
+    const root = mkComment({ id: 1, createdAt: '2026-01-01T00:00:00Z', path: 'a.ts', line: 5 });
+    const newest = mkComment({
+      id: 3,
+      createdAt: '2026-01-03T00:00:00Z',
+      path: 'a.ts',
+      line: 5,
+      inReplyToId: 1,
+    });
+    const middle = mkComment({
+      id: 2,
+      createdAt: '2026-01-02T00:00:00Z',
+      path: 'a.ts',
+      line: 5,
+      inReplyToId: 1,
+    });
+    const threads = buildThreads([newest, middle, root]);
+    expect(threads[0]?.comments.map((c) => c.id)).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/cli/src/__tests__/recap-types.test.ts
+++ b/packages/cli/src/__tests__/recap-types.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeRecap } from '../recap/types';
+
+describe('normalizeRecap', () => {
+  it('fills missing fields with safe defaults', () => {
+    const out = normalizeRecap({});
+    expect(out.goal).toBe('');
+    expect(out.stateOfPlay).toEqual({ done: [], wip: [], notStarted: [] });
+    expect(out.decisions).toEqual([]);
+    expect(out.blockers).toEqual([]);
+    expect(out.mentalModel).toEqual({ coreFiles: [], touchpoints: [], sketch: '' });
+    expect(out.howToHelp).toEqual([]);
+  });
+
+  it('survives null/undefined input', () => {
+    expect(normalizeRecap(null).goal).toBe('');
+    expect(normalizeRecap(undefined).goal).toBe('');
+  });
+
+  it('preserves valid shaped input', () => {
+    const input = {
+      goal: 'Ship feature X',
+      stateOfPlay: {
+        done: ['parser', 'tests'],
+        wip: ['UI'],
+        notStarted: ['docs'],
+      },
+      decisions: [
+        {
+          decision: 'Use Hono',
+          reason: 'small footprint',
+          source: { type: 'commit', ref: 'abc123' },
+          alternativesRuledOut: ['Express'],
+        },
+      ],
+      blockers: [{ issue: 'CI red', evidence: 'lint failed', type: 'ci' }],
+      mentalModel: {
+        coreFiles: ['src/x.ts'],
+        touchpoints: ['src/index.ts'],
+        sketch: 'A -> B -> C',
+      },
+      howToHelp: [{ suggestion: 'Run lint', why: 'CI is red' }],
+    };
+    const out = normalizeRecap(input);
+    expect(out.goal).toBe('Ship feature X');
+    expect(out.decisions).toHaveLength(1);
+    expect(out.decisions[0]?.source.type).toBe('commit');
+    expect(out.decisions[0]?.alternativesRuledOut).toEqual(['Express']);
+    expect(out.blockers).toHaveLength(1);
+    expect(out.blockers[0]?.type).toBe('ci');
+    expect(out.howToHelp[0]?.suggestion).toBe('Run lint');
+  });
+
+  it('drops decisions with no decision string and clamps unknown source types', () => {
+    const out = normalizeRecap({
+      decisions: [
+        { decision: '', reason: 'r', source: { type: 'commit', ref: 'a' } },
+        { decision: 'good', reason: 'r', source: { type: 'WAT', ref: 'a' } },
+      ],
+    });
+    expect(out.decisions).toHaveLength(1);
+    expect(out.decisions[0]?.decision).toBe('good');
+    expect(out.decisions[0]?.source.type).toBe('commit'); // unknown -> default
+  });
+
+  it('drops blockers with no issue and clamps unknown blocker types', () => {
+    const out = normalizeRecap({
+      blockers: [
+        { issue: '', evidence: 'e', type: 'ci' },
+        { issue: 'x', evidence: 'e', type: 'WAT' },
+      ],
+    });
+    expect(out.blockers).toHaveLength(1);
+    expect(out.blockers[0]?.type).toBe('todo'); // unknown -> default
+  });
+
+  it('drops howToHelp entries missing a suggestion', () => {
+    const out = normalizeRecap({
+      howToHelp: [
+        { suggestion: '', why: 'w' },
+        { suggestion: 'do it', why: 'because' },
+      ],
+    });
+    expect(out.howToHelp).toHaveLength(1);
+    expect(out.howToHelp[0]?.suggestion).toBe('do it');
+  });
+
+  it('filters non-string entries from string arrays', () => {
+    const out = normalizeRecap({
+      stateOfPlay: { done: ['ok', 1, null, 'two'], wip: 'not-an-array', notStarted: undefined },
+      mentalModel: { coreFiles: ['a', 2, 'b'] },
+    });
+    expect(out.stateOfPlay.done).toEqual(['ok', 'two']);
+    expect(out.stateOfPlay.wip).toEqual([]);
+    expect(out.stateOfPlay.notStarted).toEqual([]);
+    expect(out.mentalModel.coreFiles).toEqual(['a', 'b']);
+  });
+});

--- a/packages/cli/src/__tests__/server-sse.test.ts
+++ b/packages/cli/src/__tests__/server-sse.test.ts
@@ -1,0 +1,513 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createServer, type ServerContext } from '../server';
+import type { NarrativeResponse } from '../narrative/types';
+import type { CheckRun, DiffFile, PRComment, PRMetadata, PRReview } from '../github/types';
+import type { GitHubClient } from '../github/client';
+
+// SSE stream helpers ----------------------------------------------------------
+
+type SseEvent = { event: string; data: unknown };
+
+function parseSseChunk(raw: string): SseEvent[] {
+  const events: SseEvent[] = [];
+  for (const block of raw.split('\n\n')) {
+    if (!block.trim()) continue;
+    let event = '';
+    const dataLines: string[] = [];
+    for (const line of block.split('\n')) {
+      if (line.startsWith('event: ')) event = line.slice('event: '.length);
+      else if (line.startsWith('data: ')) dataLines.push(line.slice('data: '.length));
+    }
+    if (event) {
+      const dataStr = dataLines.join('\n');
+      let data: unknown = dataStr;
+      try {
+        data = JSON.parse(dataStr);
+      } catch {
+        // leave as string
+      }
+      events.push({ event, data });
+    }
+  }
+  return events;
+}
+
+class StreamReader {
+  private reader: ReadableStreamDefaultReader<Uint8Array>;
+  private decoder = new TextDecoder();
+  private buffer = '';
+  /** A read() that timed out — we MUST not call read() again until this one resolves or is consumed. */
+  private pendingRead: ReturnType<ReadableStreamDefaultReader<Uint8Array>['read']> | null = null;
+  private closed = false;
+  events: SseEvent[] = [];
+
+  constructor(stream: ReadableStream<Uint8Array>) {
+    this.reader = stream.getReader();
+  }
+
+  /** Drain any chunks currently waiting in the queue. Resolves quickly. */
+  async drain(timeoutMs = 50): Promise<SseEvent[] | 'closed'> {
+    const newEvents: SseEvent[] = [];
+    while (!this.closed) {
+      if (!this.pendingRead) this.pendingRead = this.reader.read();
+      const winner = await Promise.race([
+        this.pendingRead.then((r) => ({ kind: 'data' as const, value: r })),
+        new Promise<{ kind: 'timeout' }>((res) => setTimeout(() => res({ kind: 'timeout' }), timeoutMs)),
+      ]);
+      if (winner.kind === 'timeout') break;
+      // Consume the resolved read.
+      this.pendingRead = null;
+      const r = winner.value;
+      if (r.done) {
+        this.closed = true;
+        const flushed = parseSseChunk(this.buffer);
+        newEvents.push(...flushed);
+        this.events.push(...flushed);
+        this.buffer = '';
+        return 'closed';
+      }
+      this.buffer += this.decoder.decode(r.value, { stream: true });
+      const lastBoundary = this.buffer.lastIndexOf('\n\n');
+      if (lastBoundary !== -1) {
+        const complete = this.buffer.slice(0, lastBoundary + 2);
+        this.buffer = this.buffer.slice(lastBoundary + 2);
+        const parsed = parseSseChunk(complete);
+        newEvents.push(...parsed);
+        this.events.push(...parsed);
+      }
+    }
+    return newEvents;
+  }
+
+  async cancel(): Promise<void> {
+    try {
+      await this.reader.cancel();
+    } catch {
+      // ignore
+    }
+  }
+}
+
+// Fixtures --------------------------------------------------------------------
+
+const baseNarrative: NarrativeResponse = {
+  title: 'PR title',
+  tldr: 'tldr',
+  verdict: 'safe',
+  readingPlan: [],
+  concerns: [],
+  chapters: [
+    {
+      title: 'C1',
+      summary: 's',
+      whyMatters: 'w',
+      risk: 'low',
+      sections: [{ type: 'diff', file: 'a.ts', startLine: 1, endLine: 3, hunkIndex: 0 }],
+    },
+  ],
+};
+
+function mkPR(over: Partial<PRMetadata> = {}): PRMetadata {
+  return {
+    number: 1,
+    title: 'PR',
+    body: '',
+    state: 'open',
+    draft: false,
+    author: { login: 'me', avatarUrl: '' },
+    branch: 'feat',
+    base: 'main',
+    labels: [],
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    additions: 0,
+    deletions: 0,
+    changedFiles: 0,
+    commits: 0,
+    headSha: 'sha-A',
+    ...over,
+  };
+}
+
+function mkContext(over: Partial<ServerContext> = {}): ServerContext {
+  return {
+    narrative: baseNarrative,
+    pr: mkPR(),
+    files: [],
+    comments: [],
+    checkRuns: [],
+    reviews: [],
+    github: {} as GitHubClient,
+    owner: 'o',
+    repo: 'r',
+    headSha: 'sha-A',
+    ...over,
+  };
+}
+
+type GhStub = {
+  getPR: (...args: unknown[]) => Promise<PRMetadata>;
+  getComments: (...args: unknown[]) => Promise<PRComment[]>;
+  getCheckRuns: (...args: unknown[]) => Promise<CheckRun[]>;
+  getReviews: (...args: unknown[]) => Promise<PRReview[]>;
+  getDiff: (...args: unknown[]) => Promise<DiffFile[]>;
+};
+
+function defaultGh(state: {
+  pr: PRMetadata;
+  comments?: PRComment[];
+  checks?: CheckRun[];
+  reviews?: PRReview[];
+  files?: DiffFile[];
+}): GhStub {
+  return {
+    getPR: async () => state.pr,
+    getComments: async () => state.comments ?? [],
+    getCheckRuns: async () => state.checks ?? [],
+    getReviews: async () => state.reviews ?? [],
+    getDiff: async () => state.files ?? [],
+  };
+}
+
+// Timer mocking ---------------------------------------------------------------
+
+let capturedIntervalCb: (() => void | Promise<void>) | null;
+let realSetInterval: typeof setInterval;
+let realSetTimeout: typeof setTimeout;
+let realClearInterval: typeof clearInterval;
+let realClearTimeout: typeof clearTimeout;
+
+beforeEach(() => {
+  capturedIntervalCb = null;
+  realSetInterval = globalThis.setInterval;
+  realSetTimeout = globalThis.setTimeout;
+  realClearInterval = globalThis.clearInterval;
+  realClearTimeout = globalThis.clearTimeout;
+
+  // Capture the polling interval callback. Return a stable handle so
+  // clearInterval doesn't error.
+  const fakeHandle = { __fake: true } as unknown as ReturnType<typeof setInterval>;
+  globalThis.setInterval = ((fn: () => void | Promise<void>) => {
+    capturedIntervalCb = fn;
+    return fakeHandle;
+  }) as typeof setInterval;
+  globalThis.clearInterval = ((handle: unknown) => {
+    if (handle === fakeHandle) capturedIntervalCb = null;
+    else realClearInterval(handle as ReturnType<typeof setInterval>);
+  }) as typeof clearInterval;
+
+  // Stop the 30s exit timer (and the 500ms post-joke exit) from ever
+  // calling process.exit during the test run. Other setTimeouts (used by
+  // our drain helper) must still work, so only no-op long delays.
+  globalThis.setTimeout = ((fn: () => void, ms?: number, ...args: unknown[]) => {
+    if (typeof ms === 'number' && ms >= 500) {
+      // long-delay timer (exit timer or its inner exit) — never fire it
+      return { __fake: true } as unknown as ReturnType<typeof setTimeout>;
+    }
+    return realSetTimeout(fn, ms, ...args);
+  }) as typeof setTimeout;
+});
+
+afterEach(() => {
+  globalThis.setInterval = realSetInterval;
+  globalThis.setTimeout = realSetTimeout;
+  globalThis.clearInterval = realClearInterval;
+  globalThis.clearTimeout = realClearTimeout;
+  capturedIntervalCb = null;
+});
+
+async function runPoll(): Promise<void> {
+  expect(capturedIntervalCb).not.toBeNull();
+  await capturedIntervalCb!();
+}
+
+// Tests -----------------------------------------------------------------------
+
+describe('GET /api/events — initial connection', () => {
+  it('emits a "connected" event immediately', async () => {
+    const ctx = mkContext({ github: defaultGh({ pr: mkPR() }) as unknown as GitHubClient });
+    const { app } = createServer(ctx);
+    const ctrl = new AbortController();
+    const res = await app.request('/api/events', { signal: ctrl.signal });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream');
+
+    const reader = new StreamReader(res.body!);
+    const events = (await reader.drain()) as SseEvent[];
+    expect(events.find((e) => e.event === 'connected')).toBeTruthy();
+    ctrl.abort();
+    await reader.cancel();
+  });
+
+  it('replays in-flight narrative-progress when a client reconnects mid-generation', async () => {
+    const ctx = mkContext({ github: defaultGh({ pr: mkPR() }) as unknown as GitHubClient });
+    const { app, broadcast } = createServer(ctx);
+
+    // Simulate progress having accumulated before the client connected.
+    broadcast('narrative-progress', { chars: 1234 });
+
+    const ctrl = new AbortController();
+    const res = await app.request('/api/events', { signal: ctrl.signal });
+    const reader = new StreamReader(res.body!);
+    const events = (await reader.drain()) as SseEvent[];
+    const progress = events.find((e) => e.event === 'narrative-progress');
+    expect(progress).toBeDefined();
+    expect((progress!.data as { chars: number }).chars).toBe(1234);
+
+    ctrl.abort();
+    await reader.cancel();
+  });
+
+  it('forwards broadcast events to all connected clients', async () => {
+    const ctx = mkContext({ github: defaultGh({ pr: mkPR() }) as unknown as GitHubClient });
+    const { app, broadcast } = createServer(ctx);
+
+    const ctrl = new AbortController();
+    const res = await app.request('/api/events', { signal: ctrl.signal });
+    const reader = new StreamReader(res.body!);
+    await reader.drain(); // consume connected
+
+    broadcast('comment', { id: 1, body: 'hi' });
+    const events = (await reader.drain()) as SseEvent[];
+    expect(events.find((e) => e.event === 'comment')).toBeDefined();
+
+    ctrl.abort();
+    await reader.cancel();
+  });
+});
+
+describe('GET /api/events — polling cycle', () => {
+  it('emits "comments" when new comments appear', async () => {
+    const state = {
+      pr: mkPR(),
+      comments: [] as PRComment[],
+      checks: [] as CheckRun[],
+      reviews: [] as PRReview[],
+    };
+    const ctx = mkContext({ github: defaultGh(state) as unknown as GitHubClient });
+    const { app } = createServer(ctx);
+    const ctrl = new AbortController();
+    const res = await app.request('/api/events', { signal: ctrl.signal });
+    const reader = new StreamReader(res.body!);
+    await reader.drain();
+
+    state.comments = [{ id: 7, author: 'alice', body: 'new', createdAt: '', updatedAt: '' }];
+    await runPoll();
+    const events = (await reader.drain()) as SseEvent[];
+    const c = events.find((e) => e.event === 'comments');
+    expect(c).toBeDefined();
+    expect((c!.data as PRComment[])[0]?.id).toBe(7);
+
+    ctrl.abort();
+    await reader.cancel();
+  });
+
+  it('emits "comments" when an existing comment is deleted', async () => {
+    const existing: PRComment = { id: 5, author: 'a', body: 'old', createdAt: '', updatedAt: '' };
+    const state = {
+      pr: mkPR(),
+      comments: [existing],
+    };
+    const ctx = mkContext({
+      github: defaultGh(state) as unknown as GitHubClient,
+      comments: [existing],
+    });
+    const { app } = createServer(ctx);
+    const ctrl = new AbortController();
+    const res = await app.request('/api/events', { signal: ctrl.signal });
+    const reader = new StreamReader(res.body!);
+    await reader.drain();
+
+    state.comments = []; // deleted
+    await runPoll();
+    const events = (await reader.drain()) as SseEvent[];
+    expect(events.find((e) => e.event === 'comments')).toBeDefined();
+
+    ctrl.abort();
+    await reader.cancel();
+  });
+
+  it('does NOT emit "comments" when the comment set is unchanged', async () => {
+    const c: PRComment = { id: 1, author: 'a', body: 'b', createdAt: '', updatedAt: '' };
+    const state = { pr: mkPR(), comments: [c] };
+    const ctx = mkContext({
+      github: defaultGh(state) as unknown as GitHubClient,
+      comments: [c],
+    });
+    const { app } = createServer(ctx);
+    const ctrl = new AbortController();
+    const res = await app.request('/api/events', { signal: ctrl.signal });
+    const reader = new StreamReader(res.body!);
+    await reader.drain();
+
+    await runPoll();
+    const events = (await reader.drain()) as SseEvent[];
+    expect(events.find((e) => e.event === 'comments')).toBeUndefined();
+    // Still emits checks + reviews unconditionally
+    expect(events.find((e) => e.event === 'checks')).toBeDefined();
+    expect(events.find((e) => e.event === 'reviews')).toBeDefined();
+
+    ctrl.abort();
+    await reader.cancel();
+  });
+
+  it('emits "pr" when PR metadata changes without a SHA change', async () => {
+    const state = { pr: mkPR({ draft: true }) };
+    const ctx = mkContext({
+      pr: mkPR({ draft: false }),
+      github: defaultGh(state) as unknown as GitHubClient,
+    });
+    const { app } = createServer(ctx);
+    const ctrl = new AbortController();
+    const res = await app.request('/api/events', { signal: ctrl.signal });
+    const reader = new StreamReader(res.body!);
+    await reader.drain();
+
+    await runPoll();
+    const events = (await reader.drain()) as SseEvent[];
+    const prEvt = events.find((e) => e.event === 'pr');
+    expect(prEvt).toBeDefined();
+    expect((prEvt!.data as { draft: boolean }).draft).toBe(true);
+
+    ctrl.abort();
+    await reader.cancel();
+  });
+
+  it('does NOT emit "pr" when only the SHA changed (regeneration handles it)', async () => {
+    const { cacheNarrative } = await import('../narrative/cache');
+    const newSha = `sha-shaonly-${Date.now()}`;
+    // Pre-seed cache so regen doesn't call out to a real LLM.
+    await cacheNarrative('o', 'r', 1, newSha, baseNarrative);
+
+    const state = { pr: mkPR({ headSha: newSha }) };
+    const ctx = mkContext({
+      headSha: 'sha-A',
+      pr: mkPR({ headSha: 'sha-A' }),
+      github: defaultGh(state) as unknown as GitHubClient,
+    });
+    const { app } = createServer(ctx);
+    const ctrl = new AbortController();
+    const res = await app.request('/api/events', { signal: ctrl.signal });
+    const reader = new StreamReader(res.body!);
+    await reader.drain();
+
+    await runPoll();
+    await new Promise((r) => setTimeout(r, 30));
+    const events = (await reader.drain(80)) as SseEvent[];
+    expect(events.find((e) => e.event === 'pr')).toBeUndefined();
+    expect(events.find((e) => e.event === 'regenerating')).toBeDefined();
+
+    ctrl.abort();
+    await reader.cancel();
+
+    const { rm } = await import('fs/promises');
+    const { homedir } = await import('os');
+    const { join } = await import('path');
+    await rm(join(homedir(), '.cache', 'diffdad', `o-r-1-${newSha}.v2.json`), { force: true }).catch(() => {});
+  });
+
+  it('on SHA change with a cached narrative, broadcasts "narrative" without re-generating', async () => {
+    // Pre-seed cache so the regenerate path uses it.
+    const { cacheNarrative } = await import('../narrative/cache');
+    const sha = `sha-fresh-${Date.now()}`;
+    await cacheNarrative('o', 'r', 1, sha, {
+      ...baseNarrative,
+      title: 'cached title',
+    });
+
+    const state = {
+      pr: mkPR({ headSha: sha }),
+    };
+    const ctx = mkContext({
+      headSha: 'sha-A',
+      pr: mkPR({ headSha: 'sha-A' }),
+      github: defaultGh(state) as unknown as GitHubClient,
+    });
+    const { app } = createServer(ctx);
+    const ctrl = new AbortController();
+    const res = await app.request('/api/events', { signal: ctrl.signal });
+    const reader = new StreamReader(res.body!);
+    await reader.drain();
+
+    await runPoll();
+    // Give the regen path a tick to run getDiff + cache lookup (all async).
+    await new Promise((r) => setTimeout(r, 30));
+    const events = (await reader.drain(80)) as SseEvent[];
+    expect(events.find((e) => e.event === 'regenerating')).toBeDefined();
+    const narrEvt = events.find((e) => e.event === 'narrative');
+    expect(narrEvt).toBeDefined();
+    expect((narrEvt!.data as { narrative: { title: string } }).narrative.title).toBe('cached title');
+    // ctx state should have been updated
+    expect(ctx.headSha).toBe(sha);
+    expect(ctx.narrative?.title).toBe('cached title');
+
+    ctrl.abort();
+    await reader.cancel();
+
+    // cleanup the fixture cache file
+    const { rm } = await import('fs/promises');
+    const { homedir } = await import('os');
+    const { join } = await import('path');
+    await rm(join(homedir(), '.cache', 'diffdad', `o-r-1-${sha}.v2.json`), { force: true }).catch(() => {});
+  });
+
+  it('swallows polling errors and keeps the loop alive', async () => {
+    let pollCount = 0;
+    const gh: GhStub = {
+      getPR: async () => {
+        pollCount++;
+        if (pollCount === 1) throw new Error('transient');
+        return mkPR();
+      },
+      getComments: async () => [],
+      getCheckRuns: async () => [],
+      getReviews: async () => [],
+      getDiff: async () => [],
+    };
+    const ctx = mkContext({ github: gh as unknown as GitHubClient });
+    const { app } = createServer(ctx);
+    const ctrl = new AbortController();
+    const res = await app.request('/api/events', { signal: ctrl.signal });
+    const reader = new StreamReader(res.body!);
+    await reader.drain();
+
+    // First poll: getPR throws — should not crash.
+    await runPoll();
+    let events = (await reader.drain()) as SseEvent[];
+    // No 'pr' or 'checks' events emitted because the error swallowed everything.
+    expect(events.find((e) => e.event === 'checks')).toBeUndefined();
+
+    // Second poll: getPR succeeds — interval should still be active.
+    expect(capturedIntervalCb).not.toBeNull();
+    await runPoll();
+    events = (await reader.drain()) as SseEvent[];
+    expect(events.find((e) => e.event === 'checks')).toBeDefined();
+
+    ctrl.abort();
+    await reader.cancel();
+  });
+});
+
+describe('GET /api/events — disconnect cleanup', () => {
+  it('clears the interval and removes the SSE client on abort', async () => {
+    const ctx = mkContext({ github: defaultGh({ pr: mkPR() }) as unknown as GitHubClient });
+    const { app, broadcast } = createServer(ctx);
+    const ctrl = new AbortController();
+    const res = await app.request('/api/events', { signal: ctrl.signal });
+    const reader = new StreamReader(res.body!);
+    await reader.drain();
+    expect(capturedIntervalCb).not.toBeNull();
+
+    ctrl.abort();
+    // After abort, the on-abort handler clears the interval. Allow any
+    // microtasks to flush.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(capturedIntervalCb).toBeNull();
+
+    // Broadcasting after abort shouldn't error and shouldn't deliver to the
+    // (now removed) client.
+    expect(() => broadcast('comment', { id: 999 })).not.toThrow();
+
+    await reader.cancel();
+  });
+});

--- a/packages/cli/src/__tests__/server.test.ts
+++ b/packages/cli/src/__tests__/server.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vitest';
-import { createServer } from '../server';
+import { describe, expect, it } from 'vitest';
+import { createServer, type ServerContext } from '../server';
 import type { NarrativeResponse } from '../narrative/types';
-import type { PRMetadata } from '../github/types';
+import type { CheckRun, DiffFile, PRComment, PRMetadata } from '../github/types';
+import type { GitHubClient, PostCommentOptions } from '../github/client';
 
 const mockNarrative: NarrativeResponse = {
   title: 'Test PR',
@@ -42,24 +43,414 @@ const mockPR: PRMetadata = {
   headSha: 'abc123',
 };
 
-describe('server', () => {
-  it('serves narrative at /api/narrative', async () => {
-    const { app } = createServer({
-      narrative: mockNarrative,
-      pr: mockPR,
-      files: [],
-      comments: [],
-      checkRuns: [],
-      reviews: [],
-      github: {} as any,
-      owner: 'test',
-      repo: 'test',
-      headSha: 'abc123',
-    });
+const mockFiles: DiffFile[] = [
+  {
+    file: 'src/index.ts',
+    isNewFile: false,
+    isDeleted: false,
+    hunks: [
+      {
+        header: '@@ -1,3 +1,4 @@',
+        oldStart: 1,
+        oldCount: 3,
+        newStart: 1,
+        newCount: 4,
+        lines: [
+          { type: 'context', content: 'a', lineNumber: { old: 1, new: 1 } },
+          { type: 'add', content: 'b', lineNumber: { new: 2 } },
+        ],
+      },
+    ],
+  },
+];
+
+type StubGitHub = Partial<GitHubClient> & {
+  postCommentCalls: { args: unknown[]; opts?: PostCommentOptions }[];
+  submitReviewCalls: unknown[][];
+  postCommentResponse?: PRComment;
+};
+
+function createStubGithub(overrides: Partial<StubGitHub> = {}): StubGitHub {
+  const stub: StubGitHub = {
+    postCommentCalls: [],
+    submitReviewCalls: [],
+    postCommentResponse: {
+      id: 999,
+      author: 'me',
+      body: 'posted',
+      createdAt: '',
+      updatedAt: '',
+    },
+    ...overrides,
+  };
+  stub.postComment = (async (owner: string, repo: string, number: number, body: string, opts?: PostCommentOptions) => {
+    stub.postCommentCalls.push({ args: [owner, repo, number, body], opts });
+    return {
+      ...(stub.postCommentResponse as PRComment),
+      body,
+    };
+  }) as GitHubClient['postComment'];
+  stub.submitReview = (async (...args: unknown[]) => {
+    stub.submitReviewCalls.push(args);
+  }) as unknown as GitHubClient['submitReview'];
+  return stub;
+}
+
+function buildContext(overrides: Partial<ServerContext> = {}): ServerContext {
+  const github = createStubGithub();
+  return {
+    narrative: mockNarrative,
+    pr: mockPR,
+    files: mockFiles,
+    comments: [],
+    checkRuns: [],
+    reviews: [],
+    github: github as unknown as GitHubClient,
+    owner: 'test',
+    repo: 'test',
+    headSha: 'abc123',
+    ...overrides,
+  };
+}
+
+describe('GET /api/narrative', () => {
+  it('returns the full narrative when ready', async () => {
+    const { app } = createServer(buildContext());
     const res = await app.request('/api/narrative');
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.narrative.title).toBe('Test PR');
     expect(data.narrative.chapters).toHaveLength(1);
+    expect(data.repoUrl).toBe('https://github.com/test/test');
+    expect(data.config).toMatchObject({
+      theme: 'auto',
+      storyStructure: 'chapters',
+      layoutMode: 'toc',
+    });
+  });
+
+  it('returns generating=true when narrative is still in progress', async () => {
+    const { app } = createServer(buildContext({ narrative: null }));
+    const res = await app.request('/api/narrative');
+    const data = (await res.json()) as { generating: boolean; narrative?: unknown };
+    expect(data.generating).toBe(true);
+    expect(data.narrative).toBeUndefined();
+  });
+
+  it('annotates inline comments with chapterIndices', async () => {
+    const inline: PRComment = {
+      id: 1,
+      author: 'a',
+      body: 'q',
+      createdAt: '',
+      updatedAt: '',
+      path: 'src/index.ts',
+      line: 1,
+    };
+    const { app } = createServer(buildContext({ comments: [inline] }));
+    const res = await app.request('/api/narrative');
+    const data = (await res.json()) as { comments: { id: number; chapterIndices: number[] }[] };
+    expect(data.comments[0]?.chapterIndices).toEqual([0]);
+  });
+});
+
+describe('GET /api/recap', () => {
+  it('returns idle when no recap and no error', async () => {
+    const { app } = createServer(buildContext());
+    const res = await app.request('/api/recap');
+    expect(await res.json()).toEqual({ status: 'idle' });
+  });
+
+  it('returns ready with recap when present', async () => {
+    const { app } = createServer(
+      buildContext({
+        recap: {
+          goal: 'g',
+          stateOfPlay: { done: [], wip: [], notStarted: [] },
+          decisions: [],
+          blockers: [],
+          mentalModel: { coreFiles: [], touchpoints: [], sketch: '' },
+          howToHelp: [],
+        },
+      }),
+    );
+    const res = await app.request('/api/recap');
+    const body = (await res.json()) as { status: string; recap: { goal: string } };
+    expect(body.status).toBe('ready');
+    expect(body.recap.goal).toBe('g');
+  });
+
+  it('returns generating when in flight', async () => {
+    const { app } = createServer(buildContext({ recapGenerating: true }));
+    expect(await (await app.request('/api/recap')).json()).toEqual({ status: 'generating' });
+  });
+
+  it('returns error when last attempt failed', async () => {
+    const { app } = createServer(buildContext({ recapError: 'boom' }));
+    expect(await (await app.request('/api/recap')).json()).toEqual({ status: 'error', error: 'boom' });
+  });
+});
+
+describe('POST /api/comments', () => {
+  it('rejects missing body with 400', async () => {
+    const ctx = buildContext();
+    const { app } = createServer(ctx);
+    const res = await app.request('/api/comments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    expect((ctx.github as unknown as StubGitHub).postCommentCalls).toHaveLength(0);
+  });
+
+  it('rejects malformed JSON with 400', async () => {
+    const { app } = createServer(buildContext());
+    const res = await app.request('/api/comments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{not json',
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('posts an issue comment when no path/line is given', async () => {
+    const ctx = buildContext();
+    const { app } = createServer(ctx);
+    const res = await app.request('/api/comments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ body: 'general thought' }),
+    });
+    expect(res.status).toBe(201);
+    const stub = ctx.github as unknown as StubGitHub;
+    expect(stub.postCommentCalls).toHaveLength(1);
+    expect(stub.postCommentCalls[0]?.opts).toBeUndefined();
+  });
+
+  it('posts an inline comment with the head SHA when path/line are given', async () => {
+    const ctx = buildContext();
+    const { app } = createServer(ctx);
+    await app.request('/api/comments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ body: 'inline', path: 'src/index.ts', line: 2 }),
+    });
+    const stub = ctx.github as unknown as StubGitHub;
+    expect(stub.postCommentCalls[0]?.opts).toMatchObject({
+      path: 'src/index.ts',
+      line: 2,
+      side: 'RIGHT',
+      commitId: 'abc123',
+    });
+  });
+
+  it('appends posted comment to ctx.comments', async () => {
+    const ctx = buildContext();
+    const { app } = createServer(ctx);
+    expect(ctx.comments).toHaveLength(0);
+    await app.request('/api/comments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ body: 'hi' }),
+    });
+    expect(ctx.comments).toHaveLength(1);
+  });
+});
+
+describe('POST /api/review', () => {
+  it('rejects an unknown event with 400', async () => {
+    const { app } = createServer(buildContext());
+    const res = await app.request('/api/review', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ event: 'merge_it' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('maps event names and forwards to submitReview', async () => {
+    const ctx = buildContext();
+    const { app } = createServer(ctx);
+    const res = await app.request('/api/review', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        event: 'approve',
+        body: 'lgtm',
+        comments: [{ path: 'src/index.ts', line: 2, body: 'nit' }],
+      }),
+    });
+    expect(res.status).toBe(200);
+    const stub = ctx.github as unknown as StubGitHub;
+    expect(stub.submitReviewCalls).toHaveLength(1);
+    expect(stub.submitReviewCalls[0]?.[3]).toBe('APPROVE');
+  });
+
+  it('returns 422 when GitHub rejects self-approval', async () => {
+    const ctx = buildContext({
+      github: {
+        ...createStubGithub(),
+        submitReview: (async () => {
+          throw new Error('Can not approve your own pull request');
+        }) as unknown as GitHubClient['submitReview'],
+      } as unknown as GitHubClient,
+    });
+    const { app } = createServer(ctx);
+    const res = await app.request('/api/review', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ event: 'approve' }),
+    });
+    expect(res.status).toBe(422);
+  });
+
+  it('rejects malformed JSON with 400', async () => {
+    const { app } = createServer(buildContext());
+    const res = await app.request('/api/review', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{nope',
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /api/ai', () => {
+  it('rejects unknown action with 400', async () => {
+    const { app } = createServer(buildContext());
+    const res = await app.request('/api/ai', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'mystery', chapterIndex: 0 }),
+    });
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toBe('unknown action');
+  });
+
+  it('rejects missing chapterIndex on ask action with 400', async () => {
+    const { app } = createServer(buildContext());
+    const res = await app.request('/api/ai', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'ask', question: 'why?' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects ask with no question', async () => {
+    const { app } = createServer(buildContext());
+    const res = await app.request('/api/ai', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'ask', chapterIndex: 0 }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects renarrate with no lens', async () => {
+    const { app } = createServer(buildContext());
+    const res = await app.request('/api/ai', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'renarrate', chapterIndex: 0 }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 503 when narrative is still generating and action requires it', async () => {
+    const { app } = createServer(buildContext({ narrative: null }));
+    const res = await app.request('/api/ai', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'ask', chapterIndex: 0, question: 'why?' }),
+    });
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 400 for an invalid chapter index', async () => {
+    const { app } = createServer(buildContext());
+    const res = await app.request('/api/ai', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'ask', chapterIndex: 99, question: 'q' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects malformed JSON with 400', async () => {
+    const { app } = createServer(buildContext());
+    const res = await app.request('/api/ai', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{bad',
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('GET /api/checks and /api/comments', () => {
+  it('GET /api/checks calls the github client with the head SHA', async () => {
+    const calls: string[] = [];
+    const stub = {
+      ...createStubGithub(),
+      getCheckRuns: (async (_owner: string, _repo: string, sha: string): Promise<CheckRun[]> => {
+        calls.push(sha);
+        return [];
+      }) as unknown as GitHubClient['getCheckRuns'],
+    };
+    const ctx = buildContext({ github: stub as unknown as GitHubClient });
+    const { app } = createServer(ctx);
+    const res = await app.request('/api/checks');
+    expect(res.status).toBe(200);
+    expect(calls).toEqual(['abc123']);
+  });
+
+  it('GET /api/comments returns mapped comments when narrative is ready', async () => {
+    const inline: PRComment = {
+      id: 1,
+      author: 'a',
+      body: 'q',
+      createdAt: '',
+      updatedAt: '',
+      path: 'src/index.ts',
+      line: 1,
+    };
+    const stub = {
+      ...createStubGithub(),
+      getComments: (async () => [inline]) as unknown as GitHubClient['getComments'],
+    };
+    const ctx = buildContext({ github: stub as unknown as GitHubClient });
+    const { app } = createServer(ctx);
+    const res = await app.request('/api/comments');
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as Array<PRComment & { chapterIndices?: number[] }>;
+    expect(data[0]?.chapterIndices).toEqual([0]);
+  });
+
+  it('GET /api/comments returns raw comments when narrative is not ready', async () => {
+    const inline: PRComment = {
+      id: 1,
+      author: 'a',
+      body: 'q',
+      createdAt: '',
+      updatedAt: '',
+      path: 'src/index.ts',
+      line: 1,
+    };
+    const stub = {
+      ...createStubGithub(),
+      getComments: (async () => [inline]) as unknown as GitHubClient['getComments'],
+    };
+    const ctx = buildContext({
+      narrative: null,
+      github: stub as unknown as GitHubClient,
+    });
+    const { app } = createServer(ctx);
+    const res = await app.request('/api/comments');
+    const data = (await res.json()) as Array<PRComment & { chapterIndices?: number[] }>;
+    // Raw comments don't have chapterIndices.
+    expect(data[0]?.chapterIndices).toBeUndefined();
   });
 });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -400,5 +400,7 @@ async function main(argv: string[]): Promise<number> {
   }
 }
 
-const exitCode = await main(Bun.argv.slice(2));
-process.exit(exitCode);
+if (import.meta.main) {
+  const exitCode = await main(Bun.argv.slice(2));
+  process.exit(exitCode);
+}


### PR DESCRIPTION
This PR adds extensive test coverage for the CLI application and its core modules, including GitHub API client interactions, server endpoints, narrative/recap generation, and utility functions.

## Summary
Introduces 11 new test files covering critical functionality across the codebase, improving test coverage and providing regression protection for key features.

## Key Changes

**New Test Files:**
- `github-client.test.ts` - Tests for GitHubClient covering PR fetching, diff parsing, comments, reviews, and comment posting
- `server.test.ts` - Expanded tests for HTTP endpoints (narrative, recap, comments, reviews, AI actions)
- `recap-prompt.test.ts` - Tests for recap prompt generation with various PR metadata scenarios
- `comments-mapping.test.ts` - Tests for mapping inline comments to narrative chapters
- `diff-parser-edges.test.ts` - Edge case tests for diff parsing (no newlines, renames, mode changes)
- `recap-sources.test.ts` - Tests for parsing linked issues and building comment threads
- `engine-helpers.test.ts` - Tests for AI provider inference and path resolution
- `narrative-cache.test.ts` - Tests for narrative caching with roundtrip validation
- `recap-types.test.ts` - Tests for recap normalization and type safety
- `recap-cache.test.ts` - Tests for recap caching functionality
- `cli-parse.test.ts` - Tests for CLI argument parsing (URLs and shorthand)

**Modified Files:**
- `server.test.ts` - Refactored with improved test helpers and expanded endpoint coverage
- `cli.ts` - Added `import.meta.main` guard to support test execution

## Notable Implementation Details

- Mock fetch implementation for testing GitHub API interactions without network calls
- Stub GitHub client for testing server endpoints in isolation
- Comprehensive edge case coverage for diff parsing (no newlines, renames, mode-only changes)
- Cache testing with fixture cleanup to prevent test pollution
- Type-safe test helpers for building mock objects (PRMetadata, DiffFile, etc.)
- Tests validate both happy paths and error conditions (404s, self-approval rejection, etc.)

https://claude.ai/code/session_01LQwgn63wPXjWBRAcEaST51