### PR TITLE
fix: cache narratives by prompt-relevant PR metadata, not just SHA

### DIFF
--- a/packages/cli/src/__tests__/narrative-cache.test.ts
+++ b/packages/cli/src/__tests__/narrative-cache.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { homedir } from 'os';
 import { join } from 'path';
 import { rm } from 'fs/promises';
-import { cacheNarrative, getCachedNarrative } from '../narrative/cache';
+import { cacheNarrative, computePromptMetaHash, getCachedNarrative } from '../narrative/cache';
 import type { NarrativeResponse } from '../narrative/types';
 
 const CACHE_DIR = join(homedir(), '.cache', 'diffdad');
@@ -29,6 +29,7 @@ function mkResponse(overrides: Partial<NarrativeResponse> = {}): NarrativeRespon
 
 const FIXTURE_OWNER = '__diffdad_test__';
 const FIXTURE_REPO = 'cache';
+const META = computePromptMetaHash({ title: 't', body: 'b', labels: [] });
 
 async function cleanFixture() {
   try {
@@ -50,34 +51,53 @@ describe('narrative cache', () => {
   });
 
   it('returns null when nothing cached', async () => {
-    const out = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 1, 'sha-not-cached');
+    const out = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 1, 'sha-not-cached', META);
     expect(out).toBeNull();
   });
 
   it('caches and retrieves a narrative roundtrip', async () => {
     const narrative = mkResponse({ title: 'Roundtrip' });
-    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 42, 'sha-roundtrip', narrative);
-    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 42, 'sha-roundtrip');
+    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 42, 'sha-roundtrip', META, narrative);
+    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 42, 'sha-roundtrip', META);
     expect(got).not.toBeNull();
     expect(got?.title).toBe('Roundtrip');
     expect(got?.chapters).toHaveLength(1);
   });
 
   it('keys cache by owner/repo/number/sha — different sha returns null', async () => {
-    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 7, 'sha-A', mkResponse({ title: 'A' }));
-    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 7, 'sha-B');
+    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 7, 'sha-A', META, mkResponse({ title: 'A' }));
+    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 7, 'sha-B', META);
     expect(got).toBeNull();
+  });
+
+  it('keys cache by prompt-relevant metadata — title/body/label edits return null', async () => {
+    const sha = 'sha-meta';
+    const original = computePromptMetaHash({ title: 'Original', body: 'desc', labels: ['a'] });
+    const titleEdit = computePromptMetaHash({ title: 'Edited', body: 'desc', labels: ['a'] });
+    const bodyEdit = computePromptMetaHash({ title: 'Original', body: 'new desc', labels: ['a'] });
+    const labelEdit = computePromptMetaHash({ title: 'Original', body: 'desc', labels: ['a', 'b'] });
+    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 13, sha, original, mkResponse({ title: 'orig' }));
+    expect(await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 13, sha, original)).not.toBeNull();
+    expect(await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 13, sha, titleEdit)).toBeNull();
+    expect(await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 13, sha, bodyEdit)).toBeNull();
+    expect(await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 13, sha, labelEdit)).toBeNull();
+  });
+
+  it('label order does not affect the meta hash', async () => {
+    const a = computePromptMetaHash({ title: 't', body: 'b', labels: ['x', 'y'] });
+    const b = computePromptMetaHash({ title: 't', body: 'b', labels: ['y', 'x'] });
+    expect(a).toBe(b);
   });
 
   it('normalizes cached narrative on read (tolerant of older shapes)', async () => {
     // Write an "old shape" payload bypassing the type — simulate a legacy cache.
     const sha = 'sha-legacy';
-    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 9, sha, {
+    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 9, sha, META, {
       title: 'Legacy',
       // missing tldr, verdict, readingPlan, concerns
       chapters: [{ title: 'X', summary: 's', risk: 'low', sections: [] }],
     } as unknown as NarrativeResponse);
-    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 9, sha);
+    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 9, sha, META);
     expect(got).not.toBeNull();
     expect(got?.title).toBe('Legacy');
     expect(got?.tldr).toBe('');
