### PR TITLE
feat: review-loop robustness — legible doors, comment delivery, presence, app-data storage

### DIFF
--- a/packages/cli/src/__tests__/agent-activity.test.ts
+++ b/packages/cli/src/__tests__/agent-activity.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { AgentActivity } from '../units/agent-activity';
+
+describe('AgentActivity', () => {
+  it('records and returns the last-seen timestamp per unit', () => {
+    let t = 1000;
+    const a = new AgentActivity({ now: () => t });
+    expect(a.lastSeen('u1')).toBeUndefined();
+    a.touch('u1');
+    expect(a.lastSeen('u1')).toBe(1000);
+    t = 2000;
+    a.touch('u1');
+    expect(a.lastSeen('u1')).toBe(2000);
+    expect(a.lastSeen('u2')).toBeUndefined();
+  });
+
+  it('notifies onTouch with the unit + timestamp so the daemon can broadcast presence', () => {
+    const seen: [string, number][] = [];
+    const a = new AgentActivity({ now: () => 4242 });
+    a.onTouch = (id, ts) => seen.push([id, ts]);
+    a.touch('u9');
+    expect(seen).toEqual([['u9', 4242]]);
+  });
+});

--- a/packages/cli/src/__tests__/agent-comments-routes.test.ts
+++ b/packages/cli/src/__tests__/agent-comments-routes.test.ts
@@ -1,12 +1,12 @@
 import { readdir, rm } from 'fs/promises';
-import { homedir } from 'os';
 import { join } from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { AgentCommentStore } from '../agent-comments/store';
+import { dataDir } from '../paths';
 import { createServer, type ServerContext } from '../server';
 import type { PRMetadata } from '../github/types';
 
