### PR TITLE
ci: drop the legacy homebrew-diffdad tap from releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,8 +85,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - repo: nicknisi/homebrew-diffdad
-            path: tap-legacy
           - repo: nicknisi/homebrew-formulae
             path: tap-formulae
     steps:


### PR DESCRIPTION
The `nicknisi/homebrew-formulae` tap is now the single publish target for releases (`brew install nicknisi/formulae/dad`). This removes the retired `nicknisi/homebrew-diffdad` tap from the update-formula matrix: its job has failed on every release since dual-publish landed, with both the v0.10.0 and v0.11.0 tap pushes returning 403, and there is nothing left to publish to it.