@@ -88,20 +108,18 @@ describe('narrative cache', () => {
 
   it('overwrites a previous cache entry for the same key', async () => {
     const sha = 'sha-overwrite';
-    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 11, sha, mkResponse({ title: 'first' }));
-    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 11, sha, mkResponse({ title: 'second' }));
-    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 11, sha);
+    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 11, sha, META, mkResponse({ title: 'first' }));
+    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 11, sha, META, mkResponse({ title: 'second' }));
+    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 11, sha, META);
     expect(got?.title).toBe('second');
   });
 
   it('returns null when the cached file is corrupt JSON', async () => {
     const { mkdir, writeFile } = await import('fs/promises');
     await mkdir(CACHE_DIR, { recursive: true });
-    // Write a junk file at a key we control. The cache uses schema version v2
-    // — match the format so it's actually picked up.
-    const path = join(CACHE_DIR, `${FIXTURE_OWNER}-${FIXTURE_REPO}-99-sha-corrupt.v2.json`);
+    const path = join(CACHE_DIR, `${FIXTURE_OWNER}-${FIXTURE_REPO}-99-sha-corrupt-${META}.v3.json`);
     await writeFile(path, '{ not valid json');
-    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 99, 'sha-corrupt');
+    const got = await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 99, 'sha-corrupt', META);
     expect(got).toBeNull();
   });
 });

--- a/packages/cli/src/__tests__/narrative-cache.test.ts
+++ b/packages/cli/src/__tests__/narrative-cache.test.ts
@@ -89,6 +89,20 @@ describe('narrative cache', () => {
     expect(a).toBe(b);
   });
 
