### PR TITLE
fix(daemon): survive launchd's bare PATH + stop hiding the no-GitHub state

### DIFF
--- a/packages/cli/src/__tests__/github-client.test.ts
+++ b/packages/cli/src/__tests__/github-client.test.ts
@@ -523,10 +523,10 @@ describe('GitHubClient.searchReviewRequested', () => {
       labels: [],
       created_at: '2026-01-01T00:00:00Z',
       updated_at: '2026-02-01T00:00:00Z',
-      additions: 0,
-      deletions: 0,
-      changed_files: 0,
-      commits: 0,
+      additions: 12,
+      deletions: 4,
+      changed_files: 3,
+      commits: 2,
       ...over,
     };
   }
@@ -562,6 +562,11 @@ describe('GitHubClient.searchReviewRequested', () => {
       author: 'author',
       url: 'https://github.com/octo/repo/pull/7',
       updatedAt: '2026-02-01T00:00:00Z',
+      // Counts ride along from the same getPR fetch — no extra API call, real numbers at mint time.
+      additions: 12,
+      deletions: 4,
+      changedFiles: 3,
+      commits: 2,
     });
   });
 

--- a/packages/cli/src/__tests__/units-routes.test.ts
+++ b/packages/cli/src/__tests__/units-routes.test.ts
@@ -68,6 +68,7 @@ type SetupOpts = {
   ai?: (system: string, user: string) => Promise<{ text: string }>;
   statusFetcher?: (unit: ReviewUnit) => Promise<{ checks: CheckRun[]; reviews: PRReview[] }>;
   pollNow?: () => Promise<{ minted: number; resurfaced: number; removed: number }>;
+  github?: boolean;
 };
 
 function setup(opts: SetupOpts = {}) {
@@ -84,6 +85,7 @@ function setup(opts: SetupOpts = {}) {
   const { app } = createDaemonApp({
     store,
     hub,
+    github: opts.github ?? false,
     hydrate,
     commentFetcher,
     commentPoster,
@@ -162,6 +164,13 @@ describe('GET /api/units', () => {
     const byRepo = (await (await app.request('/api/units?repo=owner/a')).json()) as { units: { unitId: string }[] };
     expect(byRepo.units.map((u) => u.unitId)).toEqual(['unit-1']);
   });
+
+  it('emits the daemon GitHub-credential flag so the command center can flag the degraded state', async () => {
+    const off = (await (await setup({ github: false }).app.request('/api/units')).json()) as { github: boolean };
+    expect(off.github).toBe(false);
+    const on = (await (await setup({ github: true }).app.request('/api/units')).json()) as { github: boolean };
+    expect(on.github).toBe(true);
+  });
 });
 
 describe('GET /api/units/:id', () => {
@@ -230,14 +239,25 @@ describe('POST /api/units/:id/hydrate (lazy narrative on open)', () => {
     expect(events).not.toContain('units'); // no broadcast for a no-op
   });
 
-  it('returns the unit unchanged when no hydrate dep is wired', async () => {
+  it('503s with the credential hint when no hydrate dep is wired and the unit has no narrative', async () => {
+    const { store, app } = setup(); // credential-less daemon: no hydrate injected (github: false)
+    const gh = seedGithubUnit(store);
+    const res = await post(app, gh.unitId);
+    expect(res.status).toBe(503); // honest failure, not a silent 200 no-op the UI reads as "no narrative"
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('no GitHub credentials');
+    expect(store.get(gh.unitId)!.narrative).toBeUndefined(); // unchanged
+  });
+
+  it('no-ops (200) an already-narrated unit even when no hydrate dep is wired', async () => {
     const { store, app } = setup(); // no hydrate injected
     const gh = seedGithubUnit(store);
+    store.attachReview(gh.unitId, [], NARRATIVE, 1); // a legitimate prior narrative — a no-op regardless of wiring
     const res = await post(app, gh.unitId);
     expect(res.status).toBe(200);
     const body = (await res.json()) as { unit: ReviewUnit };
     expect(body.unit.unitId).toBe(gh.unitId);
-    expect(body.unit.narrative).toBeUndefined();
+    expect(body.unit.narrative).toEqual(NARRATIVE);
   });
 
   it('404s for an unknown unit', async () => {

--- a/packages/cli/src/daemon/__tests__/launchd.test.ts
+++ b/packages/cli/src/daemon/__tests__/launchd.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { buildPlist } from '../launchd';
+
+// --- fixtures -------------------------------------------------------------
+
+const ARGS = ['/opt/dad', 'daemon', '--port=4319', '--no-open'];
+const LOGS = '/home/dev/.local/share/diffdad';
+
+// --- tests ----------------------------------------------------------------
+
+describe('buildPlist EnvironmentVariables (launchd PATH)', () => {
+  it('bakes an explicit PATH into the EnvironmentVariables dict', () => {
+    const xml = buildPlist(ARGS, LOGS, '/opt/homebrew/bin:/usr/local/bin:/usr/bin');
+    expect(xml).toContain('<key>EnvironmentVariables</key>');
+    expect(xml).toContain('<key>PATH</key>');
+    expect(xml).toContain('<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin</string>');
+    // The PATH lives inside the EnvironmentVariables dict, after ProgramArguments.
+    expect(xml.indexOf('</array>')).toBeLessThan(xml.indexOf('<key>EnvironmentVariables</key>'));
+  });
+
+  it('XML-escapes special characters in the PATH', () => {
+    const xml = buildPlist(ARGS, LOGS, '/opt/a&b/bin:/opt/<c>/bin');
+    expect(xml).toContain('<string>/opt/a&amp;b/bin:/opt/&lt;c&gt;/bin</string>');
+    // The raw, unescaped forms must never reach the plist.
+    expect(xml).not.toContain('/opt/a&b/bin');
+    expect(xml).not.toContain('/opt/<c>/bin');
+  });
+
+  it('omits the EnvironmentVariables block entirely for an empty PATH', () => {
+    const xml = buildPlist(ARGS, LOGS, '');
+    expect(xml).not.toContain('EnvironmentVariables');
+    expect(xml).not.toContain('<key>PATH</key>');
+  });
+
+  it('omits the EnvironmentVariables block when the default PATH is unset (process.env.PATH undefined)', () => {
+    // A JS default parameter treats explicit `undefined` as "use the default", so the real undefined
+    // scenario is an unset process.env.PATH — exercise that by clearing it around the omitting call.
+    const saved = process.env.PATH;
+    delete process.env.PATH;
+    try {
+      const xml = buildPlist(ARGS, LOGS);
+      expect(xml).not.toContain('EnvironmentVariables');
+      expect(xml).not.toContain('<key>PATH</key>');
+    } finally {
+      process.env.PATH = saved;
+    }
+  });
+
+  it('leaves ProgramArguments unchanged whether or not a PATH is baked in', () => {
+    const withPath = buildPlist(ARGS, LOGS, '/usr/bin');
+    const withoutPath = buildPlist(ARGS, LOGS, '');
+    for (const xml of [withPath, withoutPath]) {
+      expect(xml).toContain('<string>/opt/dad</string>');
+      expect(xml).toContain('<string>daemon</string>');
+      expect(xml).toContain('<string>--port=4319</string>');
+      expect(xml).toContain('<string>--no-open</string>');
+    }
+  });
+});

--- a/packages/cli/src/daemon/__tests__/poller.test.ts
+++ b/packages/cli/src/daemon/__tests__/poller.test.ts
@@ -50,6 +50,10 @@ function mkPr(o: Partial<PolledPr> = {}): PolledPr {
     author: 'octocat',
     url: 'https://github.com/octo/demo/pull/42',
     updatedAt: '2026-06-26T00:00:00.000Z',
+    additions: 5,
+    deletions: 2,
+    changedFiles: 3,
+    commits: 1,
     ...o,
   };
 }
@@ -94,6 +98,120 @@ describe('pollOnce', () => {
     expect(u.metadata.branch).toBe('feat/widgets');
     expect(u.metadata.base).toBe('main'); // real base ref propagated, not hardcoded
     expect(u.baseRef).toBe('main');
+  });
+
+  it('mints a unit carrying the polled diff/line counts (not zero-filled)', async () => {
+    const store = new UnitStore([], det());
+    await pollOnce({
+      search: search([mkPr({ additions: 20, deletions: 9, changedFiles: 4, commits: 3 })]),
+      store,
+      broadcast: () => {},
+    });
+    const u = store.list()[0]!;
+    expect(u.metadata.additions).toBe(20);
+    expect(u.metadata.deletions).toBe(9);
+    expect(u.metadata.changedFiles).toBe(4);
+    expect(u.metadata.commits).toBe(3);
+  });
+
+  it('heals a stale existing unit’s counts on the next poll (same head, no resurface)', async () => {
+    const store = new UnitStore([], det());
+    // A unit minted before counts rode along: metadata counts all zero, head sha-1, still queued.
+    const u = store.addGithubUnit({
+      owner: 'octo',
+      repo: 'demo',
+      number: 42,
+      title: 'Add widgets',
+      headBranch: 'feat/widgets',
+      headSha: 'sha-1',
+      author: 'octocat',
+      url: 'https://github.com/octo/demo/pull/42',
+      metadata: { ...mkMetadata('feat/widgets'), headSha: 'sha-1' }, // additions/deletions/... = 0
+    });
+
+    const result = await pollOnce({
+      search: search([
+        mkPr({ number: 42, headSha: 'sha-1', additions: 12, deletions: 4, changedFiles: 3, commits: 2 }),
+      ]),
+      store,
+      broadcast: () => {},
+    });
+
+    expect(result).toEqual({ minted: 0, resurfaced: 0, removed: 0 }); // same PR, same head → no mint/resurface
+    const after = store.get(u.unitId)!;
+    expect(after.metadata.additions).toBe(12);
+    expect(after.metadata.deletions).toBe(4);
+    expect(after.metadata.changedFiles).toBe(3);
+    expect(after.metadata.commits).toBe(2);
+    expect(after.status).toBe('queued'); // heal does not transition
+    expect(after.metadata.headSha).toBe('sha-1'); // heal does not move the head
+  });
+
+  it('does not rewrite an existing unit whose counts already match (no pointless persist per poll)', async () => {
+    const store = new UnitStore([], det());
+    store.addGithubUnit({
+      owner: 'octo',
+      repo: 'demo',
+      number: 42,
+      title: 'Add widgets',
+      headBranch: 'feat/widgets',
+      headSha: 'sha-1',
+      author: 'octocat',
+      url: 'https://github.com/octo/demo/pull/42',
+      metadata: {
+        ...mkMetadata('feat/widgets'),
+        headSha: 'sha-1',
+        additions: 7,
+        deletions: 1,
+        changedFiles: 2,
+        commits: 1,
+      },
+    });
+    const spy = vi.spyOn(store, 'setMetadataCounts');
+    try {
+      await pollOnce({
+        search: search([
+          mkPr({ number: 42, headSha: 'sha-1', additions: 7, deletions: 1, changedFiles: 2, commits: 1 }),
+        ]),
+        store,
+        broadcast: () => {},
+      });
+      expect(spy).not.toHaveBeenCalled(); // equal counts → no heal write
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('a count heal never changes status, reviewedSha, or headSha (decided unit, same head)', async () => {
+    const store = new UnitStore([], det());
+    const u = store.addGithubUnit({
+      owner: 'octo',
+      repo: 'demo',
+      number: 42,
+      title: 'Add widgets',
+      headBranch: 'feat/widgets',
+      headSha: 'sha-1',
+      author: 'octocat',
+      url: 'https://github.com/octo/demo/pull/42',
+      metadata: { ...mkMetadata('feat/widgets'), headSha: 'sha-1' }, // counts = 0
+    });
+    store.setReviewedSha(u.unitId, 'sha-1');
+    (store.get(u.unitId) as { decision?: unknown }).decision = { kind: 'approved' };
+    (store.get(u.unitId) as { status: string }).status = 'approved';
+
+    await pollOnce({
+      search: search([
+        mkPr({ number: 42, headSha: 'sha-1', additions: 15, deletions: 6, changedFiles: 5, commits: 4 }),
+      ]),
+      store,
+      broadcast: () => {},
+    });
+
+    const after = store.get(u.unitId)!;
+    expect(after.metadata.additions).toBe(15); // healed
+    expect(after.status).toBe('approved'); // unchanged — a decided unit at the same head isn't resurfaced
+    expect(after.lastReviewedSha).toBe('sha-1'); // unchanged
+    expect(after.metadata.headSha).toBe('sha-1'); // unchanged
   });
 
   it("mints a github unit carrying the PR's real (non-default) base ref", async () => {

--- a/packages/cli/src/daemon/app.ts
+++ b/packages/cli/src/daemon/app.ts
@@ -51,9 +51,17 @@ export type DaemonAppDeps = {
   store: UnitStore;
   hub: SseHub;
   /**
+   * Whether the daemon resolved GitHub credentials. Emitted on GET /api/units so the command center
+   * can surface the degraded state (poller dark, hydrate/review/comments disabled) instead of silently
+   * 503ing on Refresh. Fixed for the process lifetime — a token can't appear without a restart — so the
+   * web hook reads it once from that snapshot; SSE `units` broadcasts omit it.
+   */
+  github: boolean;
+  /**
    * Lazily hydrates a `github` unit on open: fetch the PR diff, generate the narrative, store it, and
    * return the updated unit. Injected so tests fake it and the daemon wires the real fetch+generate
-   * path. Absent → the hydrate route is a graceful no-op (the unit is returned unchanged).
+   * path. Absent (no GitHub credentials) → the hydrate route 503s with a credential hint, since it
+   * cannot fetch the diff or narrate — a unit that already has a narrative still no-ops with 200.
    *
    * `force` (the per-PR re-read) regenerates even when a narrative already exists: it advances the unit
    * to the live head SHA and bypasses the cache read. The route passes it through from the POST body.
@@ -121,7 +129,7 @@ function resolveWebDist(override?: string): string {
  * unit-scoped store is a cleaner seam.
  */
 export function createDaemonApp(deps: DaemonAppDeps): { app: Hono } {
-  const { store, hub, hydrate } = deps;
+  const { store, hub, github, hydrate } = deps;
   const { commentFetcher, commentPoster, reviewSubmitter, ai, statusFetcher, pollNow } = deps;
   const app = new Hono();
   const broadcast = hub.broadcast;
@@ -143,7 +151,9 @@ export function createDaemonApp(deps: DaemonAppDeps): { app: Hono } {
   app.get('/api/units', (c) => {
     const status = c.req.query('status') as ReviewUnit['status'] | undefined;
     const repo = c.req.query('repo');
-    return c.json({ units: store.list({ status, repo }) });
+    // `github` rides the snapshot so the command center learns a credential-less daemon can't poll —
+    // it can't come off the SSE `units` stream, which carries only the list.
+    return c.json({ units: store.list({ status, repo }), github });
   });
 
   app.get('/api/units/:id', (c) => {
@@ -199,8 +209,9 @@ export function createDaemonApp(deps: DaemonAppDeps): { app: Hono } {
   // Lazy narrative — generated on open, not on poll, so dad never burns tokens narrating PRs you
   // never click. The web drill-in POSTs this once when it opens a unit with no narrative; the
   // `hydrate` dep fetches the PR diff + generates the walkthrough and stores it (without a status
-  // transition). No-op for already-hydrated units or when no hydrate dep is wired. Must precede the
-  // static catch-all or serveStatic swallows it.
+  // transition). No-op (200) for already-narrated units; 503 when no hydrate dep is wired (a
+  // credential-less daemon can't fetch/narrate — say so instead of a silent no-op the UI reads as a
+  // generic "no narrative"). Must precede the static catch-all or serveStatic swallows it.
   //
   // The per-PR re-read POSTs an optional `{ force: true }` body: it regenerates even when a narrative
   // exists (advancing to the live head SHA + bypassing the cache read). The body is optional — the
@@ -219,10 +230,21 @@ export function createDaemonApp(deps: DaemonAppDeps): { app: Hono } {
       // No body / not JSON — the lazy first-open path posts nothing. Treat it as a non-force hydrate.
     }
 
-    // No GitHub wired → graceful no-op (unit returned unchanged). A non-force hydrate on an already
-    // narrated unit is also a no-op (the lazy path fires once per open); `force` bypasses that guard.
-    if (!hydrate) return c.json({ unit });
+    // An already-narrated unit is a legitimate no-op regardless of wiring (the lazy path fires once
+    // per open); `force` bypasses this to regenerate. Check it FIRST so a narrated unit returns 200
+    // even on a credential-less daemon.
     if (!force && unit.narrative) return c.json({ unit });
+    // No GitHub wired → we can't fetch the diff or narrate. Fail honestly (503) with a fix-it hint,
+    // rather than a silent 200 no-op the drill-in renders as a generic "no narrative".
+    if (!hydrate) {
+      return c.json(
+        {
+          error:
+            'The daemon has no GitHub credentials — run `gh auth login` or set DIFFDAD_GITHUB_TOKEN, then restart the daemon.',
+        },
+        503,
+      );
+    }
 
     // Single-flight per unit: coalesce concurrent hydrates for this id onto one run. The first caller's
     // `force` wins the shared run — a follow-on that rides it gets the same result, which is the intent

--- a/packages/cli/src/daemon/daemon.ts
+++ b/packages/cli/src/daemon/daemon.ts
@@ -293,6 +293,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<number> {
   const { app } = createDaemonApp({
     store,
     hub,
+    github: Boolean(githubClient),
     hydrate: githubClient ? makeHydrate(githubClient, store) : undefined,
     commentFetcher: githubClient ? makeCommentFetcher(githubClient) : undefined,
     commentPoster: githubClient ? makeCommentPoster(githubClient) : undefined,

--- a/packages/cli/src/daemon/launchd.ts
+++ b/packages/cli/src/daemon/launchd.ts
@@ -58,11 +58,31 @@ function xmlEscape(s: string): string {
  * starts it at login; `KeepAlive` {SuccessfulExit:false} restarts it only on a *non-zero* exit (a
  * crash) — never on the single-instance guard's clean exit-0 refusal, so a launchd copy and a manual
  * `dad daemon` can't fight in a respawn loop. `ThrottleInterval` caps respawn frequency at 10s.
+ *
+ * CONSTRAINT: launchd starts the agent with a bare PATH (/usr/bin:/bin:/usr/sbin:/sbin), not the
+ * user's shell PATH. The daemon spawns `gh auth token` (auth.ts) and `claude -p` (narrative), which
+ * for most users live in custom dirs (Homebrew, asdf/mise, npm-global, ~/.local/bin). Absent PATH,
+ * those spawns fail → no token → the poller never starts. So the installing shell's PATH is baked
+ * into the agent via EnvironmentVariables. `path` defaults to `process.env.PATH` (the install-time
+ * shell's PATH); tests pass it explicitly. An empty/undefined value omits the block.
  */
-export function buildPlist(programArgs: string[] = resolveProgramArgs(), logs: string = logDir()): string {
+export function buildPlist(
+  programArgs: string[] = resolveProgramArgs(),
+  logs: string = logDir(),
+  path: string | undefined = process.env.PATH,
+): string {
   const argXml = programArgs.map((arg) => `    <string>${xmlEscape(arg)}</string>`).join('\n');
   const out = xmlEscape(join(logs, 'daemon.out.log'));
   const err = xmlEscape(join(logs, 'daemon.err.log'));
+  const envXml =
+    path && path.length > 0
+      ? `  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>${xmlEscape(path)}</string>
+  </dict>
+`
+      : '';
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -73,7 +93,7 @@ export function buildPlist(programArgs: string[] = resolveProgramArgs(), logs: s
   <array>
 ${argXml}
   </array>
-  <key>RunAtLoad</key>
+${envXml}  <key>RunAtLoad</key>
   <true/>
   <key>KeepAlive</key>
   <dict>

--- a/packages/cli/src/daemon/poller.ts
+++ b/packages/cli/src/daemon/poller.ts
@@ -5,9 +5,10 @@ import type { PolledPr, ReviewUnit } from '../units/types';
 import type { PRMetadata } from '../github/types';
 
 /**
- * Build the `PRMetadata` a freshly-minted `github` unit carries from the cheap PR metadata the poller
- * fetched. The diff/line counts are unknown until the lazy on-open fetch, so they start at zero; the
- * `headSha`/`branch`/`title`/`author`/`updatedAt` are the load-bearing fields (freshness + the row).
+ * Build the `PRMetadata` a freshly-minted `github` unit carries from the PR metadata the poller
+ * fetched. The diff/line counts ride along on the `PolledPr` (the search already fetched each PR), so
+ * the row shows real numbers at mint — no zero-fill until the lazy on-open hydrate. The
+ * `headSha`/`branch`/`title`/`author`/`updatedAt` remain the load-bearing freshness fields.
  */
 function metadataFromPr(pr: PolledPr): PRMetadata {
   return {
@@ -22,12 +23,22 @@ function metadataFromPr(pr: PolledPr): PRMetadata {
     labels: [],
     createdAt: pr.updatedAt,
     updatedAt: pr.updatedAt,
-    additions: 0,
-    deletions: 0,
-    changedFiles: 0,
-    commits: 0,
+    additions: pr.additions,
+    deletions: pr.deletions,
+    changedFiles: pr.changedFiles,
+    commits: pr.commits,
     headSha: pr.headSha,
   };
+}
+
+/** Whether a unit's stored diff/line counts drift from the freshly-polled PR (so a heal is worth a write). */
+function countsDiffer(meta: PRMetadata, pr: PolledPr): boolean {
+  return (
+    meta.additions !== pr.additions ||
+    meta.deletions !== pr.deletions ||
+    meta.changedFiles !== pr.changedFiles ||
+    meta.commits !== pr.commits
+  );
 }
 
 /**
@@ -82,6 +93,17 @@ export async function pollOnce(deps: {
       if (unit && shouldResurface(unit, pr.headSha)) {
         store.resurfaceForNewPush(c.unitId, pr.headSha);
         resurfaced++;
+      }
+      // Heal a unit whose stored counts drift from the live PR — minted before the counts rode along,
+      // or the author pushed since. The search already fetched the PR, so this is free. Counts ONLY:
+      // never status / reviewedSha / headSha. Skip when equal so an unchanged PR isn't rewritten each poll.
+      if (unit && countsDiffer(unit.metadata, pr)) {
+        store.setMetadataCounts(unit.unitId, {
+          additions: pr.additions,
+          deletions: pr.deletions,
+          changedFiles: pr.changedFiles,
+          commits: pr.commits,
+        });
       }
     }
   }

--- a/packages/cli/src/github/client.ts
+++ b/packages/cli/src/github/client.ts
@@ -510,6 +510,11 @@ export class GitHubClient {
           author: pr.author.login,
           url: item.html_url,
           updatedAt: pr.updatedAt,
+          // The counts come free from the getPR above — carry them so the row shows real numbers at mint.
+          additions: pr.additions,
+          deletions: pr.deletions,
+          changedFiles: pr.changedFiles,
+          commits: pr.commits,
         });
       } catch (err) {
         console.warn(

--- a/packages/cli/src/units/__tests__/linking.test.ts
+++ b/packages/cli/src/units/__tests__/linking.test.ts
@@ -59,6 +59,10 @@ function mkPr(o: Partial<PolledPr> = {}): PolledPr {
     author: 'octocat',
     url: 'https://github.com/octo/demo/pull/42',
     updatedAt: 'now',
+    additions: 0,
+    deletions: 0,
+    changedFiles: 0,
+    commits: 0,
     ...o,
   };
 }

--- a/packages/cli/src/units/__tests__/store.test.ts
+++ b/packages/cli/src/units/__tests__/store.test.ts
@@ -328,6 +328,37 @@ describe('UnitStore', () => {
     });
   });
 
+  describe('setMetadataCounts', () => {
+    it('patches only the diff/line counts, leaving status/headSha/reviewedSha/taskLabel/narrative untouched', async () => {
+      const store = new UnitStore([], det());
+      const u = mkGithub(store); // queued, headSha sha-1, mkMetadata counts (additions 1, …)
+      store.setReviewedSha(u.unitId, 'sha-1');
+      store.attachReview(u.unitId, [{ path: 'a.ts' }] as unknown as ReviewUnit['files'], NARRATIVE, 3);
+      const before = store.get(u.unitId)!;
+      const headShaBefore = before.metadata.headSha;
+      const taskLabelBefore = before.taskLabel;
+
+      const after = store.setMetadataCounts(u.unitId, { additions: 42, deletions: 7, changedFiles: 5, commits: 3 });
+      expect(after.metadata.additions).toBe(42);
+      expect(after.metadata.deletions).toBe(7);
+      expect(after.metadata.changedFiles).toBe(5);
+      expect(after.metadata.commits).toBe(3);
+      // Everything the poller's heal must NOT touch:
+      expect(after.status).toBe('queued');
+      expect(after.metadata.headSha).toBe(headShaBefore);
+      expect(after.lastReviewedSha).toBe('sha-1');
+      expect(after.taskLabel).toBe(taskLabelBefore);
+      expect(after.narrative).toEqual(NARRATIVE);
+    });
+
+    it('throws UnknownUnitError for an unknown id', () => {
+      const store = new UnitStore([], det());
+      expect(() =>
+        store.setMetadataCounts('nope', { additions: 0, deletions: 0, changedFiles: 0, commits: 0 }),
+      ).toThrow(UnknownUnitError);
+    });
+  });
+
   describe('resurfaceForNewPush', () => {
     async function approvedGithubUnit() {
       const store = new UnitStore([], det());

--- a/packages/cli/src/units/store.ts
+++ b/packages/cli/src/units/store.ts
@@ -213,6 +213,30 @@ export class UnitStore {
   }
 
   /**
+   * Patch a unit's diff/line counts (additions/deletions/changedFiles/commits) in place — the poller's
+   * heal for a unit whose stored counts drift from the live PR (minted before the counts rode along, or
+   * the author pushed since). Deliberately narrow: it touches ONLY these four metadata fields, never
+   * status / lastReviewedSha / headSha / taskLabel / narrative or any resurface semantics. Synchronous;
+   * persistence is best-effort via `save()`.
+   */
+  setMetadataCounts(
+    unitId: string,
+    counts: { additions: number; deletions: number; changedFiles: number; commits: number },
+  ): ReviewUnit {
+    const unit = this.require(unitId);
+    unit.metadata = {
+      ...unit.metadata,
+      additions: counts.additions,
+      deletions: counts.deletions,
+      changedFiles: counts.changedFiles,
+      commits: counts.commits,
+    };
+    unit.updatedAt = this.now();
+    void this.save(unit);
+    return unit;
+  }
+
+  /**
    * Lazy-hydration write for `github` units: attach the fetched diff + generated narrative WITHOUT a
    * status transition (a github unit stays `queued`). The unit is already `queued`; this only fills in
    * the deferred walkthrough. Synchronous; persistence is best-effort via `save()`.

--- a/packages/cli/src/units/types.ts
+++ b/packages/cli/src/units/types.ts
@@ -64,8 +64,9 @@ export type ReviewUnit = {
 };
 
 /**
- * A PR returned by the background review-request poller — only the cheap metadata needed to mint or
- * link a `github` unit (the diff/narrative are fetched lazily on open, not here).
+ * A PR returned by the background review-request poller. The full diff/narrative are fetched lazily on
+ * open, but the diff/line counts ride along here: `searchReviewRequested` already fetches each PR (for
+ * head branch/sha), so the counts are free at poll time and let the queue row show real numbers at mint.
  */
 export type PolledPr = {
   owner: string;
@@ -79,6 +80,11 @@ export type PolledPr = {
   author: string;
   url: string;
   updatedAt: string;
+  /** Diff/line counts from the per-item `getPR` the search already makes — no extra API call. */
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+  commits: number;
 };
 
 /** Thrown when a mutation references a unit id the store doesn't hold. */

--- a/packages/web/src/components/CommandCenter.tsx
+++ b/packages/web/src/components/CommandCenter.tsx
@@ -55,7 +55,7 @@ function Panel({ children }: { children: React.ReactNode[] }) {
  * Live via the shared SSE stream; a row click drills into that unit's review.
  */
 export function CommandCenter() {
-  const { groups, repos, facets, repoFilter, setRepoFilter, total, loaded } = useUnits();
+  const { groups, repos, facets, repoFilter, setRepoFilter, total, loaded, github } = useUnits();
   const navigate = useReviewStore((s) => s.navigate);
   const liveStatus = useReviewStore((s) => s.liveStatus);
   const accent = useReviewStore((s) => s.accent);
@@ -148,7 +148,26 @@ export function CommandCenter() {
         <span className="text-[15px] font-bold tracking-tight">
           Diff Dad <span className="font-medium text-[var(--fg-3)]">· command center</span>
         </span>
-        <span className="ml-auto inline-flex items-center gap-1.5 text-[12px] font-medium" style={{ color: live.fg }}>
+        {/* GitHub-off chip — the poller is dark without credentials. Amber (not the live green) so it
+            reads as a degraded state, not an outage; the banner below carries the remedy. */}
+        {!github && (
+          <span
+            className="ml-auto inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-[12px] font-medium"
+            style={{
+              background: 'var(--amber-3)',
+              color: 'var(--amber-11)',
+              boxShadow: 'inset 0 0 0 1px var(--amber-9)',
+            }}
+            title={copy.githubOffHint}
+          >
+            <span className="inline-block h-2 w-2 rounded-full" style={{ background: 'var(--amber-9)' }} aria-hidden />
+            {copy.githubOff}
+          </span>
+        )}
+        <span
+          className={`inline-flex items-center gap-1.5 text-[12px] font-medium ${github ? 'ml-auto' : ''}`}
+          style={{ color: live.fg }}
+        >
           <span
             className={`inline-block h-2 w-2 rounded-full ${liveStatus === 'connected' ? 'live-ping-dot' : ''}`}
             style={{ background: live.dot }}
@@ -166,7 +185,9 @@ export function CommandCenter() {
           <button
             type="button"
             onClick={refresh}
-            disabled={refreshing}
+            // Polling is off without GitHub credentials — /api/poll 503s, so don't invite a dead click.
+            disabled={refreshing || !github}
+            title={!github ? copy.githubOffHint : undefined}
             className="inline-flex items-center gap-1.5 rounded-md bg-[var(--bg-page)] px-2 py-1 text-[12.5px] font-medium text-[var(--fg-1)] transition-opacity disabled:opacity-50"
             style={{ boxShadow: 'inset 0 0 0 1px var(--gray-a5)' }}
           >
@@ -219,6 +240,21 @@ export function CommandCenter() {
         {repos.length > 1 && <RepoFacets facets={facets} value={repoFilter} onSelect={setRepoFilter} />}
         <div className="min-w-0 flex-1">
           <div className="mx-auto max-w-[1100px]">
+            {!github && (
+              <div
+                role="status"
+                className="mt-4 flex items-start gap-2 rounded-lg px-3.5 py-2.5 text-[13px]"
+                style={{
+                  background: 'var(--amber-3)',
+                  color: 'var(--amber-11)',
+                  boxShadow: 'inset 0 0 0 1px var(--amber-9)',
+                }}
+              >
+                <span aria-hidden>⚠</span>
+                <span>{copy.githubOffBanner}</span>
+              </div>
+            )}
+
             {error && (
               <div
                 className="mt-4 flex items-center justify-between rounded-lg px-3.5 py-2.5 text-[13px]"

--- a/packages/web/src/components/UnitRow.tsx
+++ b/packages/web/src/components/UnitRow.tsx
@@ -48,8 +48,10 @@ export function UnitRow({ unit, now, onOpen, onRemove, busy }: Props) {
 
   const meta: string[] = [];
   if (isNeedsYou) meta.push(unit.toResolve === 1 ? '1 to resolve' : `${unit.toResolve} to resolve`);
-  const fileCount = unit.metadata?.changedFiles ?? unit.files?.length;
-  if (typeof fileCount === 'number') meta.push(fileCount === 1 ? '1 file' : `${fileCount} files`);
+  // Search-minted units carry changedFiles:0 until hydrated, so `??` would assert "0 files". Prefer a
+  // truthy PR count, fall back to a hydrated diff's length, and otherwise omit — an unknown beats a lie.
+  const fileCount = unit.metadata?.changedFiles || unit.files?.length;
+  if (fileCount) meta.push(fileCount === 1 ? '1 file' : `${fileCount} files`);
   if (!isNeedsYou) meta.unshift(status.label);
   if (elapsed) meta.push(elapsed);
 

--- a/packages/web/src/hooks/useUnits.ts
+++ b/packages/web/src/hooks/useUnits.ts
@@ -16,6 +16,10 @@ export function useUnits() {
   // Distinguish "still fetching the first snapshot" from "fetched, genuinely empty" so the command
   // center can show a loader instead of flashing the all-clear empty state on every cold load.
   const [loaded, setLoaded] = useState(false);
+  // Whether the daemon has GitHub credentials. Only the initial fetch carries this; SSE `units`
+  // snapshots omit it, and it can't change without a daemon restart, so we capture it once. Default
+  // true so an older daemon (no field) never shows a false "GitHub off" warning.
+  const [github, setGithub] = useState(true);
 
   useEffect(() => {
     let cancelled = false;
@@ -24,8 +28,11 @@ export function useUnits() {
         const res = await fetch('/api/units');
         if (cancelled) return;
         if (res.ok) {
-          const data = (await res.json()) as { units: Unit[] };
-          if (!cancelled) setUnits(data.units ?? []);
+          const data = (await res.json()) as { units: Unit[]; github?: boolean };
+          if (!cancelled) {
+            setUnits(data.units ?? []);
+            if (typeof data.github === 'boolean') setGithub(data.github);
+          }
         }
       } catch {
         // ignore — the SSE stream backfills the queue
@@ -50,7 +57,7 @@ export function useUnits() {
   // Facets are derived from the UNFILTERED list so selecting a repo never changes the counts.
   const facets: RepoFacets = useMemo(() => buildRepoFacets(units), [units]);
 
-  return { groups, repos, facets, repoFilter, setRepoFilter, total: units.length, loaded };
+  return { groups, repos, facets, repoFilter, setRepoFilter, total: units.length, loaded, github };
 }
 
 /** Remove a unit from the queue (manual cleanup of stale work). SSE repaints the list. */

--- a/packages/web/src/lib/__tests__/microcopy.test.ts
+++ b/packages/web/src/lib/__tests__/microcopy.test.ts
@@ -29,3 +29,15 @@ describe('copy.refreshResult', () => {
     expect(copy.refreshResult(2, 1, 3)).toBe('2 new, 1 back for another look, 3 cleared out.');
   });
 });
+
+describe('github-off copy', () => {
+  it('names both remedies and the restart in the banner', () => {
+    expect(copy.githubOffBanner).toContain('gh auth login');
+    expect(copy.githubOffBanner).toContain('DIFFDAD_GITHUB_TOKEN');
+    expect(copy.githubOffBanner).toContain('dad daemon install');
+  });
+
+  it('keeps the chip label short', () => {
+    expect(copy.githubOff).toBe('GitHub off');
+  });
+});

--- a/packages/web/src/lib/microcopy.ts
+++ b/packages/web/src/lib/microcopy.ts
@@ -49,4 +49,11 @@ export const copy = {
     return `${parts.join(', ')}.`;
   },
   refreshUnreachable: 'Could not reach the daemon.',
+
+  // Daemon has no GitHub credentials: poller off, hydrate/review/comments disabled. Remedy copy stays
+  // literal — the fix is a real shell command, not a dad joke.
+  githubOff: 'GitHub off',
+  githubOffBanner:
+    "GitHub isn't wired up — the daemon can't poll, hydrate, or post. Run `gh auth login` or set DIFFDAD_GITHUB_TOKEN, then restart the agent with `dad daemon install`.",
+  githubOffHint: "GitHub isn't wired up — the daemon can't poll until it restarts with credentials.",
 } as const;


### PR DESCRIPTION
## Why

Running the daemon via `dad daemon install` (launchd) surfaced three bugs:

1. **Poller silently off.** launchd starts agents with a bare `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`), so the `gh auth token` and `claude -p` spawns fail — no token, no poller, no hydration. The plist never carried the user's environment.
2. **"No story" with no explanation.** With no GitHub wired, `POST /api/units/:id/hydrate` returned a silent `200 { unit }`, so the UI showed a generic "the daemon returned no narrative" and the real cause (missing credentials) was invisible everywhere.
3. **Every queue row said "0 files".** Search-minted units zero-fill `changedFiles`, and `UnitRow`'s `metadata?.changedFiles ?? files?.length` never falls through on `0` — even fully hydrated units displayed "0 files".

## What

- **`buildPlist()` bakes the installing shell's `PATH`** into an `EnvironmentVariables` dict (xml-escaped; omitted when empty). Reinstalling the agent picks it up automatically.
- **Hydrate 503s with an actionable message** when GitHub isn't wired (`run gh auth login or set DIFFDAD_GITHUB_TOKEN…`); a narrated unit stays a legitimate 200 no-op. `GET /api/units` now carries `github: boolean`, and the command center renders an amber **"GitHub off"** chip + remedy banner and disables Refresh (the poll route 503s anyway).
- **Real file counts.** `PolledPr` now carries `additions/deletions/changedFiles/commits` from the per-PR `getPR` the search already makes (zero new API calls). `metadataFromPr` uses them at mint; existing units heal stale counts on the next poll via the new `store.setMetadataCounts()` (counts only — never status/reviewedSha/headSha); `UnitRow` prefers a truthy count and hides the segment when genuinely unknown.

## Verification

Live end-to-end on the dev daemon, both scenarios:
- Stripped launchd-like PATH: poller-off log, `github:false` on the wire, hydrate → 503 with the credentials message rendered in the drill-in (Retry intact), amber chip + banner + disabled Refresh, no "0 files" anywhere.
- Full env: first poll healed 20/20 units to real counts (e.g. workos-node#1626 → 42 files); chip/banner gone, Refresh enabled.
- Gates: tests (335 default suite + 65 in changed daemon/units/web files), oxlint, tsc, build — all green. New tests: `launchd.test.ts` (plist env dict + escaping), poller mint/heal/no-rewrite, `setMetadataCounts`, hydrate 503 contract, `/api/units` github flag.

Note for reviewers: the root `bun run test` script only runs `packages/cli/src/__tests__/` — the new daemon/units suites pass but aren't in that leaf dir (pre-existing gate gap, worth a follow-up).