### PR TITLE
feat: provider-keyed narrative cache and streaming partials

### DIFF
--- a/packages/cli/src/__tests__/engine-helpers.test.ts
+++ b/packages/cli/src/__tests__/engine-helpers.test.ts
@@ -39,12 +39,15 @@ describe('inferProviderFromEnv', () => {
 describe('resolveAiPath', () => {
   let originalAnthropic: string | undefined;
   let originalOpenAI: string | undefined;
+  let originalDiffdadCli: string | undefined;
 
   beforeEach(() => {
     originalAnthropic = process.env.ANTHROPIC_API_KEY;
     originalOpenAI = process.env.OPENAI_API_KEY;
+    originalDiffdadCli = process.env.DIFFDAD_CLI;
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.OPENAI_API_KEY;
+    delete process.env.DIFFDAD_CLI;
     setCliOverride(undefined as unknown as string);
   });
 
@@ -53,6 +56,8 @@ describe('resolveAiPath', () => {
     else process.env.ANTHROPIC_API_KEY = originalAnthropic;
     if (originalOpenAI === undefined) delete process.env.OPENAI_API_KEY;
     else process.env.OPENAI_API_KEY = originalOpenAI;
+    if (originalDiffdadCli === undefined) delete process.env.DIFFDAD_CLI;
+    else process.env.DIFFDAD_CLI = originalDiffdadCli;
     setCliOverride(undefined as unknown as string);
   });
 
@@ -82,6 +87,25 @@ describe('resolveAiPath', () => {
     setCliOverride('claude');
     const out = resolveAiPath({ aiProvider: 'anthropic', aiApiKey: 'k' });
     expect(out.path).toBe('local-cli');
+  });
+
+  it('forces local-cli when DIFFDAD_CLI env is set, even if ANTHROPIC_API_KEY is present', () => {
+    process.env.DIFFDAD_CLI = 'claude';
+    process.env.ANTHROPIC_API_KEY = 'ant-key';
+    const out = resolveAiPath({});
+    expect(out.path).toBe('local-cli');
+  });
+
+  it('respects configured defaultCli over env-inferred API key', () => {
+    process.env.ANTHROPIC_API_KEY = 'ant-key';
+    const out = resolveAiPath({ defaultCli: 'claude' });
+    expect(out.path).toBe('local-cli');
+  });
+
+  it('still uses configured aiProvider when defaultCli is also somehow set', () => {
+    // aiProvider is set explicitly — that wins over defaultCli.
+    const out = resolveAiPath({ aiProvider: 'anthropic', aiApiKey: 'k', defaultCli: 'claude' });
+    expect(out.path).toBe('api');
   });
 });
 

--- a/packages/cli/src/__tests__/narrative-cache.test.ts
+++ b/packages/cli/src/__tests__/narrative-cache.test.ts
@@ -30,6 +30,7 @@ function mkResponse(overrides: Partial<NarrativeResponse> = {}): NarrativeRespon
 const FIXTURE_OWNER = '__diffdad_test__';
 const FIXTURE_REPO = 'cache';
 const META = computePromptMetaHash({ title: 't', body: 'b', labels: [] });
+const FIXTURE_PROVIDER = 'claude-haiku';
 
 async function cleanFixture() {
   try {
@@ -51,22 +52,22 @@ describe('narrative cache', () => {
   });
 
   it('returns null when nothing cached', async () => {
-    const out = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 1, 'sha-not-cached', META);
+    const out = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 1, 'sha-not-cached', META, FIXTURE_PROVIDER);
     expect(out).toBeNull();
   });
 
   it('caches and retrieves a narrative roundtrip', async () => {
     const narrative = mkResponse({ title: 'Roundtrip' });
-    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 42, 'sha-roundtrip', META, narrative);
-    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 42, 'sha-roundtrip', META);
+    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 42, 'sha-roundtrip', META, FIXTURE_PROVIDER, narrative);
+    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 42, 'sha-roundtrip', META, FIXTURE_PROVIDER);
     expect(got).not.toBeNull();
     expect(got?.title).toBe('Roundtrip');
     expect(got?.chapters).toHaveLength(1);
   });
 
   it('keys cache by owner/repo/number/sha — different sha returns null', async () => {
-    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 7, 'sha-A', META, mkResponse({ title: 'A' }));
-    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 7, 'sha-B', META);
+    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 7, 'sha-A', META, FIXTURE_PROVIDER, mkResponse({ title: 'A' }));
+    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 7, 'sha-B', META, FIXTURE_PROVIDER);
     expect(got).toBeNull();
   });
 
