### PR TITLE
fix(cli): stop sending temperature to Anthropic models

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: verify
+description: How to launch and drive Diff Dad for runtime verification — daemon on a scratch port, config/test-connection API, and the single-PR server.
+---
+
+# Verifying Diff Dad changes at runtime
+
+## Launch a server with the current source
+
+The daemon is the easiest surface — it registers the shared config routes and
+runs straight from source (no rebuild needed for CLI-side changes; frontend
+changes need `bun run build` first since the server serves `packages/web/dist`).
+
+```sh
+# background it; --no-open suppresses the browser
+bun packages/cli/src/cli.ts daemon --port=45677 --no-open
+
+# readiness probe
+curl -s http://localhost:45677/api/config
+```
+
+Check nothing is already on the port first (`lsof -iTCP:45677 -sTCP:LISTEN`).
+Kill when done: `lsof -tiTCP:45677 -sTCP:LISTEN | xargs kill`.
+
+## Useful endpoints
+
+- `GET  /api/config` — redacted saved config (secrets become `*Set` booleans).
+- `POST /api/config/test` — what the settings page "Test connection" buttons call.
+  Always returns 200 with `{ok, detail}`; candidate fields overlay the saved config,
+  so an omitted `aiApiKey` uses the stored one:
+  ```sh
+  curl -s -X POST http://localhost:45677/api/config/test \
+    -H 'content-type: application/json' \
+    -d '{"kind":"ai","aiProvider":"anthropic","aiModel":"claude-sonnet-5"}'
+  ```
+  `{"kind":"github"}` tests the effective GitHub token instead.
+- `PUT /api/config` — merge-patch save (broadcasts over SSE `config` event).
+
+## Gotchas
+
+- `POST /api/config/test` with `kind: ai` makes ONE real API call against the
+  user's stored key (16-token ping) — cheap, but it's live.
+- The AI test has a 15s timeout; the local-CLI path (`defaultCli`) is much slower
+  than the API path and can hit it.
+- Config lives in the dataDir (see `getConfigPath()` in `packages/cli/src/config.ts`);
+  the daemon reads it fresh per request, so config edits don't need a restart —
+  but code edits do.

--- a/packages/cli/src/__tests__/engine-helpers.test.ts
+++ b/packages/cli/src/__tests__/engine-helpers.test.ts
@@ -150,4 +150,38 @@ describe('getModel', () => {
     const m = getModel({ aiProvider: 'openai-compatible', aiBaseUrl: 'https://example.com/v1' });
     expect(m).toBeTruthy();
   });
+
+  it('does not send temperature to anthropic (ai@4 injects a default 0 that Sonnet 5+ rejects)', async () => {
+    const m = getModel({ aiProvider: 'anthropic', aiApiKey: 'k', aiModel: 'claude-sonnet-5' });
+    let capturedBody: string | undefined;
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (_url: unknown, init?: RequestInit) => {
+      capturedBody = init?.body as string;
+      return new Response(
+        JSON.stringify({
+          id: 'msg_01',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'ok' }],
+          model: 'claude-sonnet-5',
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }) as typeof fetch;
+    try {
+      await m.doGenerate({
+        inputFormat: 'messages',
+        mode: { type: 'regular' },
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+        temperature: 0, // what ai@4's streamText/generateText inject when unset
+      });
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    expect(capturedBody).toBeDefined();
+    expect(JSON.parse(capturedBody!)).not.toHaveProperty('temperature');
+  });
 });

--- a/packages/cli/src/narrative/ai-runtime.ts
+++ b/packages/cli/src/narrative/ai-runtime.ts
@@ -1,8 +1,8 @@
 import { rm } from 'fs/promises';
-import { streamText } from 'ai';
+import { streamText, wrapLanguageModel } from 'ai';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
-import type { FinishReason, LanguageModelUsage, LanguageModelV1 } from 'ai';
+import type { FinishReason, LanguageModelUsage, LanguageModelV1, LanguageModelV1Middleware } from 'ai';
 import { DEFAULT_CLI_MODELS, LOCAL_CLIS, type DiffDadConfig, type LocalCli } from '../config';
 
 export type AiChunkHandler = (delta: string) => void;
@@ -102,13 +102,26 @@ export async function resolveProviderKey(config: DiffDadConfig): Promise<string>
   return slugify(model ? `${cli}-${model}` : cli);
 }
 
+/**
+ * ai@4 injects `temperature: 0` into every call when none is set, and Claude
+ * models from Sonnet 5 / Opus 4.7 onward reject any non-default sampling
+ * params with a 400 ("`temperature` is deprecated for this model"). We never
+ * set temperature ourselves, so drop it and let the API default apply.
+ */
+const stripTemperature: LanguageModelV1Middleware = {
+  transformParams: async ({ params }) => ({ ...params, temperature: undefined }),
+};
+
 export function getModel(config: DiffDadConfig): LanguageModelV1 {
   const provider = config.aiProvider ?? 'anthropic';
 
   switch (provider) {
     case 'anthropic': {
       const anthropic = createAnthropic({ apiKey: config.aiApiKey });
-      return anthropic(config.aiModel ?? DEFAULT_ANTHROPIC_MODEL);
+      return wrapLanguageModel({
+        model: anthropic(config.aiModel ?? DEFAULT_ANTHROPIC_MODEL),
+        middleware: stripTemperature,
+      });
     }
     case 'openai': {
       const openai = createOpenAI({ apiKey: config.aiApiKey });


### PR DESCRIPTION
## Problem

The settings-page "Test connection" with `claude-sonnet-5` failed with:

> `temperature` is deprecated for this model.

We never set `temperature` anywhere — `ai@4` injects `temperature: 0` into every request when unset (the SDK source carries a `// TODO v5 remove default 0 for temperature`). Claude models from Sonnet 5 / Opus 4.7 onward reject any non-default sampling params with a 400, so every API call to those models failed.

## Fix

Wrap the Anthropic model in `getModel()` with `wrapLanguageModel` + a `transformParams` middleware that drops `temperature`, letting the API default apply. Scoped to the Anthropic provider only — OpenAI/Ollama have always received ai@4's default `temperature: 0`, and `@ai-sdk/openai` already handles its own models that reject it.

## Testing

- New test stubs `fetch`, calls the model with `temperature: 0` (what ai@4 injects), and asserts the outgoing request body has no `temperature` key — red before the fix, green after.
- Verified live against the real API via `POST /api/config/test`: `claude-sonnet-5` and `claude-opus-4-8` now return `{"ok":true}` (both previously 400), and `claude-sonnet-4-6` (still accepts temperature) keeps working.
- Full suite: 369 pass; oxlint/oxfmt clean.

Also adds `.claude/skills/verify/SKILL.md` documenting the daemon-launch + test-connection recipe used to verify this.