-const STORE_DIR = join(homedir(), '.cache', 'diffdad', 'agent-comments');
+const STORE_DIR = join(dataDir(), 'agent-comments');
 
 async function cleanFixture() {
   try {

--- a/packages/cli/src/__tests__/agent-comments-sse.test.ts
+++ b/packages/cli/src/__tests__/agent-comments-sse.test.ts
@@ -1,12 +1,12 @@
 import { readdir, rm } from 'fs/promises';
-import { homedir } from 'os';
 import { join } from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { AgentCommentStore } from '../agent-comments/store';
+import { dataDir } from '../paths';
 import { createServer, type ServerContext } from '../server';
 import type { PRMetadata } from '../github/types';
 
-const STORE_DIR = join(homedir(), '.cache', 'diffdad', 'agent-comments');
+const STORE_DIR = join(dataDir(), 'agent-comments');
 
 async function cleanFixture() {
   try {

--- a/packages/cli/src/__tests__/agent-comments.test.ts
+++ b/packages/cli/src/__tests__/agent-comments.test.ts
@@ -1,11 +1,11 @@
 import { readdir, rm } from 'fs/promises';
-import { homedir } from 'os';
 import { join } from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { AgentCommentStore } from '../agent-comments/store';
 import { UnknownCommentError } from '../agent-comments/types';
+import { dataDir } from '../paths';
 
-const STORE_DIR = join(homedir(), '.cache', 'diffdad', 'agent-comments');
+const STORE_DIR = join(dataDir(), 'agent-comments');
 const FIXTURE_KEY = '__diffdad_test__store';
 
 function deterministic() {

--- a/packages/cli/src/__tests__/mcp-submit.test.ts
+++ b/packages/cli/src/__tests__/mcp-submit.test.ts
@@ -1,9 +1,10 @@
 import { mkdtemp, readdir, rm } from 'fs/promises';
-import { homedir, tmpdir } from 'os';
+import { tmpdir } from 'os';
 import { join } from 'path';
 import { Hono } from 'hono';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AgentCommentStore } from '../agent-comments/store';
+import { dataDir } from '../paths';
 import { UnitStore } from '../units/store';
 import { DecisionChannel } from '../units/decision-channel';
 import { type ComputeSlice, registerSubmitTools } from '../mcp/submit';
@@ -90,7 +91,7 @@ async function callTool(app: Hono, sessionId: string, name: string, args: Record
   return { parsed, isError: json.result?.isError ?? false };
 }
 
-const COMMENT_DIR = join(homedir(), '.cache', 'diffdad', 'agent-comments');
+const COMMENT_DIR = join(dataDir(), 'agent-comments');
 async function cleanCommentFixture() {
   try {
     for (const e of await readdir(COMMENT_DIR)) {

--- a/packages/cli/src/__tests__/mcp-submit.test.ts
+++ b/packages/cli/src/__tests__/mcp-submit.test.ts
@@ -1,8 +1,9 @@
-import { mkdtemp, rm } from 'fs/promises';
-import { tmpdir } from 'os';
+import { mkdtemp, readdir, rm } from 'fs/promises';
+import { homedir, tmpdir } from 'os';
 import { join } from 'path';
 import { Hono } from 'hono';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { AgentCommentStore } from '../agent-comments/store';
 import { UnitStore } from '../units/store';
 import { DecisionChannel } from '../units/decision-channel';
 import { type ComputeSlice, registerSubmitTools } from '../mcp/submit';
@@ -89,19 +90,48 @@ async function callTool(app: Hono, sessionId: string, name: string, args: Record
   return { parsed, isError: json.result?.isError ?? false };
 }
 
+const COMMENT_DIR = join(homedir(), '.cache', 'diffdad', 'agent-comments');
+async function cleanCommentFixture() {
+  try {
+    for (const e of await readdir(COMMENT_DIR)) {
+      if (e.startsWith('__diffdad_test__submit')) await rm(join(COMMENT_DIR, e), { force: true });
+    }
+  } catch {
+    /* dir may not exist */
+  }
+}
+
 let dir: string;
 beforeEach(async () => {
   dir = await mkdtemp(join(tmpdir(), 'diffdad-mcp-submit-'));
 });
 afterEach(async () => {
   await rm(dir, { recursive: true, force: true });
+  await cleanCommentFixture();
 });
 
-function setup(computeSlice: ComputeSlice = async () => fakeReview()) {
+function setup(computeSlice: ComputeSlice = async () => fakeReview(), opts: { withComments?: boolean } = {}) {
   const store = new UnitStore([], { dir, ...deterministic() });
   const decision = new DecisionChannel();
   const events: { event: string; data: unknown }[] = [];
   const submitted: ReviewUnit[] = [];
+  // Per-unit comment stores, mirroring the daemon's getCommentStore (undefined for unknown units).
+  const commentStores = new Map<string, AgentCommentStore>();
+  let cid = 0;
+  const getCommentStore = opts.withComments
+    ? async (unitId: string): Promise<AgentCommentStore | undefined> => {
+        if (!store.get(unitId)) return undefined;
+        let cs = commentStores.get(unitId);
+        if (!cs) {
+          cs = new AgentCommentStore(`__diffdad_test__submit-${unitId}`, [], {
+            genId: () => `c-${++cid}`,
+            now: () => '2026-06-26T00:00:00.000Z',
+          });
+          commentStores.set(unitId, cs);
+        }
+        return cs;
+      }
+    : undefined;
   const app = new Hono();
   mountMcp(app, (server) =>
     registerSubmitTools(server, {
@@ -111,9 +141,20 @@ function setup(computeSlice: ComputeSlice = async () => fakeReview()) {
       computeSlice,
       onSubmitted: (u) => submitted.push(u),
       awaitTimeoutMs: 40,
+      getCommentStore,
     }),
   );
-  return { store, decision, events, submitted, app };
+  return { store, decision, events, submitted, app, getCommentStore };
+}
+
+async function submitUnit(app: Hono, sid: string): Promise<string> {
+  const { parsed } = await callTool(app, sid, 'submit_for_review', {
+    taskLabel: 't',
+    intent: 'x',
+    repo: 'owner/a',
+    worktreePath: '/wt',
+  });
+  return (parsed as { unitId: string }).unitId;
 }
 
 describe('MCP submit/decision tools', () => {
@@ -191,5 +232,77 @@ describe('MCP submit/decision tools', () => {
     const sid = await connect(app);
     const { isError } = await callTool(app, sid, 'await_decision', { unitId: 'nope' });
     expect(isError).toBe(true);
+  });
+});
+
+describe('await_decision bundles outstanding comments (beats can’t be missed)', () => {
+  it('returns + delivers open comments on a pending poll, and broadcasts the change', async () => {
+    const { app, events, getCommentStore } = setup(undefined, { withComments: true });
+    const sid = await connect(app);
+    const unitId = await submitUnit(app, sid);
+    const cs = (await getCommentStore!(unitId))!;
+    await cs.add({ path: 'a.ts', line: 3, body: 'extract this guard' });
+
+    const res = await callTool(app, sid, 'await_decision', { unitId });
+    const out = res.parsed as { pending?: boolean; comments?: { body: string; status: string }[] };
+    expect(out.pending).toBe(true);
+    expect(out.comments?.map((c) => c.body)).toEqual(['extract this guard']);
+    expect(out.comments?.[0]!.status).toBe('delivered'); // bundling IS delivery
+
+    // Persisted: the open comment is now delivered, and the UI was told over SSE.
+    expect(cs.list('open')).toHaveLength(0);
+    expect(cs.list('delivered')).toHaveLength(1);
+    expect(events.some((e) => e.event === 'agent-comment' && (e.data as { unitId: string }).unitId === unitId)).toBe(
+      true,
+    );
+  });
+
+  it('bundles outstanding comments alongside a recorded decision too', async () => {
+    const { store, app, getCommentStore } = setup(undefined, { withComments: true });
+    const sid = await connect(app);
+    const unitId = await submitUnit(app, sid);
+    await store.setReviewing(unitId);
+    await store.setQueued(unitId, NARRATIVE, 1);
+    await store.setDecision(unitId, { kind: 'approved' });
+    const cs = (await getCommentStore!(unitId))!;
+    await cs.add({ path: 'a.ts', line: 1, body: 'nit: rename' });
+
+    const res = await callTool(app, sid, 'await_decision', { unitId });
+    const out = res.parsed as { decision?: { kind: string }; comments?: { body: string }[] };
+    expect(out.decision).toMatchObject({ kind: 'approved' });
+    expect(out.comments?.map((c) => c.body)).toEqual(['nit: rename']);
+  });
+
+  it('keeps surfacing an already-delivered-but-unaddressed comment (so it can’t be lost)', async () => {
+    const { app, getCommentStore } = setup(undefined, { withComments: true });
+    const sid = await connect(app);
+    const unitId = await submitUnit(app, sid);
+    const cs = (await getCommentStore!(unitId))!;
+    const c = await cs.add({ path: 'a.ts', line: 1, body: 'still open' });
+    await cs.markDelivered([c.id]); // first poll already delivered it
+
+    const res = await callTool(app, sid, 'await_decision', { unitId });
+    expect((res.parsed as { comments?: { body: string }[] }).comments?.map((x) => x.body)).toEqual(['still open']);
+  });
+
+  it('drops an addressed comment from the bundle', async () => {
+    const { app, getCommentStore } = setup(undefined, { withComments: true });
+    const sid = await connect(app);
+    const unitId = await submitUnit(app, sid);
+    const cs = (await getCommentStore!(unitId))!;
+    const c = await cs.add({ path: 'a.ts', line: 1, body: 'done already' });
+    await cs.resolve(c.id, 'fixed');
+
+    const res = await callTool(app, sid, 'await_decision', { unitId });
+    expect((res.parsed as { comments?: unknown }).comments).toBeUndefined();
+    expect((res.parsed as { pending?: boolean }).pending).toBe(true);
+  });
+
+  it('omits the comments field entirely when there are none outstanding', async () => {
+    const { app } = setup(undefined, { withComments: true });
+    const sid = await connect(app);
+    const unitId = await submitUnit(app, sid);
+    const res = await callTool(app, sid, 'await_decision', { unitId });
+    expect((res.parsed as { comments?: unknown }).comments).toBeUndefined();
   });
 });

--- a/packages/cli/src/__tests__/mcp-tools.test.ts
+++ b/packages/cli/src/__tests__/mcp-tools.test.ts
@@ -1,13 +1,13 @@
 import { readdir, rm } from 'fs/promises';
 import { Hono } from 'hono';
-import { homedir } from 'os';
 import { join } from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { AgentCommentStore } from '../agent-comments/store';
 import { registerAgentCommentTools } from '../mcp/tools';
 import { mountMcp } from '../mcp/server';
+import { dataDir } from '../paths';
 
-const STORE_DIR = join(homedir(), '.cache', 'diffdad', 'agent-comments');
+const STORE_DIR = join(dataDir(), 'agent-comments');
 const FIXTURE_KEY = '__diffdad_test__mcp';
 const HEADERS = { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' };
 

--- a/packages/cli/src/__tests__/paths.test.ts
+++ b/packages/cli/src/__tests__/paths.test.ts
@@ -1,0 +1,68 @@
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { dataDir, legacyDir, migrateLegacyData } from '../paths';
+
+describe('data paths', () => {
+  it('puts durable data in a real app-data location, distinct from the cache dir', () => {
+    expect(dataDir()).not.toBe(legacyDir());
+    expect(dataDir()).toContain('diffdad');
+    expect(legacyDir()).toContain('.cache');
+    if (process.platform === 'darwin') expect(dataDir()).toContain('Application Support');
+    else expect(dataDir()).not.toContain('.cache');
+  });
+});
+
+describe('migrateLegacyData', () => {
+  let from: string;
+  let to: string;
+  beforeEach(async () => {
+    from = await mkdtemp(join(tmpdir(), 'diffdad-legacy-'));
+    to = await mkdtemp(join(tmpdir(), 'diffdad-data-'));
+    await rm(to, { recursive: true, force: true }); // exercise the fresh-install path: `to` absent
+  });
+  afterEach(async () => {
+    await rm(from, { recursive: true, force: true });
+    await rm(to, { recursive: true, force: true });
+  });
+
+  it('moves durable subdirs (units, agent-comments) from the legacy dir into the data dir', async () => {
+    await mkdir(join(from, 'units'), { recursive: true });
+    await writeFile(join(from, 'units', 'u1.json'), '{"unitId":"u1"}');
+    await mkdir(join(from, 'agent-comments'), { recursive: true });
+    await writeFile(join(from, 'agent-comments', 'unit-u1.json'), '[]');
+
+    await migrateLegacyData({ from, to });
+
+    expect(await readFile(join(to, 'units', 'u1.json'), 'utf-8')).toContain('u1');
+    expect(await readFile(join(to, 'agent-comments', 'unit-u1.json'), 'utf-8')).toBe('[]');
+  });
+
+  it('leaves regenerable caches behind — only durable data moves', async () => {
+    await writeFile(join(from, 'owner-repo-1-abc.json'), '{}'); // a narrative cache file
+    await mkdir(join(from, 'units'), { recursive: true });
+    await writeFile(join(from, 'units', 'u1.json'), '{}');
+
+    await migrateLegacyData({ from, to });
+
+    expect(await readFile(join(from, 'owner-repo-1-abc.json'), 'utf-8')).toBe('{}'); // still in cache
+    await expect(access(join(to, 'owner-repo-1-abc.json'))).rejects.toThrow(); // not copied to data
+  });
+
+  it('never clobbers data already present in the destination', async () => {
+    await mkdir(join(from, 'units'), { recursive: true });
+    await writeFile(join(from, 'units', 'u1.json'), 'LEGACY');
+    await mkdir(join(to, 'units'), { recursive: true });
+    await writeFile(join(to, 'units', 'u1.json'), 'CURRENT');
+
+    await migrateLegacyData({ from, to });
+
+    expect(await readFile(join(to, 'units', 'u1.json'), 'utf-8')).toBe('CURRENT');
+  });
+
+  it('is a no-op when there is nothing to migrate', async () => {
+    await migrateLegacyData({ from, to }); // `from` is empty
+    await expect(access(join(to, 'units'))).rejects.toThrow();
+  });
+});

--- a/packages/cli/src/__tests__/server.test.ts
+++ b/packages/cli/src/__tests__/server.test.ts
@@ -1,9 +1,23 @@
-import { describe, expect, it } from 'vitest';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { AgentCommentStore } from '../agent-comments/store';
 import { createServer, type ServerContext } from '../server';
 import type { NarrativeResponse } from '../narrative/types';
 import type { CheckRun, DiffFile, PRComment, PRMetadata } from '../github/types';
 import type { GitHubClient, PostCommentOptions } from '../github/client';
+
+// Isolate config: point XDG_CONFIG_HOME at an empty dir so readConfig() returns defaults rather than
+// the developer's real ~/.config/diffdad/config.json (whose theme/layout would break the assertions
+// below). Restored after the file so the env doesn't leak to other test files.
+const prevXdgConfigHome = process.env.XDG_CONFIG_HOME;
+beforeAll(() => {
+  process.env.XDG_CONFIG_HOME = join(tmpdir(), 'diffdad-test-empty-config');
+});
+afterAll(() => {
+  if (prevXdgConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = prevXdgConfigHome;
+});
 
 const mockNarrative: NarrativeResponse = {
   title: 'Test PR',

--- a/packages/cli/src/__tests__/unit-agent-comments.test.ts
+++ b/packages/cli/src/__tests__/unit-agent-comments.test.ts
@@ -1,10 +1,11 @@
 import { readdir, rm } from 'fs/promises';
 import { Hono } from 'hono';
 import { mkdtemp } from 'fs/promises';
-import { homedir, tmpdir } from 'os';
+import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AgentCommentStore } from '../agent-comments/store';
+import { dataDir } from '../paths';
 import { createDaemonApp, SseHub } from '../daemon/app';
 import type { ComputeSlice } from '../mcp/submit';
 import type { LocalReview } from '../local/diff-source';
@@ -12,7 +13,7 @@ import type { PRMetadata } from '../github/types';
 import { UnitStore } from '../units/store';
 import { DecisionChannel } from '../units/decision-channel';
 
-const STORE_DIR = join(homedir(), '.cache', 'diffdad', 'agent-comments');
+const STORE_DIR = join(dataDir(), 'agent-comments');
 const HEADERS = { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' };
 
 function mkMetadata(): PRMetadata {

--- a/packages/cli/src/__tests__/unit-agent-comments.test.ts
+++ b/packages/cli/src/__tests__/unit-agent-comments.test.ts
@@ -256,6 +256,33 @@ describe('per-unit agent-comment replies (threading)', () => {
   });
 });
 
+describe('per-unit agent presence', () => {
+  it('404s presence for an unknown unit', async () => {
+    const { app } = setup();
+    expect((await app.request('/api/units/nope/presence')).status).toBe(404);
+  });
+
+  it('reports no last-seen until an agent interacts, then records + broadcasts it', async () => {
+    const { store, app, messages } = setup();
+    const a = await addUnit(store, 'owner/a');
+
+    const before = await app.request(`/api/units/${a.unitId}/presence`);
+    expect(before.status).toBe(200);
+    expect(await before.json()).toEqual({ lastSeenAt: null });
+
+    // An agent listing the unit's comments counts as "seen".
+    const sid = await connect(app);
+    await callTool(app, sid, 'list_review_comments', { unitId: a.unitId });
+
+    const after = await app.request(`/api/units/${a.unitId}/presence`);
+    const body = (await after.json()) as { lastSeenAt: number | null };
+    expect(typeof body.lastSeenAt).toBe('number');
+    expect(messages.some((m) => m.event === 'presence' && (m.data as { unitId: string }).unitId === a.unitId)).toBe(
+      true,
+    );
+  });
+});
+
 describe('per-unit agent-comment MCP tools', () => {
   it("list_review_comments returns a unit's open comments and flips them delivered", async () => {
     const { store, app, messages } = setup();

--- a/packages/cli/src/agent-comments/store.ts
+++ b/packages/cli/src/agent-comments/store.ts
@@ -1,9 +1,9 @@
 import { mkdir, readFile, writeFile } from 'fs/promises';
-import { homedir } from 'os';
 import { join } from 'path';
+import { dataDir } from '../paths';
 import { type AgentComment, type AgentReply, type NewAgentComment, UnknownCommentError } from './types';
 
-const STORE_DIR = join(homedir(), '.cache', 'diffdad', 'agent-comments');
+const STORE_DIR = join(dataDir(), 'agent-comments');
 
 /** Sanitize a store key (base ref / PR coordinates) into a safe filename segment. */
 function keyToFile(key: string): string {
@@ -20,7 +20,7 @@ export type StoreOptions = {
 /**
  * The single source of truth for agent-bound comments, shared by the HTTP routes
  * (UI) and the MCP tools. In-memory with best-effort write-through persistence to
- * ~/.cache/diffdad/agent-comments/<key>.json — keyed by base ref so threads survive
+ * <dataDir>/agent-comments/<key>.json (see paths.ts) — keyed by base ref so threads survive
  * narrative regeneration, and durable across dad restarts / agent context resets.
  */
 export class AgentCommentStore {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -9,6 +9,7 @@ import { LOCAL_CLIS, readConfig, resetConfig, runConfig, showConfig } from './co
 import { GitHubClient } from './github/client';
 import { cacheNarrative, clearCache, computePromptMetaHash, getCachedNarrative } from './narrative/cache';
 import { generateNarrative, resolveAiPath, resolveProviderKey, setCliOverride } from './narrative/engine';
+import { migrateLegacyData } from './paths';
 import { getCachedRecap } from './recap/cache';
 import { createServer } from './server';
 import { DEFAULT_DAEMON_PORT, daemonStatus, startDaemon } from './daemon/daemon';
@@ -646,6 +647,10 @@ async function main(argv: string[]): Promise<number> {
     console.log(pkg.version ?? '0.0.0');
     return 0;
   }
+
+  // One-time relocation of durable data (queue + agent-comment threads) out of the legacy ~/.cache
+  // dir into the proper app-data location. Best-effort and idempotent — never blocks a command.
+  await migrateLegacyData().catch(() => {});
 
   switch (classifyCommand(cmd)) {
     case 'review':

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -40,7 +40,11 @@ export interface DiffDadConfig {
 }
 
 export function getConfigPath(): string {
-  return join(homedir(), '.config', 'diffdad', 'config.json');
+  // Honor XDG_CONFIG_HOME (defaults to ~/.config) — both the standard location and a clean seam for
+  // tests to isolate config instead of reading the developer's real ~/.config/diffdad/config.json.
+  const xdg = process.env.XDG_CONFIG_HOME;
+  const base = xdg ? join(xdg, 'diffdad') : join(homedir(), '.config', 'diffdad');
+  return join(base, 'config.json');
 }
 
 export async function readConfig(): Promise<DiffDadConfig> {

--- a/packages/cli/src/daemon/app.ts
+++ b/packages/cli/src/daemon/app.ts
@@ -16,6 +16,7 @@ import type { Broadcast } from '../mcp/tools';
 import { AgentCommentStore } from '../agent-comments/store';
 import { UnknownCommentError } from '../agent-comments/types';
 import { registerUnitCommentTools } from '../mcp/unit-comments';
+import { AgentActivity } from '../units/agent-activity';
 import type { DecisionChannel } from '../units/decision-channel';
 import { decisionTarget } from '../units/decision-target';
 import type { UnitStore } from '../units/store';
@@ -117,6 +118,8 @@ export type DaemonAppDeps = {
    * agent's reply visible to the UI).
    */
   loadCommentStore?: (unitId: string) => Promise<AgentCommentStore>;
+  /** Last-seen-per-unit tracker behind the presence cue. Injected for tests; defaults to a fresh one. */
+  activity?: AgentActivity;
   /** Override the command-center static root (defaults to the same fallbacks as `server.ts`). */
   webDist?: string;
 };
@@ -160,6 +163,13 @@ export function createDaemonApp(deps: DaemonAppDeps): { app: Hono } {
     }
     return pending;
   };
+
+  // Last-seen-per-unit, the honest backing for the drill-in's "agent connected / no agent connected"
+  // cue: the MCP tools touch it whenever the unit's agent parks or works its comments, and a touch
+  // broadcasts a `presence` snapshot so an open tab updates live.
+  const activity = deps.activity ?? new AgentActivity();
+  activity.onTouch = (unitId, lastSeenAt) => broadcast('presence', { unitId, lastSeenAt });
+  const onAgentSeen = (unitId: string) => activity.touch(unitId);
 
   // --- Command-center bootstrap ---------------------------------------------
   // The web SPA's single bootstrap is `GET /api/narrative`; it multiplexes on `mode`
@@ -494,6 +504,17 @@ export function createDaemonApp(deps: DaemonAppDeps): { app: Hono } {
     return c.json(comment, 201);
   });
 
+  // --- Agent presence (local units) -----------------------------------------
+  // The drill-in's "agent connected / no agent connected" cue. `lastSeenAt` is epoch-ms of the unit's
+  // most recent agent interaction (parking on await_decision, or working its comments), or null if an
+  // agent has never checked in. The client decides "connected" from how fresh it is; live updates
+  // arrive over the `presence` SSE event. Unknown unit → 404. Must precede the static catch-all.
+  app.get('/api/units/:id/presence', (c) => {
+    const id = c.req.param('id');
+    if (!store.get(id)) return c.json({ error: new UnknownUnitError(id).message }, 404);
+    return c.json({ lastSeenAt: activity.lastSeen(id) ?? null });
+  });
+
   // --- Review submission (github units) -------------------------------------
   // The drill-in's full submit: COMMENT/APPROVE/REQUEST_CHANGES + batched inline draft comments, in
   // one GitHub review (mirrors the PR server's /api/review). Unlike that route, a verdict (approve /
@@ -674,8 +695,9 @@ export function createDaemonApp(deps: DaemonAppDeps): { app: Hono } {
       onSubmitted,
       awaitTimeoutMs,
       getCommentStore,
+      onAgentSeen,
     });
-    registerUnitCommentTools(server, { getStore: getCommentStore, broadcast });
+    registerUnitCommentTools(server, { getStore: getCommentStore, broadcast, onAgentSeen });
   });
 
   // --- Command-center SPA ---------------------------------------------------

--- a/packages/cli/src/daemon/app.ts
+++ b/packages/cli/src/daemon/app.ts
@@ -666,7 +666,15 @@ export function createDaemonApp(deps: DaemonAppDeps): { app: Hono } {
   // the same per-unit stores the HTTP routes use). Must be registered BEFORE the static catch-all or
   // `/mcp` is swallowed by serveStatic.
   mountMcp(app, (server) => {
-    registerSubmitTools(server, { store, decision, broadcast, computeSlice, onSubmitted, awaitTimeoutMs });
+    registerSubmitTools(server, {
+      store,
+      decision,
+      broadcast,
+      computeSlice,
+      onSubmitted,
+      awaitTimeoutMs,
+      getCommentStore,
+    });
     registerUnitCommentTools(server, { getStore: getCommentStore, broadcast });
   });
 

--- a/packages/cli/src/daemon/daemon.ts
+++ b/packages/cli/src/daemon/daemon.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
-import { homedir } from 'os';
 import { join } from 'path';
 import { resolveGitHubToken } from '../auth';
+import { dataDir } from '../paths';
 import { readConfig } from '../config';
 import { GitHubClient, type PostCommentOptions } from '../github/client';
 import { parseDiff } from '../github/diff-parser';
@@ -23,7 +23,7 @@ const DEFAULT_CONCURRENCY = 3;
 const DEFAULT_POLL_MS = 60_000;
 
 /** Single-instance pidfile. Beside the rest of dad's state so a stale file is easy to find/clear. */
-const PIDFILE = join(homedir(), '.cache', 'diffdad', 'daemon.pid');
+const PIDFILE = join(dataDir(), 'daemon.pid');
 
 /** True if a process with this pid is alive (signal 0 probes without delivering a signal). */
 function isProcessAlive(pid: number): boolean {
@@ -66,7 +66,7 @@ async function claimPidfile(): Promise<{ conflict: number | null }> {
     if (still !== null) return { conflict: still };
   }
   try {
-    mkdirSync(join(homedir(), '.cache', 'diffdad'), { recursive: true });
+    mkdirSync(dataDir(), { recursive: true });
     writeFileSync(PIDFILE, String(process.pid));
   } catch {
     // best-effort: can't persist the pidfile, but don't block the daemon on it.

--- a/packages/cli/src/daemon/launchd.ts
+++ b/packages/cli/src/daemon/launchd.ts
@@ -1,6 +1,7 @@
 import { mkdir, rm, writeFile } from 'fs/promises';
 import { homedir } from 'os';
 import { basename, join } from 'path';
+import { dataDir } from '../paths';
 import { DEFAULT_DAEMON_PORT } from './daemon';
 
 /** Reverse-DNS label for the per-user LaunchAgent. Also the plist basename and the launchctl target. */
@@ -13,7 +14,7 @@ function plistPath(): string {
 
 /** Daemon stdout/stderr land beside the rest of dad's state so logs are findable. */
 function logDir(): string {
-  return join(homedir(), '.cache', 'diffdad');
+  return dataDir();
 }
 
 /** The `gui/<uid>` domain a per-user LaunchAgent is bootstrapped into (modern launchctl). */

--- a/packages/cli/src/mcp/submit.ts
+++ b/packages/cli/src/mcp/submit.ts
@@ -1,10 +1,11 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import type { AgentCommentStore } from '../agent-comments/store';
 import { CleanTreeError, type LocalReview } from '../local/diff-source';
 import type { UnitStore } from '../units/store';
 import type { DecisionChannel } from '../units/decision-channel';
 import { type ReviewUnit, UnknownUnitError } from '../units/types';
-import { type Broadcast, errorText, text, type ToolHost } from './tools';
+import { type Broadcast, errorText, project, text, type ToolHost } from './tools';
 
 /** Computes a unit's diff slice from its worktree. The daemon injects `buildLocalReview` bound
  *  to the worktree as cwd; tests inject a fake. Throws `CleanTreeError` when there's nothing to review. */
@@ -19,6 +20,13 @@ export type SubmitToolDeps = {
   onSubmitted?: (unit: ReviewUnit) => void;
   /** Long-poll ceiling for `await_decision`. Kept under Bun's 255s idle timeout. */
   awaitTimeoutMs?: number;
+  /**
+   * Resolve a unit's agent-comment mailbox (the daemon's per-unit `getCommentStore`; `undefined`
+   * for an unknown unit). When provided, `await_decision` bundles the unit's outstanding comments
+   * into its response and marks open ones delivered — so an agent parked on the verdict never has
+   * to remember a separate `list_review_comments` call to catch a hand-typed beat.
+   */
+  getCommentStore?: (unitId: string) => Promise<AgentCommentStore | undefined>;
 };
 
 // Under Bun's `idleTimeout: 255`, a single held request must resolve well before the socket
@@ -31,10 +39,33 @@ const DEFAULT_AWAIT_MS = 240_000;
  * verdict. Both close over the shared `UnitStore` + `DecisionChannel`, mirroring `registerAgentCommentTools`.
  */
 export function registerSubmitTools(server: McpServer, deps: SubmitToolDeps): void {
-  const { store, broadcast, computeSlice, decision, onSubmitted } = deps;
+  const { store, broadcast, computeSlice, decision, onSubmitted, getCommentStore } = deps;
   const awaitTimeoutMs = deps.awaitTimeoutMs ?? DEFAULT_AWAIT_MS;
   const host = server as unknown as ToolHost;
   const notify = () => broadcast('units', { units: store.list() });
+
+  /**
+   * The unit's outstanding (open + delivered, i.e. not-yet-addressed) comments, projected for the
+   * agent — or `undefined` when there's no mailbox or nothing outstanding. Marks any `open` ones
+   * delivered as a side effect (bundling them IS delivery) and broadcasts so the UI badge updates.
+   */
+  const bundleComments = async (unitId: string) => {
+    if (!getCommentStore) return undefined;
+    const cs = await getCommentStore(unitId);
+    if (!cs) return undefined;
+    const outstanding = cs.list().filter((c) => c.status !== 'addressed');
+    if (outstanding.length === 0) return undefined;
+    const openIds = outstanding.filter((c) => c.status === 'open').map((c) => c.id);
+    if (openIds.length > 0) {
+      await cs.markDelivered(openIds);
+      broadcast('agent-comment', { unitId, comments: cs.list() });
+    }
+    // Re-read so just-delivered statuses are reflected in what the agent receives.
+    return cs
+      .list()
+      .filter((c) => c.status !== 'addressed')
+      .map(project);
+  };
 
   host.registerTool(
     'submit_for_review',
@@ -87,17 +118,24 @@ export function registerSubmitTools(server: McpServer, deps: SubmitToolDeps): vo
       description:
         'Long-poll for the review decision on your unit. Returns { decision } once the reviewer decides ' +
         '(approved or changes_requested, with curated concerns), or { pending: true } on timeout — re-call ' +
-        'to keep waiting. The decision is persisted, so it is never lost across reconnects.',
+        'to keep waiting. The decision is persisted, so it is never lost across reconnects. Any outstanding ' +
+        'review comments are bundled in as { comments } (and marked delivered), so you never miss a ' +
+        'hand-typed note while parked — reply_to_comment / resolve_comment to close them out.',
       inputSchema: { unitId: z.string() },
     },
     async (args) => {
       const unitId = args.unitId as string;
       const unit = store.get(unitId);
       if (!unit) return errorText(new UnknownUnitError(unitId).message);
-      if (unit.decision) return text({ decision: unit.decision });
+      if (unit.decision) {
+        const comments = await bundleComments(unitId);
+        return text(comments ? { decision: unit.decision, comments } : { decision: unit.decision });
+      }
 
       const decided = await decision.wait(unitId, awaitTimeoutMs);
-      return decided ? text({ decision: decided }) : text({ pending: true });
+      const comments = await bundleComments(unitId);
+      if (decided) return text(comments ? { decision: decided, comments } : { decision: decided });
+      return text(comments ? { pending: true, comments } : { pending: true });
     },
   );
 }

--- a/packages/cli/src/mcp/submit.ts
+++ b/packages/cli/src/mcp/submit.ts
@@ -27,6 +27,8 @@ export type SubmitToolDeps = {
    * to remember a separate `list_review_comments` call to catch a hand-typed beat.
    */
   getCommentStore?: (unitId: string) => Promise<AgentCommentStore | undefined>;
+  /** Mark the unit's agent as seen (parked on the verdict) — drives the drill-in's presence cue. */
+  onAgentSeen?: (unitId: string) => void;
 };
 
 // Under Bun's `idleTimeout: 255`, a single held request must resolve well before the socket
@@ -39,7 +41,7 @@ const DEFAULT_AWAIT_MS = 240_000;
  * verdict. Both close over the shared `UnitStore` + `DecisionChannel`, mirroring `registerAgentCommentTools`.
  */
 export function registerSubmitTools(server: McpServer, deps: SubmitToolDeps): void {
-  const { store, broadcast, computeSlice, decision, onSubmitted, getCommentStore } = deps;
+  const { store, broadcast, computeSlice, decision, onSubmitted, getCommentStore, onAgentSeen } = deps;
   const awaitTimeoutMs = deps.awaitTimeoutMs ?? DEFAULT_AWAIT_MS;
   const host = server as unknown as ToolHost;
   const notify = () => broadcast('units', { units: store.list() });
@@ -127,6 +129,7 @@ export function registerSubmitTools(server: McpServer, deps: SubmitToolDeps): vo
       const unitId = args.unitId as string;
       const unit = store.get(unitId);
       if (!unit) return errorText(new UnknownUnitError(unitId).message);
+      onAgentSeen?.(unitId); // parking on the verdict means the agent is here right now
       if (unit.decision) {
         const comments = await bundleComments(unitId);
         return text(comments ? { decision: unit.decision, comments } : { decision: unit.decision });

--- a/packages/cli/src/mcp/unit-comments.ts
+++ b/packages/cli/src/mcp/unit-comments.ts
@@ -14,6 +14,8 @@ export type ResolveCommentStore = (unitId: string) => Promise<AgentCommentStore 
 export type UnitCommentToolDeps = {
   getStore: ResolveCommentStore;
   broadcast: Broadcast;
+  /** Mark the unit's agent as seen on any comment interaction — drives the drill-in's presence cue. */
+  onAgentSeen?: (unitId: string) => void;
 };
 
 /**
@@ -23,7 +25,10 @@ export type UnitCommentToolDeps = {
  * each mutation to that unit's own store and broadcast a unit-scoped `agent-comment` snapshot, which
  * the dad UI applies only to the open unit's tab.
  */
-export function registerUnitCommentTools(server: McpServer, { getStore, broadcast }: UnitCommentToolDeps): void {
+export function registerUnitCommentTools(
+  server: McpServer,
+  { getStore, broadcast, onAgentSeen }: UnitCommentToolDeps,
+): void {
   const host = server as unknown as ToolHost;
   const notify = (unitId: string, store: AgentCommentStore) =>
     broadcast('agent-comment', { unitId, comments: store.list() });
@@ -40,6 +45,7 @@ export function registerUnitCommentTools(server: McpServer, { getStore, broadcas
     async (args) => {
       const store = await getStore(args.unitId as string);
       if (!store) return errorText(`unknown unit: ${args.unitId as string}`);
+      onAgentSeen?.(args.unitId as string);
       const filter = (args.status as 'open' | 'delivered' | 'all' | undefined) ?? 'open';
       // Capture the matching set BEFORE flipping — markDelivered mutates these objects in place, so
       // projecting `requested` afterward reflects the new delivered status without re-filtering.
@@ -64,6 +70,7 @@ export function registerUnitCommentTools(server: McpServer, { getStore, broadcas
     async (args) => {
       const store = await getStore(args.unitId as string);
       if (!store) return errorText(`unknown unit: ${args.unitId as string}`);
+      onAgentSeen?.(args.unitId as string);
       try {
         const comment = await store.addReply(args.id as string, { author: 'agent', body: args.body as string });
         notify(args.unitId as string, store);
@@ -84,6 +91,7 @@ export function registerUnitCommentTools(server: McpServer, { getStore, broadcas
     async (args) => {
       const store = await getStore(args.unitId as string);
       if (!store) return errorText(`unknown unit: ${args.unitId as string}`);
+      onAgentSeen?.(args.unitId as string);
       try {
         const comment = await store.resolve(args.id as string, args.note as string | undefined);
         notify(args.unitId as string, store);

--- a/packages/cli/src/paths.ts
+++ b/packages/cli/src/paths.ts
@@ -1,0 +1,62 @@
+import { cp, mkdir, readdir, rename } from 'fs/promises';
+import { homedir } from 'os';
+import { join } from 'path';
+
+/**
+ * Durable application data — the review queue and agent-comment threads. This is state the user would
+ * be upset to lose, so it belongs in a real app-data location, NOT a cache dir that tools (or the OS)
+ * may clear: `~/Library/Application Support/diffdad` on macOS, else `$XDG_DATA_HOME/diffdad` or
+ * `~/.local/share/diffdad`. (Pre-1.0 this all lived under `~/.cache/diffdad`; see {@link legacyDir}.)
+ */
+export function dataDir(): string {
+  if (process.platform === 'darwin') return join(homedir(), 'Library', 'Application Support', 'diffdad');
+  const xdg = process.env.XDG_DATA_HOME;
+  return xdg ? join(xdg, 'diffdad') : join(homedir(), '.local', 'share', 'diffdad');
+}
+
+/**
+ * The pre-1.0 location everything used to live under (`~/.cache/diffdad`). Regenerable caches
+ * (narratives, recaps) correctly stay here — `~/.cache` is the right home for disposable data — so
+ * only the durable subdirs move out (see {@link migrateLegacyData}).
+ */
+export function legacyDir(): string {
+  return join(homedir(), '.cache', 'diffdad');
+}
+
+/** The subdirs under the legacy dir that hold durable (non-regenerable) data. */
+const DURABLE_SUBDIRS = ['units', 'agent-comments'] as const;
+
+/**
+ * One-time move of durable data from the legacy `~/.cache/diffdad` location into {@link dataDir}.
+ * Idempotent and non-destructive: a subdir moves only when the destination doesn't already exist, so
+ * a second run (or a fresh install that already wrote to the new location) is a clean no-op and the
+ * user's queue is never clobbered. Regenerable caches are deliberately left in `~/.cache`. Safe to
+ * call on every startup; best-effort — a failure here must never block the CLI.
+ */
+export async function migrateLegacyData(opts: { from?: string; to?: string } = {}): Promise<void> {
+  const from = opts.from ?? legacyDir();
+  const to = opts.to ?? dataDir();
+  if (from === to) return;
+  for (const sub of DURABLE_SUBDIRS) {
+    const src = join(from, sub);
+    const dest = join(to, sub);
+    if (!(await dirExists(src))) continue;
+    if (await dirExists(dest)) continue; // already migrated (or fresh install) — don't touch
+    await mkdir(to, { recursive: true });
+    try {
+      await rename(src, dest); // atomic on the same volume (the common case: same home dir)
+    } catch {
+      // Cross-device or other rename failure — copy instead and leave the source as a backup.
+      await cp(src, dest, { recursive: true });
+    }
+  }
+}
+
+async function dirExists(path: string): Promise<boolean> {
+  try {
+    await readdir(path);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/cli/src/units/agent-activity.ts
+++ b/packages/cli/src/units/agent-activity.ts
@@ -1,0 +1,34 @@
+export type AgentActivityOptions = { now?: () => number };
+
+/**
+ * Tracks when an agent was last seen interacting with each unit — parking on `await_decision`, or
+ * listing / replying to / resolving its comments. The drill-in turns this into an honest presence
+ * cue ("agent connected" vs "no agent connected") WITHOUT faking a real-time socket: an active agent
+ * refreshes its timestamp every poll (≤ the await ceiling, ~4 min), so a recent stamp means it will
+ * see your notes on its next pass; a stale one means it's gone and the note will wait. Crucially this
+ * does NOT flip to "disconnected" the instant the agent unparks to do work between polls — it only
+ * goes stale after the window — so the cue stays steady instead of flickering. In-memory only:
+ * presence is ephemeral and resets when the daemon restarts (an agent re-announces on its next call).
+ */
+export class AgentActivity {
+  private readonly seen = new Map<string, number>();
+  private readonly now: () => number;
+  /** Set by the daemon to broadcast a `presence` SSE snapshot when a unit's agent checks in. */
+  onTouch?: (unitId: string, lastSeenAt: number) => void;
+
+  constructor(opts: AgentActivityOptions = {}) {
+    this.now = opts.now ?? (() => Date.now());
+  }
+
+  /** Record that the unit's agent is active right now. */
+  touch(unitId: string): void {
+    const ts = this.now();
+    this.seen.set(unitId, ts);
+    this.onTouch?.(unitId, ts);
+  }
+
+  /** The agent's last-seen epoch-ms for this unit, or `undefined` if never seen. */
+  lastSeen(unitId: string): number | undefined {
+    return this.seen.get(unitId);
+  }
+}

--- a/packages/cli/src/units/store.ts
+++ b/packages/cli/src/units/store.ts
@@ -1,6 +1,6 @@
 import { mkdir, readdir, readFile, unlink, writeFile } from 'fs/promises';
-import { homedir } from 'os';
 import { join } from 'path';
+import { dataDir } from '../paths';
 import type { DiffFile, PRMetadata } from '../github/types';
 import type { NarrativeResponse } from '../narrative/types';
 import {
@@ -12,7 +12,7 @@ import {
   UnknownUnitError,
 } from './types';
 
-const DEFAULT_DIR = join(homedir(), '.cache', 'diffdad', 'units');
+const DEFAULT_DIR = join(dataDir(), 'units');
 
 /** Permitted state-machine edges (spec-phase-2 Data Model). An unlisted edge throws. */
 const TRANSITIONS: Record<UnitStatus, UnitStatus[]> = {
@@ -53,7 +53,7 @@ export type ResubmitInput = {
 /**
  * The cross-repo review-unit store — the spine of the daemon, shared by the MCP tools and the
  * HTTP routes. In-memory (keyed by globally-unique `unitId`) with best-effort write-through to
- * one JSON file per unit under ~/.cache/diffdad/units/. Single-process synchronous mutations +
+ * one JSON file per unit under <dataDir>/units/ (see paths.ts). Single-process synchronous mutations +
  * `save()` after each — no real concurrency in Bun's loop (same reasoning as agent-comments).
  * Mutations validate against the state machine; an illegal jump throws a typed error the MCP
  * layer maps to a tool error.

--- a/packages/cli/src/units/types.ts
+++ b/packages/cli/src/units/types.ts
@@ -31,7 +31,7 @@ export type Decision = {
  * A unit of agent work submitted for review. Owns its diff slice (`files`/`metadata`), the
  * Phase-1 review output (`narrative` — the brief is derived in the UI via `buildWalkthrough`,
  * since `WalkthroughModel` is a web type the CLI can't produce), a state-machine `status`, and
- * a `toResolve` count. Persisted one-file-per-unit under ~/.cache/diffdad/units/.
+ * a `toResolve` count. Persisted one-file-per-unit under <dataDir>/units/ (see paths.ts).
  */
 export type ReviewUnit = {
   unitId: string;

--- a/packages/web/src/components/CommentThread.tsx
+++ b/packages/web/src/components/CommentThread.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
 import { useComments } from '../hooks/useComments';
-import { commentGoesToAgent } from '../lib/units-view';
+import { commentTarget } from '../lib/units-view';
 import { copy } from '../lib/microcopy';
 import { useReviewStore } from '../state/review-store';
 import type { CommentId, PRComment } from '../state/types';
@@ -78,9 +78,11 @@ export function CommentThread({
   const drafts = useReviewStore((s) => s.drafts);
   const addDraft = useReviewStore((s) => s.addDraft);
   const removeDraft = useReviewStore((s) => s.removeDraft);
-  // Agent target = watch mode, or a local (agent/cli) unit in the daemon — both send to the agent
-  // loop rather than GitHub, so the composer drops the "Add to review" affordance and relabels.
-  const isAgentTarget = useReviewStore((s) => commentGoesToAgent(s.mode, s.route, s.units));
+  // Where this comment lands drives the composer's copy + affordances. `agent` (watch, or a local
+  // daemon unit) drops the "Add to review" batch flow and relabels; `github` (a daemon PR unit) keeps
+  // the GitHub-comment flow but says so plainly ("Comment on PR"); `review` is PR mode's batch flow.
+  const target = useReviewStore((s) => commentTarget(s.mode, s.route, s.units));
+  const isAgentTarget = target === 'agent';
 
   const draftKey = useMemo(() => draftKeyFor(path, line, chapterIndex), [path, line, chapterIndex]);
 
@@ -275,7 +277,15 @@ export function CommentThread({
             onClick={() => void submit()}
             className="rounded-md bg-[var(--brand)] px-3 py-1 text-sm font-semibold text-white shadow-sm hover:bg-[var(--brand-hover)] disabled:cursor-not-allowed disabled:opacity-50"
           >
-            {submitting ? (isAgentTarget ? 'Sending…' : 'Posting...') : isAgentTarget ? 'Send to agent' : 'Comment'}
+            {submitting
+              ? isAgentTarget
+                ? 'Sending…'
+                : 'Posting...'
+              : isAgentTarget
+                ? 'Send to agent'
+                : target === 'github'
+                  ? 'Comment on PR'
+                  : 'Comment'}
           </button>
         </div>
       </div>

--- a/packages/web/src/components/UnitReview.tsx
+++ b/packages/web/src/components/UnitReview.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { getAccentMeta } from '../lib/accents';
 import { loadDrafts, pendingReviewComments, useReviewStore } from '../state/review-store';
-import { reviewEndpoint, summarizeChecks, summarizeReviews } from '../lib/units-view';
+import { agentPresence, reviewEndpoint, summarizeChecks, summarizeReviews } from '../lib/units-view';
 import { useComments } from '../hooks/useComments';
 import { postDecision, removeUnit, retryUnit } from '../hooks/useUnits';
 import { AccentPicker } from './AccentPicker';
@@ -39,6 +39,43 @@ function applyUnitToStore(unit: Unit): void {
   });
 }
 
+/**
+ * The drill-in's honest "is anyone listening" cue for local units. Reads the unit's agent last-seen
+ * from the store (seeded on open, kept live by the `presence` SSE event) and ticks its own clock so a
+ * fresh stamp goes stale on its own. Steady, not flickery: an active agent refreshes every poll, so
+ * working between polls doesn't flip it — see {@link agentPresence}.
+ */
+function AgentPresencePill({ unitId }: { unitId: string }) {
+  const lastSeenAt = useReviewStore((s) => s.presence[unitId]);
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(id);
+  }, []);
+  const { connected, label } = agentPresence(lastSeenAt, now);
+  const title = connected
+    ? 'An agent is on this review — your comments and the verdict reach it on its next poll (≤4 min).'
+    : lastSeenAt == null
+      ? 'No agent has connected to this review yet. Your notes are saved and delivered when one does.'
+      : 'No agent connected right now. Your notes are saved and delivered when an agent reconnects.';
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11.5px] font-medium"
+      style={{
+        background: connected ? 'var(--green-3)' : 'var(--gray-3)',
+        color: connected ? 'var(--green-11)' : 'var(--fg-3)',
+      }}
+      title={title}
+    >
+      <span
+        className={`inline-block h-1.5 w-1.5 rounded-full ${connected ? 'live-ping-dot' : ''}`}
+        style={{ background: connected ? 'var(--green-10)' : 'var(--gray-8)' }}
+      />
+      {label}
+    </span>
+  );
+}
+
 function BackLink() {
   const navigate = useReviewStore((s) => s.navigate);
   return (
@@ -70,6 +107,7 @@ export function UnitReview() {
   const mode = useReviewStore((s) => s.mode);
   const setComments = useReviewStore((s) => s.setComments);
   const setAgentComments = useReviewStore((s) => s.setAgentComments);
+  const setPresence = useReviewStore((s) => s.setPresence);
   const draftCount = useReviewStore((s) => pendingReviewComments(s.drafts).length);
   const clearDrafts = useReviewStore((s) => s.clearDrafts);
   const setCheckRuns = useReviewStore((s) => s.setCheckRuns);
@@ -155,6 +193,26 @@ export function UnitReview() {
       cancelled = true;
     };
   }, [unitId, setAgentComments]);
+
+  // Seed the agent-presence cue on open (the `presence` SSE event keeps it live thereafter). Cheap
+  // enough to fetch for any unit; the pill only renders for local units.
+  useEffect(() => {
+    if (!unitId) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(`/api/units/${encodeURIComponent(unitId)}/presence`);
+        if (!res.ok || cancelled) return;
+        const data = (await res.json()) as { lastSeenAt: number | null };
+        if (!cancelled) setPresence(unitId, data.lastSeenAt ?? null);
+      } catch {
+        // ignore — the SSE stream backfills
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [unitId, setPresence]);
 
   // Load this github unit's CI checks + reviews. Keyed on the head SHA too, so a new push (the SSE
   // `units` event updates the unit's metadata) re-fetches the status — modest liveness without a poll.
@@ -325,6 +383,8 @@ export function UnitReview() {
         )}
         <span className="truncate text-[13.5px] font-semibold text-[var(--fg-1)]">{unit?.taskLabel}</span>
         <div className="ml-auto flex items-center gap-2">
+          {/* Local units run the agent loop — show whether an agent is actually there to receive notes. */}
+          {unitId && unit && unit.source !== 'github' && <AgentPresencePill unitId={unitId} />}
           {unit?.source === 'github' && unit.prUrl && (
             <a
               href={unit.prUrl}

--- a/packages/web/src/components/UnitRow.tsx
+++ b/packages/web/src/components/UnitRow.tsx
@@ -1,5 +1,20 @@
-import { groupOf, recommendedAction, relativeTime, type VerdictTone, verdictTone } from '../lib/units-view';
+import {
+  groupOf,
+  recommendedAction,
+  relativeTime,
+  type SourceBadge,
+  sourceBadge,
+  type VerdictTone,
+  verdictTone,
+} from '../lib/units-view';
 import type { Unit, UnitStatus } from '../state/types';
+
+/** Source-badge palette — agent (has a parked agent) reads purple like the bot cue; github blue; local neutral. */
+const SOURCE_TONE: Record<SourceBadge['tone'], React.CSSProperties> = {
+  agent: { background: 'var(--purple-3)', color: 'var(--purple-11)' },
+  github: { background: 'var(--blue-3)', color: 'var(--blue-11)' },
+  local: { background: 'var(--gray-3)', color: 'var(--fg-3)' },
+};
 
 const TONE: Record<VerdictTone, { fg: string; glyph: string }> = {
   risk: { fg: 'var(--red-11)', glyph: '▲' },
@@ -79,6 +94,7 @@ export function UnitRow({ unit, now, onOpen, onApprove, onRequestChanges, onRetr
   const branch = unit.metadata?.branch;
   const elapsed = relativeTime(unit.updatedAt, now);
   const action = isNeedsYou ? recommendedAction(unit) : null;
+  const badge = sourceBadge(unit.source);
 
   const meta: string[] = [];
   if (isNeedsYou) meta.push(unit.toResolve === 1 ? '1 to resolve' : `${unit.toResolve} to resolve`);
@@ -113,15 +129,13 @@ export function UnitRow({ unit, now, onOpen, onApprove, onRequestChanges, onRetr
             )}
             <span className="text-[var(--fg-3)]">·</span>
             <span className="font-medium text-[var(--fg-1)]">{unit.taskLabel}</span>
-            {unit.source === 'cli' && (
-              <span
-                className="rounded px-1 py-px text-[10.5px] font-medium leading-none"
-                style={{ background: 'var(--gray-3)', color: 'var(--fg-3)' }}
-                title="Added locally via dad add"
-              >
-                local
-              </span>
-            )}
+            <span
+              className="rounded px-1 py-px text-[10.5px] font-medium leading-none"
+              style={SOURCE_TONE[badge.tone]}
+              title={badge.title}
+            >
+              {badge.label}
+            </span>
             {unit.source === 'github' && unit.prAuthor && (
               <span className="text-[12px] text-[var(--fg-3)]" title={`PR by @${unit.prAuthor}`}>
                 @{unit.prAuthor}

--- a/packages/web/src/hooks/useLiveStream.ts
+++ b/packages/web/src/hooks/useLiveStream.ts
@@ -188,6 +188,17 @@ export function useLiveStream() {
       }
     };
 
+    // Command center: a unit's agent checked in (parked on the verdict, or worked its comments).
+    const onPresence = (e: MessageEvent) => {
+      try {
+        const data = JSON.parse(e.data) as { unitId: string; lastSeenAt: number | null };
+        useReviewStore.getState().setPresence(data.unitId, data.lastSeenAt ?? null);
+        setLastEventAt(Date.now());
+      } catch {
+        // ignore malformed event
+      }
+    };
+
     const onTriage = (e: MessageEvent) => {
       try {
         const data = JSON.parse(e.data) as { flags: TriageFlag[]; status?: TriageStatus };
@@ -307,6 +318,7 @@ export function useLiveStream() {
     es.addEventListener('pr', onPr as EventListener);
     es.addEventListener('watch-update', onWatchUpdate as EventListener);
     es.addEventListener('units', onUnits as EventListener);
+    es.addEventListener('presence', onPresence as EventListener);
     es.addEventListener('triage', onTriage as EventListener);
     es.addEventListener('regenerating', onRegenerating as EventListener);
     es.addEventListener('narrative-progress', onNarrativeProgress as EventListener);
@@ -337,6 +349,7 @@ export function useLiveStream() {
       es.removeEventListener('pr', onPr as EventListener);
       es.removeEventListener('watch-update', onWatchUpdate as EventListener);
       es.removeEventListener('units', onUnits as EventListener);
+      es.removeEventListener('presence', onPresence as EventListener);
       es.removeEventListener('triage', onTriage as EventListener);
       es.removeEventListener('regenerating', onRegenerating as EventListener);
       es.removeEventListener('narrative-progress', onNarrativeProgress as EventListener);

--- a/packages/web/src/lib/__tests__/units-view.test.ts
+++ b/packages/web/src/lib/__tests__/units-view.test.ts
@@ -11,7 +11,9 @@ import {
   relativeTime,
   repoOptions,
   reviewEndpoint,
+  commentTarget,
   routePath,
+  sourceBadge,
   summarizeChecks,
   summarizeReviews,
   verdictTone,
@@ -200,6 +202,24 @@ describe('agentCommentsEndpoint', () => {
   });
 });
 
+describe('commentTarget', () => {
+  it('sends to the agent loop in watch mode and on local daemon units', () => {
+    expect(commentTarget('watch', { name: 'center' }, [])).toBe('agent');
+    const units = [mkUnit({ unitId: 'u1', source: 'cli' }), mkUnit({ unitId: 'u2', source: 'agent' })];
+    expect(commentTarget('command-center', { name: 'unit', unitId: 'u1' }, units)).toBe('agent');
+    expect(commentTarget('command-center', { name: 'unit', unitId: 'u2' }, units)).toBe('agent');
+  });
+  it('targets the GitHub PR on a github daemon unit (the relabel case)', () => {
+    const units = [mkUnit({ unitId: 'g1', source: 'github' })];
+    expect(commentTarget('command-center', { name: 'unit', unitId: 'g1' }, units)).toBe('github');
+  });
+  it('falls back to the PR review flow in pr mode and at the center root', () => {
+    expect(commentTarget('pr', { name: 'center' }, [])).toBe('review');
+    expect(commentTarget('command-center', { name: 'center' }, [])).toBe('review');
+    expect(commentTarget('command-center', { name: 'unit', unitId: 'missing' }, [])).toBe('review');
+  });
+});
+
 describe('commentGoesToAgent', () => {
   it('always routes to the agent loop in watch mode', () => {
     expect(commentGoesToAgent('watch', { name: 'center' }, [])).toBe(true);
@@ -219,6 +239,21 @@ describe('commentGoesToAgent', () => {
   it('routes to GitHub at the center root or for an unknown unit', () => {
     expect(commentGoesToAgent('command-center', { name: 'center' }, [])).toBe(false);
     expect(commentGoesToAgent('command-center', { name: 'unit', unitId: 'missing' }, [])).toBe(false);
+  });
+});
+
+describe('sourceBadge', () => {
+  it('labels each ingestion door distinctly so the queue is legible', () => {
+    expect(sourceBadge('agent')).toMatchObject({ label: 'agent', tone: 'agent' });
+    expect(sourceBadge('cli')).toMatchObject({ label: 'local', tone: 'local' });
+    expect(sourceBadge('github')).toMatchObject({ label: 'GitHub', tone: 'github' });
+  });
+  it('defaults an unset source to the agent door (matches server back-compat)', () => {
+    expect(sourceBadge(undefined)).toMatchObject({ label: 'agent', tone: 'agent' });
+  });
+  it('carries a human title explaining where the unit came from', () => {
+    expect(sourceBadge('github').title).toMatch(/github/i);
+    expect(sourceBadge('cli').title).toMatch(/dad add/i);
   });
 });
 

--- a/packages/web/src/lib/__tests__/units-view.test.ts
+++ b/packages/web/src/lib/__tests__/units-view.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   agentCommentsEndpoint,
+  agentPresence,
   aiEndpoint,
   commentGoesToAgent,
   commentsEndpoint,
@@ -254,6 +255,20 @@ describe('sourceBadge', () => {
   it('carries a human title explaining where the unit came from', () => {
     expect(sourceBadge('github').title).toMatch(/github/i);
     expect(sourceBadge('cli').title).toMatch(/dad add/i);
+  });
+});
+
+describe('agentPresence', () => {
+  const now = Date.parse('2026-06-26T12:00:00.000Z');
+  it('reads as disconnected when an agent has never been seen', () => {
+    expect(agentPresence(null, now)).toEqual({ connected: false, label: 'no agent connected' });
+    expect(agentPresence(undefined, now)).toEqual({ connected: false, label: 'no agent connected' });
+  });
+  it('reads as connected when the agent checked in within the freshness window', () => {
+    expect(agentPresence(now - 60_000, now)).toEqual({ connected: true, label: 'agent connected' });
+  });
+  it('goes stale (disconnected) once the last check-in is past the window', () => {
+    expect(agentPresence(now - 10 * 60_000, now)).toEqual({ connected: false, label: 'no agent connected' });
   });
 });
 

--- a/packages/web/src/lib/units-view.ts
+++ b/packages/web/src/lib/units-view.ts
@@ -124,6 +124,27 @@ export function relativeTime(iso: string, nowMs: number): string {
   return `${Math.floor(hours / 24)}d`;
 }
 
+/**
+ * An agent counts as "connected" to a unit if it checked in (parked on the verdict, or worked the
+ * unit's comments) within this window. The daemon's `await_decision` poll ceiling is ~4 min, so an
+ * active agent always refreshes inside 5 min — and the cue won't false-flip to "disconnected" while
+ * the agent is merely working between polls.
+ */
+export const AGENT_PRESENCE_WINDOW_MS = 5 * 60_000;
+
+/**
+ * Turn a unit's `lastSeenAt` (epoch-ms of the agent's most recent interaction, or null/undefined if
+ * never) into the drill-in's honest presence cue. Pure, so it's unit-tested; the component supplies
+ * `nowMs` from a ticking clock so a fresh stamp naturally goes stale without another event.
+ */
+export function agentPresence(
+  lastSeenAt: number | null | undefined,
+  nowMs: number,
+): { connected: boolean; label: string } {
+  const connected = lastSeenAt != null && nowMs - lastSeenAt < AGENT_PRESENCE_WINDOW_MS;
+  return { connected, label: connected ? 'agent connected' : 'no agent connected' };
+}
+
 // --- Client-side routing (the daemon serves index.html for any path, so deep links work) ------
 
 export type Route = { name: 'center' } | { name: 'unit'; unitId: string };

--- a/packages/web/src/lib/units-view.ts
+++ b/packages/web/src/lib/units-view.ts
@@ -87,6 +87,30 @@ export function repoOptions(units: Unit[]): string[] {
   return [...new Set(units.map((u) => u.repo))].sort();
 }
 
+/**
+ * The visible "where did this unit come from" badge. The three ingestion doors read very
+ * differently — an `agent` unit has a parked agent that pulls comments, a `cli` unit is a local
+ * `dad add` diff, a `github` unit mirrors a real PR and comments post to GitHub — so making the
+ * door legible is what gates the affordances (see {@link commentGoesToAgent}). An unset source
+ * defaults to `agent`, matching the store's server-side back-compat default.
+ */
+export type SourceBadge = { label: string; title: string; tone: 'agent' | 'local' | 'github' };
+
+export function sourceBadge(source: Unit['source']): SourceBadge {
+  switch (source) {
+    case 'github':
+      return {
+        label: 'GitHub',
+        title: 'Pulled from a GitHub review request — comments post to the PR',
+        tone: 'github',
+      };
+    case 'cli':
+      return { label: 'local', title: 'Added locally via dad add', tone: 'local' };
+    default:
+      return { label: 'agent', title: 'Submitted by an agent via submit_for_review', tone: 'agent' };
+  }
+}
+
 /** Compact elapsed label ("just now" / "5m" / "3h" / "2d"). Empty string for an unparseable date. */
 export function relativeTime(iso: string, nowMs: number): string {
   const then = Date.parse(iso);
@@ -148,17 +172,31 @@ export const agentCommentsEndpoint = (mode: 'pr' | 'watch' | 'command-center', r
   resourceEndpoint(mode, route, 'agent-comments');
 
 /**
- * Does an inline comment on the current surface go to the agent loop (vs a GitHub PR comment)? Watch
- * mode always does. In the daemon, a LOCAL unit (agent/cli — it has no PR) does; a github unit gets a
- * real PR comment instead. Pure, so the routing is unit-tested without rendering a hook.
+ * Where an inline comment on the current surface actually lands — the one fact that gates the
+ * composer's copy and affordances:
+ *   - `agent`  → the per-unit agent loop (watch mode; a local agent/cli daemon unit with a parked agent)
+ *   - `github` → a real GitHub PR comment (a daemon `github` unit — the relabel "Comment on PR" case)
+ *   - `review` → the standalone PR-review batch flow (pr mode, or the center root with no open unit)
+ * Pure, so the routing is unit-tested without rendering a hook.
  */
-export function commentGoesToAgent(mode: 'pr' | 'watch' | 'command-center', route: Route, units: Unit[]): boolean {
-  if (mode === 'watch') return true;
+export type CommentTarget = 'agent' | 'github' | 'review';
+
+export function commentTarget(mode: 'pr' | 'watch' | 'command-center', route: Route, units: Unit[]): CommentTarget {
+  if (mode === 'watch') return 'agent';
   if (mode === 'command-center' && route.name === 'unit') {
     const unit = units.find((u) => u.unitId === route.unitId);
-    return !!unit && unit.source !== 'github';
+    if (!unit) return 'review';
+    return unit.source === 'github' ? 'github' : 'agent';
   }
-  return false;
+  return 'review';
+}
+
+/**
+ * Does an inline comment on the current surface go to the agent loop (vs a GitHub PR comment)? Thin
+ * wrapper over {@link commentTarget} so callers that only need the agent/not-agent split stay simple.
+ */
+export function commentGoesToAgent(mode: 'pr' | 'watch' | 'command-center', route: Route, units: Unit[]): boolean {
+  return commentTarget(mode, route, units) === 'agent';
 }
 
 // --- CI checks + reviews rollups (the drill-in's merge-readiness strip) ------------------------

--- a/packages/web/src/state/review-store.ts
+++ b/packages/web/src/state/review-store.ts
@@ -56,6 +56,8 @@ type ReviewState = {
   mode: 'pr' | 'watch' | 'command-center';
   /** Command-center: the daemon's review-unit queue, kept live via the `units` SSE event. */
   units: Unit[];
+  /** Per-unit agent last-seen (epoch-ms, or null if never) behind the drill-in's presence cue. */
+  presence: Record<string, number | null>;
   /** Command-center client-side route (center vs. a drill-in `/units/:id`). */
   route: Route;
   checkRuns: CheckRun[];
@@ -144,6 +146,8 @@ type ReviewState = {
   setTriage: (flags: TriageFlag[], status: TriageStatus) => void;
   setMode: (mode: 'pr' | 'watch' | 'command-center') => void;
   setUnits: (units: Unit[]) => void;
+  /** Record a unit's agent last-seen (from the `presence` SSE event or the drill-in's open fetch). */
+  setPresence: (unitId: string, lastSeenAt: number | null) => void;
   /** Navigate the command center, pushing browser history (deep-linkable `/units/:id`). */
   navigate: (route: Route) => void;
   /** Sync the route from the address bar without pushing history (popstate / initial load). */
@@ -302,6 +306,7 @@ export const useReviewStore = create<ReviewState>((set) => ({
   triageStatus: 'idle',
   mode: 'pr',
   units: [],
+  presence: {},
   route: typeof window !== 'undefined' ? parseRoute(window.location.pathname) : { name: 'center' },
   checkRuns: [],
   reviews: [],
@@ -447,6 +452,7 @@ export const useReviewStore = create<ReviewState>((set) => ({
   setTriage: (triageFlags, triageStatus) => set({ triageFlags, triageStatus }),
   setMode: (mode) => set({ mode }),
   setUnits: (units) => set({ units }),
+  setPresence: (unitId, lastSeenAt) => set((s) => ({ presence: { ...s.presence, [unitId]: lastSeenAt } })),
 
   navigate: (route) => {
     if (typeof window !== 'undefined') window.history.pushState(null, '', routePath(route));


### PR DESCRIPTION
Robustness follow-ups to the agent review loop (#38), hardening the four conceptual gaps from that PR's review. Each commit is independent and TDD'd.

## What's in here

- **`feat(web)` — legible ingestion doors + composer relabel**
  Every queue row now shows a source badge (`agent` · `local` · `GitHub`) so the three doors read at a glance, and the inline composer says where a comment actually lands — **"Comment on PR"** on a GitHub unit instead of the ambiguous "Comment". New `commentTarget()` (`agent | github | review`) is the single source of truth; `commentGoesToAgent()` delegates to it. Kills the dead-affordance problem.

- **`feat(daemon)` — bundle outstanding comments into `await_decision`**
  A parked agent receives its unit's not-yet-addressed comments in the verdict response (open → delivered, broadcast over SSE), so a hand-typed beat can't be missed while it waits — no separate `list_review_comments` call required. Omitted when nothing's outstanding.

- **`feat(daemon)` — honest agent-presence cue**
  The drill-in shows **"agent connected" / "no agent connected"** from real last-seen activity (`AgentActivity`), touched whenever the unit's agent parks on `await_decision` or works its comments, surfaced via a new `presence` SSE event + `GET /api/units/:id/presence`. It's steady, not flickery: an active agent refreshes within the ~4-min poll ceiling, so working between polls doesn't flip it; it goes stale only after 5 min. Closes the "did anyone get my note?" trust hole without faking a real-time socket.

- **`feat(cli)` — move durable data out of `~/.cache`**
  The review queue (`units/`) and agent-comment threads (`agent-comments/`) are durable state, not cache — they now live under `dataDir()` (`~/Library/Application Support/diffdad` on macOS, `$XDG_DATA_HOME`/`~/.local/share` elsewhere), alongside the daemon pidfile + logs. Regenerable narrative/recap caches correctly stay in `~/.cache`. A best-effort, idempotent `migrateLegacyData()` runs once at CLI startup to relocate existing data without clobbering. Prep for the menu-bar app.

- **`fix(cli)` — honor `XDG_CONFIG_HOME`**
  `getConfigPath()` now respects `XDG_CONFIG_HOME` (defaults to `~/.config`, so no change for users). Fixes a pre-existing test-isolation bug where `server.test.ts` read the developer's real config and failed locally on any customized machine (CI passed it because CI has no user config).

## Notes

- The `await_decision` poll ceiling (~4 min) is the current delivery latency for comments left while an agent is parked — the bundle is picked up on the next poll, not pushed instantly. Honest "instant push" (waking a parked `await_decision` on comment-add) is a deliberate follow-up, not in scope here.

## Verification

- CLI tests: **396 pass, 0 fail** · web tests: **77 pass** · web build ✓
- typecheck (web + cli + site) ✓ · oxlint 0/0 · oxfmt clean