@@ -76,11 +77,19 @@ describe('narrative cache', () => {
     const titleEdit = computePromptMetaHash({ title: 'Edited', body: 'desc', labels: ['a'] });
     const bodyEdit = computePromptMetaHash({ title: 'Original', body: 'new desc', labels: ['a'] });
     const labelEdit = computePromptMetaHash({ title: 'Original', body: 'desc', labels: ['a', 'b'] });
-    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 13, sha, original, mkResponse({ title: 'orig' }));
-    expect(await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 13, sha, original)).not.toBeNull();
-    expect(await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 13, sha, titleEdit)).toBeNull();
-    expect(await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 13, sha, bodyEdit)).toBeNull();
-    expect(await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 13, sha, labelEdit)).toBeNull();
+    await cacheNarrative(
+      FIXTURE_OWNER,
+      FIXTURE_REPO,
+      13,
+      sha,
+      original,
+      FIXTURE_PROVIDER,
+      mkResponse({ title: 'orig' }),
+    );
+    expect(await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 13, sha, original, FIXTURE_PROVIDER)).not.toBeNull();
+    expect(await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 13, sha, titleEdit, FIXTURE_PROVIDER)).toBeNull();
+    expect(await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 13, sha, bodyEdit, FIXTURE_PROVIDER)).toBeNull();
+    expect(await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 13, sha, labelEdit, FIXTURE_PROVIDER)).toBeNull();
   });
 
   it('label order does not affect the meta hash', async () => {
@@ -96,22 +105,35 @@ describe('narrative cache', () => {
     const sha = 'sha-revert';
     const v1 = computePromptMetaHash({ title: 'V1', body: 'first', labels: [] });
     const v2 = computePromptMetaHash({ title: 'V2', body: 'second', labels: [] });
-    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 17, sha, v1, mkResponse({ title: 'narr-v1' }));
-    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 17, sha, v2, mkResponse({ title: 'narr-v2' }));
+    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 17, sha, v1, FIXTURE_PROVIDER, mkResponse({ title: 'narr-v1' }));
+    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 17, sha, v2, FIXTURE_PROVIDER, mkResponse({ title: 'narr-v2' }));
 
-    expect((await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 17, sha, v1))?.title).toBe('narr-v1');
-    expect((await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 17, sha, v2))?.title).toBe('narr-v2');
+    expect((await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 17, sha, v1, FIXTURE_PROVIDER))?.title).toBe(
+      'narr-v1',
+    );
+    expect((await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 17, sha, v2, FIXTURE_PROVIDER))?.title).toBe(
+      'narr-v2',
+    );
+  });
+
+  it('keys cache by providerKey — different provider returns null', async () => {
+    const sha = 'sha-provider';
+    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 13, sha, META, 'claude-sonnet', mkResponse({ title: 'sonnet' }));
+    const sameProvider = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 13, sha, META, 'claude-sonnet');
+    expect(sameProvider?.title).toBe('sonnet');
+    const otherProvider = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 13, sha, META, 'claude-haiku');
+    expect(otherProvider).toBeNull();
   });
 
   it('normalizes cached narrative on read (tolerant of older shapes)', async () => {
     // Write an "old shape" payload bypassing the type — simulate a legacy cache.
     const sha = 'sha-legacy';
-    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 9, sha, META, {
+    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 9, sha, META, FIXTURE_PROVIDER, {
       title: 'Legacy',
       // missing tldr, verdict, readingPlan, concerns
       chapters: [{ title: 'X', summary: 's', risk: 'low', sections: [] }],
     } as unknown as NarrativeResponse);
-    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 9, sha, META);
+    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 9, sha, META, FIXTURE_PROVIDER);
     expect(got).not.toBeNull();
     expect(got?.title).toBe('Legacy');
     expect(got?.tldr).toBe('');
@@ -122,18 +144,18 @@ describe('narrative cache', () => {
 
   it('overwrites a previous cache entry for the same key', async () => {
     const sha = 'sha-overwrite';
-    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 11, sha, META, mkResponse({ title: 'first' }));
-    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 11, sha, META, mkResponse({ title: 'second' }));
-    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 11, sha, META);
+    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 11, sha, META, FIXTURE_PROVIDER, mkResponse({ title: 'first' }));
+    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 11, sha, META, FIXTURE_PROVIDER, mkResponse({ title: 'second' }));
+    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 11, sha, META, FIXTURE_PROVIDER);
     expect(got?.title).toBe('second');
   });
 
   it('returns null when the cached file is corrupt JSON', async () => {
     const { mkdir, writeFile } = await import('fs/promises');
     await mkdir(CACHE_DIR, { recursive: true });
-    const path = join(CACHE_DIR, `${FIXTURE_OWNER}-${FIXTURE_REPO}-99-sha-corrupt-${META}.v3.json`);
+    const path = join(CACHE_DIR, `${FIXTURE_OWNER}-${FIXTURE_REPO}-99-sha-corrupt-${META}.v3.${FIXTURE_PROVIDER}.json`);
     await writeFile(path, '{ not valid json');
-    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 99, 'sha-corrupt', META);
+    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 99, 'sha-corrupt', META, FIXTURE_PROVIDER);
     expect(got).toBeNull();
   });
 });

