### PR TITLE
feat: dual-publish formula to homebrew-formulae

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,13 +82,20 @@ jobs:
   update-formula:
     needs: [release-please, build]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - repo: nicknisi/homebrew-diffdad
+            path: tap-legacy
+          - repo: nicknisi/homebrew-formulae
+            path: tap-formulae
     steps:
       - name: Checkout tap repo
         uses: actions/checkout@v4
         with:
-          repository: nicknisi/homebrew-diffdad
+          repository: ${{ matrix.repo }}
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          path: tap
+          path: ${{ matrix.path }}
 
       - uses: actions/download-artifact@v4
         with:
@@ -97,15 +104,16 @@ jobs:
       - name: Update formula
         env:
           VERSION: ${{ needs.release-please.outputs.tag_name }}
+          TAP_PATH: ${{ matrix.path }}
         run: |
           VER="${VERSION#v}"
           SHA_ARM64=$(shasum -a 256 dad-darwin-arm64.tar.gz | cut -d' ' -f1)
           SHA_X86_64=$(shasum -a 256 dad-darwin-x86_64.tar.gz | cut -d' ' -f1)
           SHA_LINUX=$(shasum -a 256 dad-linux-x86_64.tar.gz | cut -d' ' -f1)
-          cd tap
+          cd "$TAP_PATH"
           sed -i "s/version \".*\"/version \"${VER}\"/" Formula/dad.rb
           python3 -c "
-          import re, sys
+          import re
           f = 'Formula/dad.rb'
           txt = open(f).read()
           shas = {'arm64': '${SHA_ARM64}', 'x86_64': '${SHA_X86_64}', 'linux': '${SHA_LINUX}'}
@@ -115,10 +123,13 @@ jobs:
           "
 
       - name: Commit formula
+        env:
+          TAP_PATH: ${{ matrix.path }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
         run: |
-          cd tap
+          cd "$TAP_PATH"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Formula/dad.rb
-          git diff --cached --quiet || git commit -m "formula: update to ${{ needs.release-please.outputs.tag_name }}"
+          git diff --cached --quiet || git commit -m "dad: update to $TAG"
           git push

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@
 ### Homebrew
 
 ```sh
-brew install nicknisi/diffdad/dad
+brew install nicknisi/formulae/dad
 ```
 
 Or, equivalently:
 
 ```sh
-brew tap nicknisi/diffdad
+brew tap nicknisi/formulae
 brew install dad
 ```
 

--- a/packages/site/src/components/CTAStrip.astro
+++ b/packages/site/src/components/CTAStrip.astro
@@ -14,7 +14,7 @@ import InstallPill from './InstallPill.astro';
         it from here.
       </p>
       <div class="flex gap-3 flex-wrap">
-        <InstallPill cmd="brew install nicknisi/diffdad/dad" variant="accent" />
+        <InstallPill cmd="brew install nicknisi/formulae/dad" variant="accent" />
         <a
           href="https://github.com/nicknisi/diffdad"
           target="_blank"

--- a/packages/site/src/components/Hero.astro
+++ b/packages/site/src/components/Hero.astro
@@ -16,7 +16,7 @@ import InstallPill from './InstallPill.astro';
       <code class="font-mono bg-card border border-line px-[6px] py-[2px] rounded text-base">dad</code> reads the whole pull request, groups changes by behavior into chapters, and walks you through them with prose, risk levels, and inline comments. Think of it as a code review with a <i>thicker mustache</i>.
     </p>
     <div class="flex gap-3 items-center flex-wrap">
-      <InstallPill cmd="brew install nicknisi/diffdad/dad" />
+      <InstallPill cmd="brew install nicknisi/formulae/dad" />
       <a
         href="#story"
         class="inline-flex items-center gap-2 px-[18px] py-3 rounded-[10px] font-mono text-sm no-underline text-ink border border-ink hover:bg-ink hover:text-on-ink transition-colors"

--- a/packages/site/src/components/Install.astro
+++ b/packages/site/src/components/Install.astro
@@ -18,7 +18,7 @@
         <div class="font-mono text-[11px] text-muted uppercase tracking-[0.1em] mb-[10px]">recommended · "the easy way"</div>
         <h4 class="font-serif text-[22px] font-semibold m-0 mb-[14px]">Homebrew</h4>
         <div class="bg-[#14202E] text-[#E6EAF2] rounded-[10px] px-4 py-[14px] font-mono text-[13px] leading-[1.7] overflow-x-auto">
-          <div><span class="text-[#6B7B9A]">$</span> brew install nicknisi/diffdad/dad</div>
+          <div><span class="text-[#6B7B9A]">$</span> brew install nicknisi/formulae/dad</div>
         </div>
         <div class="mt-3 text-[13px] text-muted">Standalone binary. No node, no bun, no nonsense.</div>
       </div>

--- a/packages/site/src/components/InstallPill.astro
+++ b/packages/site/src/components/InstallPill.astro
@@ -4,7 +4,7 @@ interface Props {
   variant?: 'default' | 'accent';
 }
 
-const { cmd = 'brew install nicknisi/diffdad/dad', variant = 'default' } = Astro.props;
+const { cmd = 'brew install nicknisi/formulae/dad', variant = 'default' } = Astro.props;
 const isAccent = variant === 'accent';
 ---
 


### PR DESCRIPTION
## Summary
- Release workflow now publishes the `dad` formula to **both** taps via matrix strategy:
  - `nicknisi/homebrew-diffdad` (legacy, being deprecated)
  - `nicknisi/homebrew-formulae` (new consolidated tap)
- Updated README and all site install commands from `nicknisi/diffdad/dad` → `nicknisi/formulae/dad`

## Related
- nicknisi/homebrew-diffdad#1 — adds `deprecate!` directive to the legacy tap
- nicknisi/homebrew-formulae — new shared tap (also hosts `sessions`)

## Test plan
- [ ] Merge this PR, then trigger a release
- [ ] Verify both `homebrew-diffdad` and `homebrew-formulae` get updated formula with correct sha256s
- [ ] Verify `brew install nicknisi/formulae/dad` works
- [ ] Verify site shows updated install command