+  it('reverting a metadata edit re-hits the prior cache entry', async () => {
+    // The whole point of putting the meta hash in the key (rather than
+    // invalidating on write) is that flipping back to a prior version of the
+    // PR description finds the original narrative instead of regenerating.
+    const sha = 'sha-revert';
+    const v1 = computePromptMetaHash({ title: 'V1', body: 'first', labels: [] });
+    const v2 = computePromptMetaHash({ title: 'V2', body: 'second', labels: [] });
+    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 17, sha, v1, mkResponse({ title: 'narr-v1' }));
+    await cacheNarrative(FIXTURE_OWNER, FIXTURE_REPO, 17, sha, v2, mkResponse({ title: 'narr-v2' }));
+
+    expect((await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 17, sha, v1))?.title).toBe('narr-v1');
+    expect((await getCachedNarrative(FIXTURE_OWNER, FIXTURE_REPO, 17, sha, v2))?.title).toBe('narr-v2');
+  });
+
   it('normalizes cached narrative on read (tolerant of older shapes)', async () => {
     // Write an "old shape" payload bypassing the type — simulate a legacy cache.
     const sha = 'sha-legacy';

--- a/packages/cli/src/__tests__/server-sse.test.ts
+++ b/packages/cli/src/__tests__/server-sse.test.ts
@@ -374,12 +374,14 @@ describe('GET /api/events — polling cycle', () => {
   });
 
   it('does NOT emit "pr" when only the SHA changed (regeneration handles it)', async () => {
-    const { cacheNarrative } = await import('../narrative/cache');
+    const { cacheNarrative, computePromptMetaHash } = await import('../narrative/cache');
     const newSha = `sha-shaonly-${Date.now()}`;
+    const freshPr = mkPR({ headSha: newSha });
+    const metaHash = computePromptMetaHash(freshPr);
     // Pre-seed cache so regen doesn't call out to a real LLM.
-    await cacheNarrative('o', 'r', 1, newSha, baseNarrative);
+    await cacheNarrative('o', 'r', 1, newSha, metaHash, baseNarrative);
 
-    const state = { pr: mkPR({ headSha: newSha }) };
+    const state = { pr: freshPr };
     const ctx = mkContext({
       headSha: 'sha-A',
       pr: mkPR({ headSha: 'sha-A' }),
@@ -403,20 +405,105 @@ describe('GET /api/events — polling cycle', () => {
     const { rm } = await import('fs/promises');
     const { homedir } = await import('os');
     const { join } = await import('path');
-    await rm(join(homedir(), '.cache', 'diffdad', `o-r-1-${newSha}.v2.json`), { force: true }).catch(() => {});
+    await rm(join(homedir(), '.cache', 'diffdad', `o-r-1-${newSha}-${metaHash}.v3.json`), { force: true }).catch(
+      () => {},
+    );
+  });
+
+  it('regenerates when only PR title changed (SHA unchanged)', async () => {
+    const { cacheNarrative, computePromptMetaHash } = await import('../narrative/cache');
+    const sha = `sha-titleonly-${Date.now()}`;
+    const editedPr = mkPR({ headSha: sha, title: 'Edited title' });
+    const newMetaHash = computePromptMetaHash(editedPr);
+    // Pre-seed cache for the *new* title so regen finds a hit instead of calling the LLM.
+    await cacheNarrative('o', 'r', 1, sha, newMetaHash, { ...baseNarrative, title: 'after edit' });
+
+    const state = { pr: editedPr };
+    const ctx = mkContext({
+      headSha: sha,
+      pr: mkPR({ headSha: sha, title: 'Original title' }),
+      github: defaultGh(state) as unknown as GitHubClient,
+    });
+    const { app } = createServer(ctx);
+    const ctrl = new AbortController();
+    const res = await app.request('/api/events', { signal: ctrl.signal });
+    const reader = new StreamReader(res.body!);
+    await reader.drain();
+
+    await runPoll();
+    await new Promise((r) => setTimeout(r, 30));
+    const events = (await reader.drain(80)) as SseEvent[];
+    expect(events.find((e) => e.event === 'regenerating')).toBeDefined();
+    // No standalone 'pr' event — the regen path's 'narrative' broadcast carries the fresh PR.
+    expect(events.find((e) => e.event === 'pr')).toBeUndefined();
+    const narrEvt = events.find((e) => e.event === 'narrative');
+    expect(narrEvt).toBeDefined();
+    expect((narrEvt!.data as { narrative: { title: string } }).narrative.title).toBe('after edit');
+    expect(ctx.pr.title).toBe('Edited title');
+
+    ctrl.abort();
+    await reader.cancel();
+
+    const { rm } = await import('fs/promises');
+    const { homedir } = await import('os');
+    const { join } = await import('path');
+    await rm(join(homedir(), '.cache', 'diffdad', `o-r-1-${sha}-${newMetaHash}.v3.json`), { force: true }).catch(
+      () => {},
+    );
+  });
+
+  it('regenerates when only PR body changed (SHA unchanged)', async () => {
+    const { cacheNarrative, computePromptMetaHash } = await import('../narrative/cache');
+    const sha = `sha-bodyonly-${Date.now()}`;
+    const editedPr = mkPR({ headSha: sha, body: 'New description with detail' });
+    const newMetaHash = computePromptMetaHash(editedPr);
+    await cacheNarrative('o', 'r', 1, sha, newMetaHash, { ...baseNarrative, title: 'after body edit' });
+
+    const state = { pr: editedPr };
+    const ctx = mkContext({
+      headSha: sha,
+      pr: mkPR({ headSha: sha, body: '' }),
+      github: defaultGh(state) as unknown as GitHubClient,
+    });
+    const { app } = createServer(ctx);
+    const ctrl = new AbortController();
+    const res = await app.request('/api/events', { signal: ctrl.signal });
+    const reader = new StreamReader(res.body!);
+    await reader.drain();
+
+    await runPoll();
+    await new Promise((r) => setTimeout(r, 30));
+    const events = (await reader.drain(80)) as SseEvent[];
+    expect(events.find((e) => e.event === 'regenerating')).toBeDefined();
+    const narrEvt = events.find((e) => e.event === 'narrative');
+    expect(narrEvt).toBeDefined();
+    expect((narrEvt!.data as { narrative: { title: string } }).narrative.title).toBe('after body edit');
+    expect(ctx.pr.body).toBe('New description with detail');
+
+    ctrl.abort();
+    await reader.cancel();
+
+    const { rm } = await import('fs/promises');
+    const { homedir } = await import('os');
+    const { join } = await import('path');
+    await rm(join(homedir(), '.cache', 'diffdad', `o-r-1-${sha}-${newMetaHash}.v3.json`), { force: true }).catch(
+      () => {},
+    );
   });
 
   it('on SHA change with a cached narrative, broadcasts "narrative" without re-generating', async () => {
     // Pre-seed cache so the regenerate path uses it.
-    const { cacheNarrative } = await import('../narrative/cache');
+    const { cacheNarrative, computePromptMetaHash } = await import('../narrative/cache');
     const sha = `sha-fresh-${Date.now()}`;
-    await cacheNarrative('o', 'r', 1, sha, {
+    const freshPr = mkPR({ headSha: sha });
+    const metaHash = computePromptMetaHash(freshPr);
+    await cacheNarrative('o', 'r', 1, sha, metaHash, {
       ...baseNarrative,
       title: 'cached title',
     });
 
     const state = {
-      pr: mkPR({ headSha: sha }),
+      pr: freshPr,
     };
     const ctx = mkContext({
       headSha: 'sha-A',
@@ -448,7 +535,7 @@ describe('GET /api/events — polling cycle', () => {
     const { rm } = await import('fs/promises');
     const { homedir } = await import('os');
     const { join } = await import('path');
-    await rm(join(homedir(), '.cache', 'diffdad', `o-r-1-${sha}.v2.json`), { force: true }).catch(() => {});
+    await rm(join(homedir(), '.cache', 'diffdad', `o-r-1-${sha}-${metaHash}.v3.json`), { force: true }).catch(() => {});
   });
 
   it('swallows polling errors and keeps the loop alive', async () => {

--- a/packages/cli/src/__tests__/server-sse.test.ts
+++ b/packages/cli/src/__tests__/server-sse.test.ts
@@ -538,6 +538,144 @@ describe('GET /api/events — polling cycle', () => {
     await rm(join(homedir(), '.cache', 'diffdad', `o-r-1-${sha}-${metaHash}.v3.json`), { force: true }).catch(() => {});
   });
 
+  it('regenerates when only PR labels changed (SHA unchanged)', async () => {
+    const { cacheNarrative, computePromptMetaHash } = await import('../narrative/cache');
+    const sha = `sha-labelonly-${Date.now()}`;
+    const editedPr = mkPR({ headSha: sha, labels: ['security', 'breaking'] });
+    const newMetaHash = computePromptMetaHash(editedPr);
+    await cacheNarrative('o', 'r', 1, sha, newMetaHash, { ...baseNarrative, title: 'after label edit' });
+
+    const state = { pr: editedPr };
+    const ctx = mkContext({
+      headSha: sha,
+      pr: mkPR({ headSha: sha, labels: [] }),
+      github: defaultGh(state) as unknown as GitHubClient,
+    });
+    const { app } = createServer(ctx);
+    const ctrl = new AbortController();
+    const res = await app.request('/api/events', { signal: ctrl.signal });
+    const reader = new StreamReader(res.body!);
+    await reader.drain();
+
+    await runPoll();
+    await new Promise((r) => setTimeout(r, 30));
+    const events = (await reader.drain(80)) as SseEvent[];
+    expect(events.find((e) => e.event === 'regenerating')).toBeDefined();
+    const narrEvt = events.find((e) => e.event === 'narrative');
+    expect(narrEvt).toBeDefined();
+    expect((narrEvt!.data as { narrative: { title: string } }).narrative.title).toBe('after label edit');
+    expect(ctx.pr.labels).toEqual(['security', 'breaking']);
+
+    ctrl.abort();
+    await reader.cancel();
+
+    const { rm } = await import('fs/promises');
+    const { homedir } = await import('os');
+    const { join } = await import('path');
+    await rm(join(homedir(), '.cache', 'diffdad', `o-r-1-${sha}-${newMetaHash}.v3.json`), { force: true }).catch(
+      () => {},
+    );
+  });
+
+  it('does NOT regenerate when only draft/state changed (no prompt impact)', async () => {
+    // draft and state aren't fed into the narrative prompt, so flipping them
+    // should emit 'pr' but never trigger regeneration. Guards against future
+    // changes accidentally treating these like prompt-relevant fields.
+    const state = { pr: mkPR({ draft: true }) };
+    const ctx = mkContext({
+      pr: mkPR({ draft: false }),
+      github: defaultGh(state) as unknown as GitHubClient,
+    });
+    const { app } = createServer(ctx);
+    const ctrl = new AbortController();
+    const res = await app.request('/api/events', { signal: ctrl.signal });
+    const reader = new StreamReader(res.body!);
+    await reader.drain();
+
+    await runPoll();
+    await new Promise((r) => setTimeout(r, 30));
+    const events = (await reader.drain(80)) as SseEvent[];
+    expect(events.find((e) => e.event === 'pr')).toBeDefined();
+    expect(events.find((e) => e.event === 'regenerating')).toBeUndefined();
+    expect(events.find((e) => e.event === 'narrative')).toBeUndefined();
+
+    ctrl.abort();
+    await reader.cancel();
+  });
+
+  it('does not start a second regeneration while one is already in flight', async () => {
+    // If a poll arrives mid-regeneration with a PR title edit, the regen
+    // branch must be guarded by `regenerating` and skip — only one
+    // 'regenerating' event should fire across the two polls.
+    const { cacheNarrative, computePromptMetaHash } = await import('../narrative/cache');
+    const newSha = `sha-reentrant-${Date.now()}`;
+    const initialPr = mkPR({ headSha: newSha });
+    const editedPr = mkPR({ headSha: newSha, title: 'Edited mid-regen' });
+    // Pre-seed the cache under the edited title's hash. The standalone 'pr'
+    // branch in poll 2 mutates ctx.pr before poll 1's getDiff resolves, so the
+    // post-await metaHash computation picks up the edited title.
+    const editedMeta = computePromptMetaHash(editedPr);
+    await cacheNarrative('o', 'r', 1, newSha, editedMeta, baseNarrative);
+
+    let releaseDiff!: () => void;
+    const diffGate = new Promise<void>((res) => {
+      releaseDiff = res;
+    });
+
+    const state = { pr: initialPr };
+    const gh: GhStub = {
+      getPR: async () => state.pr,
+      getComments: async () => [],
+      getCheckRuns: async () => [],
+      getReviews: async () => [],
+      getDiff: async () => {
+        await diffGate;
+        return [];
+      },
+    };
+    const ctx = mkContext({
+      headSha: 'sha-A',
+      pr: mkPR({ headSha: 'sha-A' }),
+      github: gh as unknown as GitHubClient,
+    });
+    const { app } = createServer(ctx);
+    const ctrl = new AbortController();
+    const res = await app.request('/api/events', { signal: ctrl.signal });
+    const reader = new StreamReader(res.body!);
+    await reader.drain();
+
+    // First poll: SHA changes, regen starts and blocks on getDiff.
+    const firstPoll = capturedIntervalCb!();
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Mid-flight: someone edits the PR title.
+    state.pr = editedPr;
+
+    // Second poll: should hit the regen guard and skip — but still emit 'pr'
+    // for the title change so the UI doesn't go stale.
+    await capturedIntervalCb!();
+    let events = (await reader.drain(50)) as SseEvent[];
+    expect(events.filter((e) => e.event === 'regenerating')).toHaveLength(1);
+    expect(events.find((e) => e.event === 'pr')).toBeDefined();
+
+    // Let the first regen finish.
+    releaseDiff();
+    await firstPoll;
+    events = (await reader.drain(50)) as SseEvent[];
+    // The completed regen broadcasts a 'narrative' event.
+    expect(events.find((e) => e.event === 'narrative')).toBeDefined();
+
+    ctrl.abort();
+    await reader.cancel();
+
+    const { rm } = await import('fs/promises');
+    const { homedir } = await import('os');
+    const { join } = await import('path');
+    await rm(join(homedir(), '.cache', 'diffdad', `o-r-1-${newSha}-${editedMeta}.v3.json`), { force: true }).catch(
+      () => {},
+    );
+  });
+
   it('swallows polling errors and keeps the loop alive', async () => {
     let pollCount = 0;
     const gh: GhStub = {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,7 +2,7 @@
 import { resolveGitHubToken } from './auth';
 import { readConfig, resetConfig, runConfig, showConfig } from './config';
 import { GitHubClient } from './github/client';
-import { cacheNarrative, clearCache, getCachedNarrative } from './narrative/cache';
+import { cacheNarrative, clearCache, computePromptMetaHash, getCachedNarrative } from './narrative/cache';
 import { generateNarrative, resolveAiPath, setCliOverride } from './narrative/engine';
 import { getCachedRecap } from './recap/cache';
 import { createServer } from './server';
@@ -236,7 +236,10 @@ async function reviewCommand(prArg: string | undefined): Promise<number> {
   }
 
   const noCache = Bun.argv.includes('--no-cache');
-  const cached = noCache ? null : await getCachedNarrative(parsed.owner, parsed.repo, parsed.number, metadata.headSha);
+  const metaHash = computePromptMetaHash(metadata);
+  const cached = noCache
+    ? null
+    : await getCachedNarrative(parsed.owner, parsed.repo, parsed.number, metadata.headSha, metaHash);
   const cachedRecap = noCache ? null : await getCachedRecap(parsed.owner, parsed.repo, parsed.number, metadata.headSha);
 
   const ctx = {
@@ -326,7 +329,7 @@ async function reviewCommand(prArg: string | undefined): Promise<number> {
       if (isTty) process.stdout.write('\r\x1b[2K');
     }
     ctx.narrative = generated;
-    await cacheNarrative(parsed.owner, parsed.repo, parsed.number, metadata.headSha, generated);
+    await cacheNarrative(parsed.owner, parsed.repo, parsed.number, metadata.headSha, metaHash, generated);
     console.log(
       `  ${a.green}✓${a.reset} ${generated.chapters.length} chapters generated ${a.dim}via ${usedProvider} in ${fmtElapsed()}${a.reset}`,
     );

--- a/packages/cli/src/narrative/cache.ts
+++ b/packages/cli/src/narrative/cache.ts
@@ -1,16 +1,35 @@
 import { homedir } from 'os';
 import { join } from 'path';
+import { createHash } from 'crypto';
 import { readdir, readFile, rm, writeFile, mkdir } from 'fs/promises';
 import { normalizeNarrative, type NarrativeResponse } from './types';
 
 const CACHE_DIR = join(homedir(), '.cache', 'diffdad');
 
-// Cache schema version. Bump when the NarrativeResponse shape changes in a way
-// that would make older cached entries unreadable.
-const SCHEMA_VERSION = 2;
+// Cache schema version. Bump when the NarrativeResponse shape OR the cache key
+// format changes in a way that would make older cached entries unreadable. v3
+// added the prompt-meta hash to the key so PR title/body/label edits regenerate.
+const SCHEMA_VERSION = 3;
 
-function cachePath(owner: string, repo: string, number: number, sha: string): string {
-  return join(CACHE_DIR, `${owner}-${repo}-${number}-${sha}.v${SCHEMA_VERSION}.json`);
+export type PromptRelevantMeta = {
+  title: string;
+  body: string;
+  labels: string[];
+};
+
+// Short stable hash over the PR fields the narrative prompt actually consumes.
+// If any of these change on GitHub, the cached narrative is no longer valid.
+export function computePromptMetaHash(meta: PromptRelevantMeta): string {
+  const canonical = JSON.stringify({
+    title: meta.title,
+    body: meta.body,
+    labels: [...meta.labels].sort(),
+  });
+  return createHash('sha256').update(canonical).digest('hex').slice(0, 12);
+}
+
+function cachePath(owner: string, repo: string, number: number, sha: string, metaHash: string): string {
+  return join(CACHE_DIR, `${owner}-${repo}-${number}-${sha}-${metaHash}.v${SCHEMA_VERSION}.json`);
 }
 
 export async function getCachedNarrative(
@@ -18,9 +37,10 @@ export async function getCachedNarrative(
   repo: string,
   number: number,
   sha: string,
+  metaHash: string,
 ): Promise<NarrativeResponse | null> {
   try {
-    const path = cachePath(owner, repo, number, sha);
+    const path = cachePath(owner, repo, number, sha, metaHash);
     const raw = await readFile(path, 'utf-8');
     return normalizeNarrative(JSON.parse(raw));
   } catch {
@@ -46,9 +66,10 @@ export async function cacheNarrative(
   repo: string,
   number: number,
   sha: string,
+  metaHash: string,
   narrative: NarrativeResponse,
 ): Promise<void> {
-  const path = cachePath(owner, repo, number, sha);
+  const path = cachePath(owner, repo, number, sha, metaHash);
   await mkdir(CACHE_DIR, { recursive: true });
   await writeFile(path, JSON.stringify(narrative));
 }

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -6,7 +6,7 @@ import { readConfig } from './config';
 import type { GitHubClient } from './github/client';
 import { mapCommentsToChapters } from './github/comments';
 import type { CheckRun, DiffFile, PRComment, PRMetadata, PRReview } from './github/types';
-import { cacheNarrative, getCachedNarrative } from './narrative/cache';
+import { cacheNarrative, computePromptMetaHash, getCachedNarrative } from './narrative/cache';
 import { callAi, generateNarrative, resolveAiPath } from './narrative/engine';
 import type { NarrativeResponse } from './narrative/types';
 import { cacheRecap } from './recap/cache';
@@ -374,12 +374,17 @@ export function createServer(ctx: ServerContext) {
             const freshPr = await ctx.github.getPR(ctx.owner, ctx.repo, ctx.pr.number);
             const shaChanged = freshPr.headSha !== ctx.headSha;
 
-            const prMetaChanged =
-              freshPr.draft !== ctx.pr.draft ||
-              freshPr.state !== ctx.pr.state ||
+            // These fields feed into the narrative prompt — changes here mean
+            // the cached narrative is stale and we need to regenerate.
+            const promptMetaChanged =
               freshPr.title !== ctx.pr.title ||
+              freshPr.body !== ctx.pr.body ||
               freshPr.labels.join(',') !== ctx.pr.labels.join(',');
-            if (prMetaChanged && !shaChanged) {
+            const otherMetaChanged = freshPr.draft !== ctx.pr.draft || freshPr.state !== ctx.pr.state;
+            // If the regen branch below will fire, it'll broadcast the fresh PR
+            // alongside the new narrative — skip the standalone 'pr' event then.
+            const willRegenerate = (shaChanged || promptMetaChanged) && !regenerating;
+            if ((promptMetaChanged || otherMetaChanged) && !shaChanged && !willRegenerate) {
               ctx.pr = freshPr;
               send('pr', ctx.pr);
             }
@@ -402,11 +407,15 @@ export function createServer(ctx: ServerContext) {
             ctx.reviews = freshReviews;
             send('reviews', freshReviews);
 
-            if (shaChanged && !regenerating) {
+            if ((shaChanged || promptMetaChanged) && !regenerating) {
               regenerating = true;
               const prevSha = ctx.headSha.slice(0, 7);
               const newSha = freshPr.headSha.slice(0, 7);
-              console.log(`\n  \x1b[38;5;221m↻\x1b[0m New commits detected \x1b[2m(${prevSha} → ${newSha})\x1b[0m`);
+              if (shaChanged) {
+                console.log(`\n  \x1b[38;5;221m↻\x1b[0m New commits detected \x1b[2m(${prevSha} → ${newSha})\x1b[0m`);
+              } else {
+                console.log(`\n  \x1b[38;5;221m↻\x1b[0m PR title/description/labels changed`);
+              }
               console.log(`  \x1b[2mRegenerating narrative...\x1b[0m`);
               broadcast('regenerating', { previousSha: prevSha, newSha });
 
@@ -415,11 +424,15 @@ export function createServer(ctx: ServerContext) {
                 const prevChapterTitles = ctx.narrative?.chapters.map((ch) => ch.title) ?? [];
 
                 ctx.pr = freshPr;
-                ctx.headSha = freshPr.headSha;
-                const freshFiles = await ctx.github.getDiff(ctx.owner, ctx.repo, ctx.pr.number);
-                ctx.files = freshFiles;
+                let freshFiles = ctx.files;
+                if (shaChanged) {
+                  ctx.headSha = freshPr.headSha;
+                  freshFiles = await ctx.github.getDiff(ctx.owner, ctx.repo, ctx.pr.number);
+                  ctx.files = freshFiles;
+                }
 
-                const cached = await getCachedNarrative(ctx.owner, ctx.repo, ctx.pr.number, ctx.headSha);
+                const metaHash = computePromptMetaHash(ctx.pr);
+                const cached = await getCachedNarrative(ctx.owner, ctx.repo, ctx.pr.number, ctx.headSha, metaHash);
                 if (cached) {
                   ctx.narrative = cached;
                   console.log(`  \x1b[38;5;78m✓\x1b[0m Using cached narrative \x1b[2m(${newSha})\x1b[0m`);
@@ -477,7 +490,7 @@ export function createServer(ctx: ServerContext) {
                     if (isTty) process.stdout.write('\r\x1b[2K');
                   }
                   ctx.narrative = generated;
-                  await cacheNarrative(ctx.owner, ctx.repo, ctx.pr.number, ctx.headSha, generated);
+                  await cacheNarrative(ctx.owner, ctx.repo, ctx.pr.number, ctx.headSha, metaHash, generated);
                   console.log(
                     `  \x1b[38;5;78m✓\x1b[0m ${generated.chapters.length} chapters regenerated \x1b[2mvia ${provider} in ${fmtRegenElapsed()}\x1b[0m`,
                   );


### PR DESCRIPTION
## Summary
This change extends the narrative cache key to include a hash of prompt-relevant PR metadata (title, body, labels), enabling the system to detect and regenerate narratives when these fields change without requiring a new commit. Previously, only the commit SHA was used as a cache key, so editing a PR's title/description/labels wouldn't trigger regeneration.

## Key Changes

- **New `computePromptMetaHash()` function**: Computes a stable 12-character SHA256 hash of PR title, body, and labels (sorted for consistency). This hash is now part of the cache key.

- **Updated cache key format**: Changed from `owner-repo-number-sha.v2.json` to `owner-repo-number-sha-metaHash.v3.json` (schema version bumped to v3).

- **Regeneration logic**: The polling cycle now detects changes to prompt-relevant fields (`title`, `body`, `labels`) separately from other PR metadata (`draft`, `state`). When these fields change without a SHA change, regeneration is triggered.

- **Conditional diff fetching**: When regenerating due to metadata changes (not SHA changes), the system reuses existing file diffs instead of fetching new ones from GitHub.

- **Standalone 'pr' event handling**: When regeneration will occur, the standalone 'pr' event is skipped to avoid duplicate broadcasts—the regeneration path broadcasts both the fresh PR and new narrative together.

- **Reentrant regeneration guard**: Added protection against starting a second regeneration while one is already in flight, with proper event sequencing.

## Notable Implementation Details

- Label order doesn't affect the hash (labels are sorted before hashing), so reordering labels won't invalidate the cache.
- Reverting a PR description to a prior version will re-hit the original cached narrative instead of regenerating.
- The `draft` and `state` fields are explicitly excluded from the prompt hash since they don't affect narrative generation, with a test guarding against accidental future changes.
- All cache operations now require the `metaHash` parameter, ensuring consistency across the codebase.

https://claude.ai/code/session_012JzLSE2bCJffDgKdJjoFDv