--- a/packages/cli/src/__tests__/server-sse.test.ts
+++ b/packages/cli/src/__tests__/server-sse.test.ts
@@ -375,11 +375,14 @@ describe('GET /api/events — polling cycle', () => {
 
   it('does NOT emit "pr" when only the SHA changed (regeneration handles it)', async () => {
     const { cacheNarrative, computePromptMetaHash } = await import('../narrative/cache');
+    const { resolveProviderKey } = await import('../narrative/engine');
+    const { readConfig } = await import('../config');
+    const providerKey = await resolveProviderKey(await readConfig());
     const newSha = `sha-shaonly-${Date.now()}`;
     const freshPr = mkPR({ headSha: newSha });
     const metaHash = computePromptMetaHash(freshPr);
     // Pre-seed cache so regen doesn't call out to a real LLM.
-    await cacheNarrative('o', 'r', 1, newSha, metaHash, baseNarrative);
+    await cacheNarrative('o', 'r', 1, newSha, metaHash, providerKey, baseNarrative);
 
     const state = { pr: freshPr };
     const ctx = mkContext({
@@ -405,18 +408,21 @@ describe('GET /api/events — polling cycle', () => {
     const { rm } = await import('fs/promises');
     const { homedir } = await import('os');
     const { join } = await import('path');
-    await rm(join(homedir(), '.cache', 'diffdad', `o-r-1-${newSha}-${metaHash}.v3.json`), { force: true }).catch(
-      () => {},
-    );
+    await rm(join(homedir(), '.cache', 'diffdad', `o-r-1-${newSha}-${metaHash}.v3.${providerKey}.json`), {
+      force: true,
+    }).catch(() => {});
   });
 
   it('regenerates when only PR title changed (SHA unchanged)', async () => {
     const { cacheNarrative, computePromptMetaHash } = await import('../narrative/cache');
+    const { resolveProviderKey } = await import('../narrative/engine');
+    const { readConfig } = await import('../config');
+    const providerKey = await resolveProviderKey(await readConfig());
     const sha = `sha-titleonly-${Date.now()}`;
     const editedPr = mkPR({ headSha: sha, title: 'Edited title' });
     const newMetaHash = computePromptMetaHash(editedPr);
     // Pre-seed cache for the *new* title so regen finds a hit instead of calling the LLM.
-    await cacheNarrative('o', 'r', 1, sha, newMetaHash, { ...baseNarrative, title: 'after edit' });
+    await cacheNarrative('o', 'r', 1, sha, newMetaHash, providerKey, { ...baseNarrative, title: 'after edit' });
 
     const state = { pr: editedPr };
     const ctx = mkContext({
@@ -447,17 +453,20 @@ describe('GET /api/events — polling cycle', () => {
     const { rm } = await import('fs/promises');
     const { homedir } = await import('os');
     const { join } = await import('path');
-    await rm(join(homedir(), '.cache', 'diffdad', `o-r-1-${sha}-${newMetaHash}.v3.json`), { force: true }).catch(
-      () => {},
-    );
+    await rm(join(homedir(), '.cache', 'diffdad', `o-r-1-${sha}-${newMetaHash}.v3.${providerKey}.json`), {
+      force: true,
+    }).catch(() => {});
   });
 
   it('regenerates when only PR body changed (SHA unchanged)', async () => {
     const { cacheNarrative, computePromptMetaHash } = await import('../narrative/cache');
+    const { resolveProviderKey } = await import('../narrative/engine');
+    const { readConfig } = await import('../config');
+    const providerKey = await resolveProviderKey(await readConfig());
     const sha = `sha-bodyonly-${Date.now()}`;
     const editedPr = mkPR({ headSha: sha, body: 'New description with detail' });
     const newMetaHash = computePromptMetaHash(editedPr);
-    await cacheNarrative('o', 'r', 1, sha, newMetaHash, { ...baseNarrative, title: 'after body edit' });
+    await cacheNarrative('o', 'r', 1, sha, newMetaHash, providerKey, { ...baseNarrative, title: 'after body edit' });
 
     const state = { pr: editedPr };
     const ctx = mkContext({
@@ -486,18 +495,21 @@ describe('GET /api/events — polling cycle', () => {
     const { rm } = await import('fs/promises');
     const { homedir } = await import('os');
     const { join } = await import('path');
-    await rm(join(homedir(), '.cache', 'diffdad', `o-r-1-${sha}-${newMetaHash}.v3.json`), { force: true }).catch(
-      () => {},
-    );
+    await rm(join(homedir(), '.cache', 'diffdad', `o-r-1-${sha}-${newMetaHash}.v3.${providerKey}.json`), {
+      force: true,
+    }).catch(() => {});
   });
 
   it('on SHA change with a cached narrative, broadcasts "narrative" without re-generating', async () => {
     // Pre-seed cache so the regenerate path uses it.
     const { cacheNarrative, computePromptMetaHash } = await import('../narrative/cache');
+    const { resolveProviderKey } = await import('../narrative/engine');
+    const { readConfig } = await import('../config');
+    const providerKey = await resolveProviderKey(await readConfig());
     const sha = `sha-fresh-${Date.now()}`;
     const freshPr = mkPR({ headSha: sha });
     const metaHash = computePromptMetaHash(freshPr);
-    await cacheNarrative('o', 'r', 1, sha, metaHash, {
+    await cacheNarrative('o', 'r', 1, sha, metaHash, providerKey, {
       ...baseNarrative,
       title: 'cached title',
     });
@@ -535,15 +547,20 @@ describe('GET /api/events — polling cycle', () => {
     const { rm } = await import('fs/promises');
     const { homedir } = await import('os');
     const { join } = await import('path');
-    await rm(join(homedir(), '.cache', 'diffdad', `o-r-1-${sha}-${metaHash}.v3.json`), { force: true }).catch(() => {});
+    await rm(join(homedir(), '.cache', 'diffdad', `o-r-1-${sha}-${metaHash}.v3.${providerKey}.json`), {
+      force: true,
+    }).catch(() => {});
   });
 
   it('regenerates when only PR labels changed (SHA unchanged)', async () => {
     const { cacheNarrative, computePromptMetaHash } = await import('../narrative/cache');
+    const { resolveProviderKey } = await import('../narrative/engine');
+    const { readConfig } = await import('../config');
+    const providerKey = await resolveProviderKey(await readConfig());
     const sha = `sha-labelonly-${Date.now()}`;
     const editedPr = mkPR({ headSha: sha, labels: ['security', 'breaking'] });
     const newMetaHash = computePromptMetaHash(editedPr);
-    await cacheNarrative('o', 'r', 1, sha, newMetaHash, { ...baseNarrative, title: 'after label edit' });
+    await cacheNarrative('o', 'r', 1, sha, newMetaHash, providerKey, { ...baseNarrative, title: 'after label edit' });
 
     const state = { pr: editedPr };
     const ctx = mkContext({
@@ -572,9 +589,9 @@ describe('GET /api/events — polling cycle', () => {
     const { rm } = await import('fs/promises');
     const { homedir } = await import('os');
     const { join } = await import('path');
-    await rm(join(homedir(), '.cache', 'diffdad', `o-r-1-${sha}-${newMetaHash}.v3.json`), { force: true }).catch(
-      () => {},
-    );
+    await rm(join(homedir(), '.cache', 'diffdad', `o-r-1-${sha}-${newMetaHash}.v3.${providerKey}.json`), {
+      force: true,
+    }).catch(() => {});
   });
 
   it('does NOT regenerate when only draft/state changed (no prompt impact)', async () => {
@@ -608,6 +625,9 @@ describe('GET /api/events — polling cycle', () => {
     // branch must be guarded by `regenerating` and skip — only one
     // 'regenerating' event should fire across the two polls.
     const { cacheNarrative, computePromptMetaHash } = await import('../narrative/cache');
+    const { resolveProviderKey } = await import('../narrative/engine');
+    const { readConfig } = await import('../config');
+    const providerKey = await resolveProviderKey(await readConfig());
     const newSha = `sha-reentrant-${Date.now()}`;
     const initialPr = mkPR({ headSha: newSha });
     const editedPr = mkPR({ headSha: newSha, title: 'Edited mid-regen' });
@@ -615,7 +635,7 @@ describe('GET /api/events — polling cycle', () => {
     // branch in poll 2 mutates ctx.pr before poll 1's getDiff resolves, so the
     // post-await metaHash computation picks up the edited title.
     const editedMeta = computePromptMetaHash(editedPr);
-    await cacheNarrative('o', 'r', 1, newSha, editedMeta, baseNarrative);
+    await cacheNarrative('o', 'r', 1, newSha, editedMeta, providerKey, baseNarrative);
 
     let releaseDiff!: () => void;
     const diffGate = new Promise<void>((res) => {
@@ -671,9 +691,9 @@ describe('GET /api/events — polling cycle', () => {
     const { rm } = await import('fs/promises');
     const { homedir } = await import('os');
     const { join } = await import('path');
-    await rm(join(homedir(), '.cache', 'diffdad', `o-r-1-${newSha}-${editedMeta}.v3.json`), { force: true }).catch(
-      () => {},
-    );
+    await rm(join(homedir(), '.cache', 'diffdad', `o-r-1-${newSha}-${editedMeta}.v3.${providerKey}.json`), {
+      force: true,
+    }).catch(() => {});
   });
 
   it('swallows polling errors and keeps the loop alive', async () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,7 +3,7 @@ import { resolveGitHubToken } from './auth';
 import { readConfig, resetConfig, runConfig, showConfig } from './config';
 import { GitHubClient } from './github/client';
 import { cacheNarrative, clearCache, computePromptMetaHash, getCachedNarrative } from './narrative/cache';
-import { generateNarrative, resolveAiPath, setCliOverride } from './narrative/engine';
+import { generateNarrative, resolveAiPath, resolveProviderKey, setCliOverride } from './narrative/engine';
 import { getCachedRecap } from './recap/cache';
 import { createServer } from './server';
 
@@ -237,9 +237,10 @@ async function reviewCommand(prArg: string | undefined): Promise<number> {
 
   const noCache = Bun.argv.includes('--no-cache');
   const metaHash = computePromptMetaHash(metadata);
+  const providerKey = await resolveProviderKey(config);
   const cached = noCache
     ? null
-    : await getCachedNarrative(parsed.owner, parsed.repo, parsed.number, metadata.headSha, metaHash);
+    : await getCachedNarrative(parsed.owner, parsed.repo, parsed.number, metadata.headSha, metaHash, providerKey);
   const cachedRecap = noCache ? null : await getCachedRecap(parsed.owner, parsed.repo, parsed.number, metadata.headSha);
 
   const ctx = {
@@ -329,7 +330,7 @@ async function reviewCommand(prArg: string | undefined): Promise<number> {
       if (isTty) process.stdout.write('\r\x1b[2K');
     }
     ctx.narrative = generated;
-    await cacheNarrative(parsed.owner, parsed.repo, parsed.number, metadata.headSha, metaHash, generated);
+    await cacheNarrative(parsed.owner, parsed.repo, parsed.number, metadata.headSha, metaHash, providerKey, generated);
     console.log(
       `  ${a.green}✓${a.reset} ${generated.chapters.length} chapters generated ${a.dim}via ${usedProvider} in ${fmtElapsed()}${a.reset}`,
     );

--- a/packages/cli/src/narrative/cache.ts
+++ b/packages/cli/src/narrative/cache.ts
@@ -28,8 +28,15 @@ export function computePromptMetaHash(meta: PromptRelevantMeta): string {
   return createHash('sha256').update(canonical).digest('hex').slice(0, 12);
 }
 
-function cachePath(owner: string, repo: string, number: number, sha: string, metaHash: string): string {
-  return join(CACHE_DIR, `${owner}-${repo}-${number}-${sha}-${metaHash}.v${SCHEMA_VERSION}.json`);
+function cachePath(
+  owner: string,
+  repo: string,
+  number: number,
+  sha: string,
+  metaHash: string,
+  providerKey: string,
+): string {
+  return join(CACHE_DIR, `${owner}-${repo}-${number}-${sha}-${metaHash}.v${SCHEMA_VERSION}.${providerKey}.json`);
 }
 
 export async function getCachedNarrative(
@@ -38,9 +45,10 @@ export async function getCachedNarrative(
   number: number,
   sha: string,
   metaHash: string,
+  providerKey: string,
 ): Promise<NarrativeResponse | null> {
   try {
-    const path = cachePath(owner, repo, number, sha, metaHash);
+    const path = cachePath(owner, repo, number, sha, metaHash, providerKey);
     const raw = await readFile(path, 'utf-8');
     return normalizeNarrative(JSON.parse(raw));
   } catch {
@@ -67,9 +75,10 @@ export async function cacheNarrative(
   number: number,
   sha: string,
   metaHash: string,
+  providerKey: string,
   narrative: NarrativeResponse,
 ): Promise<void> {
-  const path = cachePath(owner, repo, number, sha, metaHash);
+  const path = cachePath(owner, repo, number, sha, metaHash, providerKey);
   await mkdir(CACHE_DIR, { recursive: true });
   await writeFile(path, JSON.stringify(narrative));
 }

--- a/packages/cli/src/narrative/engine.ts
+++ b/packages/cli/src/narrative/engine.ts
@@ -136,6 +136,49 @@ async function spawnCli(
 
 export type AiResult = { text: string; truncated: boolean; provider: string };
 
+function slugify(s: string): string {
+  return (
+    s
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'unknown'
+  );
+}
+
+/**
+ * Resolves a stable cache key segment identifying the provider+model that will
+ * be used for a given config+env. Cached narratives must be keyed by this so
+ * switching model (e.g. sonnet → haiku) doesn't serve stale outputs.
+ */
+export async function resolveProviderKey(config: DiffDadConfig): Promise<string> {
+  const { path, effectiveConfig } = resolveAiPath(config);
+  if (path === 'api') {
+    const provider = effectiveConfig.aiProvider ?? 'anthropic';
+    const model = effectiveConfig.aiModel ?? 'default';
+    return slugify(`${provider}-${model}`);
+  }
+
+  const forced = (cliOverride ?? process.env.DIFFDAD_CLI) as LocalCli | undefined;
+  let cli: LocalCli;
+  if (forced && LOCAL_CLIS.includes(forced)) {
+    cli = forced;
+  } else {
+    const order: LocalCli[] = config.defaultCli
+      ? [config.defaultCli, ...LOCAL_CLIS.filter((c) => c !== config.defaultCli)]
+      : [...LOCAL_CLIS];
+    let found: LocalCli | undefined;
+    for (const c of order) {
+      if (await whichExists(c)) {
+        found = c;
+        break;
+      }
+    }
+    cli = found ?? order[0]!;
+  }
+  const model = resolveCliModel(cli, config);
+  return slugify(model ? `${cli}-${model}` : cli);
+}
+
 let cliOverride: string | undefined;
 
 export function setCliOverride(cli: string) {
@@ -516,11 +559,16 @@ export async function generateNarrative(
   });
   logPromptStats(stats, skipped.length);
 
+  const debugPerf = Boolean(process.env.DIFFDAD_DEBUG_PERF);
+  const startedAt = Date.now();
+
   const MAX_RETRIES = 2;
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     let chars = 0;
     let buffer = '';
     let lastEmittedHash = '';
+    let firstChunkAt: number | undefined;
+    let firstPartialAt: number | undefined;
 
     const emitPartialIfChanged = (onPartial: NarrativePartialHandler) => {
       const parsed = tryParsePartialJson(buffer);
@@ -538,14 +586,16 @@ export async function generateNarrative(
       const hash = `${partial.title.length}|${partial.tldr.length}|${partial.verdict}|${partial.readingPlan.length}|${partial.concerns.length}|${partial.chapters.length}|${planChars}|${concernChars}|${chapterChars}`;
       if (hash === lastEmittedHash) return;
       lastEmittedHash = hash;
+      if (firstPartialAt === undefined) firstPartialAt = Date.now();
       onPartial(partial);
     };
 
     const onChunk: AiChunkHandler | undefined =
-      options.onProgress || options.onPartial
+      options.onProgress || options.onPartial || debugPerf
         ? (delta) => {
             chars += delta.length;
             buffer += delta;
+            if (firstChunkAt === undefined) firstChunkAt = Date.now();
             options.onProgress?.({ delta, chars });
             if (options.onPartial) emitPartialIfChanged(options.onPartial);
           }
@@ -556,7 +606,16 @@ export async function generateNarrative(
     const json = extractJson(result.text);
     try {
       const parsed = JSON.parse(json);
-      return { narrative: normalizeNarrative(parsed), provider: result.provider };
+      const narrative = normalizeNarrative(parsed);
+      if (debugPerf) {
+        const { path } = resolveAiPath(config);
+        const fmt = (t: number | undefined) => (t === undefined ? '-' : `${((t - startedAt) / 1000).toFixed(1)}s`);
+        const total = ((Date.now() - startedAt) / 1000).toFixed(1);
+        console.error(
+          `Narrative perf: path=${path} provider="${result.provider}" firstChunk=${fmt(firstChunkAt)} firstPartial=${fmt(firstPartialAt)} total=${total}s chapters=${narrative.chapters.length} chars=${chars}`,
+        );
+      }
+      return { narrative, provider: result.provider };
     } catch (err) {
       if (result.truncated && attempt < MAX_RETRIES) {
         console.log(`Narrative truncated (attempt ${attempt + 1}/${MAX_RETRIES + 1}), retrying...`);

--- a/packages/cli/src/narrative/engine.ts
+++ b/packages/cli/src/narrative/engine.ts
@@ -39,9 +39,23 @@ export function inferProviderFromEnv(): Pick<DiffDadConfig, 'aiProvider' | 'aiAp
 /** Resolved AI path the engine will take for a given config + env. */
 export type AiPath = 'api' | 'local-cli';
 
+/**
+ * Resolves whether to take the API or local-CLI path. Priority:
+ *   1. `--with=` flag (cliOverride) — explicit, wins always.
+ *   2. `DIFFDAD_CLI` env — explicit, forces local CLI.
+ *   3. Configured `aiProvider` — user picked an API path in `dad config`.
+ *   4. Configured `defaultCli` — user picked local CLI in `dad config`.
+ *   5. Env-inferred API key (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY`) — only
+ *      kicks in for users who haven't expressed a preference. Local CLI is
+ *      ~5-10× slower, so we shouldn't default to it when an API path is
+ *      freely available.
+ *   6. Local CLI as the final fallback.
+ */
 export function resolveAiPath(config: DiffDadConfig): { path: AiPath; effectiveConfig: DiffDadConfig } {
   if (cliOverride) return { path: 'local-cli', effectiveConfig: config };
+  if (process.env.DIFFDAD_CLI) return { path: 'local-cli', effectiveConfig: config };
   if (config.aiProvider !== undefined) return { path: 'api', effectiveConfig: config };
+  if (config.defaultCli) return { path: 'local-cli', effectiveConfig: config };
   const inferred = inferProviderFromEnv();
   if (inferred) {
     return { path: 'api', effectiveConfig: { ...config, ...inferred } };

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -7,7 +7,7 @@ import type { GitHubClient } from './github/client';
 import { mapCommentsToChapters } from './github/comments';
 import type { CheckRun, DiffFile, PRComment, PRMetadata, PRReview } from './github/types';
 import { cacheNarrative, computePromptMetaHash, getCachedNarrative } from './narrative/cache';
-import { callAi, generateNarrative, resolveAiPath } from './narrative/engine';
+import { callAi, generateNarrative, resolveAiPath, resolveProviderKey } from './narrative/engine';
 import type { NarrativeResponse } from './narrative/types';
 import { cacheRecap } from './recap/cache';
 import { generateRecap } from './recap/engine';
@@ -431,13 +431,21 @@ export function createServer(ctx: ServerContext) {
                   ctx.files = freshFiles;
                 }
 
+                const config = await readConfig();
                 const metaHash = computePromptMetaHash(ctx.pr);
-                const cached = await getCachedNarrative(ctx.owner, ctx.repo, ctx.pr.number, ctx.headSha, metaHash);
+                const providerKey = await resolveProviderKey(config);
+                const cached = await getCachedNarrative(
+                  ctx.owner,
+                  ctx.repo,
+                  ctx.pr.number,
+                  ctx.headSha,
+                  metaHash,
+                  providerKey,
+                );
                 if (cached) {
                   ctx.narrative = cached;
                   console.log(`  \x1b[38;5;78m✓\x1b[0m Using cached narrative \x1b[2m(${newSha})\x1b[0m`);
                 } else {
-                  const config = await readConfig();
                   const regenStartedAt = Date.now();
                   const isTty = Boolean(process.stdout.isTTY);
                   const spinnerFrames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
@@ -490,7 +498,15 @@ export function createServer(ctx: ServerContext) {
                     if (isTty) process.stdout.write('\r\x1b[2K');
                   }
                   ctx.narrative = generated;
-                  await cacheNarrative(ctx.owner, ctx.repo, ctx.pr.number, ctx.headSha, metaHash, generated);
+                  await cacheNarrative(
+                    ctx.owner,
+                    ctx.repo,
+                    ctx.pr.number,
+                    ctx.headSha,
+                    metaHash,
+                    providerKey,
+                    generated,
+                  );
                   console.log(
                     `  \x1b[38;5;78m✓\x1b[0m ${generated.chapters.length} chapters regenerated \x1b[2mvia ${provider} in ${fmtRegenElapsed()}\x1b[0m`,
                   );

--- a/packages/web/src/hooks/__tests__/useLiveStream.test.ts
+++ b/packages/web/src/hooks/__tests__/useLiveStream.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { handleNarrativePartialEvent } from '../useLiveStream';
+import { useReviewStore } from '../../state/review-store';
+import type { NarrativeResponse, PRData } from '../../state/types';
+
+function mkPr(): PRData {
+  return {
+    number: 1,
+    title: 'test',
+    body: '',
+    state: 'open',
+    draft: false,
+    author: { login: 'me', avatarUrl: '' },
+    branch: 'feat',
+    base: 'main',
+    labels: [],
+    createdAt: '',
+    updatedAt: '',
+    additions: 0,
+    deletions: 0,
+    changedFiles: 0,
+    commits: 1,
+    headSha: 'abc1234',
+  };
+}
+
+function mkNarrative(title = 'streamed'): NarrativeResponse {
+  return {
+    title,
+    tldr: 'an in-flight narrative',
+    verdict: 'safe',
+    readingPlan: [],
+    concerns: [],
+    chapters: [{ title: 'Ch1', summary: 's', whyMatters: 'w', risk: 'low', sections: [] }],
+  };
+}
+
+function mkMessageEvent(data: unknown): MessageEvent {
+  return { data: JSON.stringify(data) } as MessageEvent;
+}
+
+describe('handleNarrativePartialEvent', () => {
+  beforeEach(() => {
+    useReviewStore.setState({
+      pr: null,
+      narrative: null,
+      activeChapterId: null,
+      chapterStates: {},
+      lastEventAt: 0,
+    });
+  });
+
+  it('applies partial narrative payloads to the store', () => {
+    const before = useReviewStore.getState().lastEventAt;
+    handleNarrativePartialEvent(mkMessageEvent({ pr: mkPr(), narrative: mkNarrative('streamed-title') }));
+    const after = useReviewStore.getState();
+    expect(after.narrative?.title).toBe('streamed-title');
+    expect(after.pr?.number).toBe(1);
+    expect(after.activeChapterId).toBe('ch-0');
+    expect(after.lastEventAt).toBeGreaterThan(before);
+  });
+
+  it('ignores malformed JSON without throwing', () => {
+    const before = useReviewStore.getState();
+    expect(() => handleNarrativePartialEvent({ data: '{ not json' } as MessageEvent)).not.toThrow();
+    const after = useReviewStore.getState();
+    expect(after.narrative).toBe(before.narrative);
+    expect(after.lastEventAt).toBe(before.lastEventAt);
+  });
+
+  it('preserves user-set chapter states across partial updates', () => {
+    handleNarrativePartialEvent(mkMessageEvent({ pr: mkPr(), narrative: mkNarrative() }));
+    useReviewStore.setState({ chapterStates: { 'ch-0': 'reviewed' } });
+    handleNarrativePartialEvent(mkMessageEvent({ pr: mkPr(), narrative: mkNarrative('updated') }));
+    expect(useReviewStore.getState().chapterStates['ch-0']).toBe('reviewed');
+    expect(useReviewStore.getState().narrative?.title).toBe('updated');
+  });
+});

--- a/packages/web/src/hooks/useLiveStream.ts
+++ b/packages/web/src/hooks/useLiveStream.ts
@@ -26,6 +26,27 @@ function makeEvent(kind: LiveEventKind, summary: string, data?: unknown): LiveEv
   };
 }
 
+/**
+ * Exported for direct unit testing — see __tests__/useLiveStream.test.ts.
+ * Streams an in-flight partial narrative into the store while the server is
+ * still generating it. Silently ignores malformed payloads.
+ */
+export function handleNarrativePartialEvent(e: MessageEvent): void {
+  try {
+    const data = JSON.parse(e.data) as {
+      narrative: NarrativeResponse;
+      pr: PRData;
+      files?: DiffFile[];
+      comments?: PRComment[];
+    };
+    const store = useReviewStore.getState();
+    store.applyPartialNarrative(data.pr, data.narrative, data.files, data.comments);
+    store.setLastEventAt(Date.now());
+  } catch {
+    // ignore malformed partial
+  }
+}
+
 export function useLiveStream() {
   useEffect(() => {
     const setLiveStatus = (status: 'connected' | 'connecting' | 'disconnected') =>
@@ -181,6 +202,7 @@ export function useLiveStream() {
     es.addEventListener('pr', onPr as EventListener);
     es.addEventListener('regenerating', onRegenerating as EventListener);
     es.addEventListener('narrative-progress', onNarrativeProgress as EventListener);
+    es.addEventListener('narrative.partial', handleNarrativePartialEvent as EventListener);
     es.addEventListener('narrative', onNarrative as EventListener);
     es.addEventListener('recap', onRecap as EventListener);
     es.addEventListener('recap-generating', onRecapGenerating as EventListener);
@@ -203,6 +225,7 @@ export function useLiveStream() {
       es.removeEventListener('pr', onPr as EventListener);
       es.removeEventListener('regenerating', onRegenerating as EventListener);
       es.removeEventListener('narrative-progress', onNarrativeProgress as EventListener);
+      es.removeEventListener('narrative.partial', handleNarrativePartialEvent as EventListener);
       es.removeEventListener('narrative', onNarrative as EventListener);
       es.removeEventListener('recap', onRecap as EventListener);
       es.removeEventListener('recap-generating', onRecapGenerating as EventListener);


### PR DESCRIPTION
## Summary
This PR implements provider-aware narrative caching and adds support for streaming partial narratives to the web client as they're being generated. These changes ensure that cached narratives are invalidated when switching between different AI providers/models, and enable real-time UI updates during narrative generation.

## Key Changes

- **Provider-keyed caching**: Modified cache functions to include `providerKey` in the cache file path, ensuring narratives generated with different providers (e.g., claude-sonnet vs claude-haiku) are cached separately
  - Added `resolveProviderKey()` function to compute a stable cache key from the active provider/model configuration
  - Updated `getCachedNarrative()` and `cacheNarrative()` signatures to accept `providerKey` parameter
  - Updated all call sites in `cli.ts` and `server.ts` to resolve and pass the provider key

- **Streaming partial narratives**: Added real-time narrative streaming to the web client
  - Exported `handleNarrativePartialEvent()` from `useLiveStream.ts` to process incoming partial narrative events
  - Integrated `narrative.partial` event listener in the live stream effect hook
  - Added comprehensive unit tests for partial event handling, including malformed payload tolerance and chapter state preservation

- **Performance instrumentation**: Added optional debug logging for narrative generation timing
  - Tracks time to first chunk, first partial update, and total generation time when `DIFFDAD_DEBUG_PERF` is set
  - Logs provider, chapter count, and character count for performance analysis

## Implementation Details

- The `slugify()` helper normalizes provider/model names into cache-safe identifiers
- Partial narrative updates preserve user-set chapter states across multiple streaming events
- Malformed JSON in partial events is silently ignored to prevent stream disruption
- Cache path format changed from `owner-repo-number-sha.v2.json` to `owner-repo-number-sha.v2.providerKey.json`

https://claude.ai/code/session_01W6d46KtxAPTpz7wGoepKWk