### PR TITLE
feat: add Amazon Bedrock as an AI provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dad
 *.bun-build
 .astro/
 .vscode/
+.tool-versions

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,6 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "diffdad",
@@ -12,14 +12,18 @@
     },
     "packages/cli": {
       "name": "@diffdad/cli",
-      "version": "0.10.0",
+      "version": "0.12.0",
       "bin": {
         "dad": "./src/cli.ts",
       },
       "dependencies": {
+        "@ai-sdk/amazon-bedrock": "^2",
         "@ai-sdk/anthropic": "^1",
         "@ai-sdk/openai": "^1",
+        "@aws-sdk/client-bedrock": "^3",
+        "@aws-sdk/credential-providers": "^3",
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "@smithy/shared-ini-file-loader": "^4.6.7",
         "ai": "^4",
         "hono": "^4",
         "open": "^10",
@@ -69,6 +73,8 @@
     },
   },
   "packages": {
+    "@ai-sdk/amazon-bedrock": ["@ai-sdk/amazon-bedrock@2.2.12", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "@smithy/eventstream-codec": "^4.0.1", "@smithy/util-utf8": "^4.0.0", "aws4fetch": "^1.0.20" }, "peerDependencies": { "zod": "^3.0.0" } }, "sha512-m8gARnh45pr1s08Uu4J/Pm8913mwJPejPOm59b+kUqMsP9ilhUtH/bp8432Ra/v+vHuMoBrglG2ZvXtctAaH2g=="],
+
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@1.2.12", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8" }, "peerDependencies": { "zod": "^3.0.0" } }, "sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ=="],
 
     "@ai-sdk/openai": ["@ai-sdk/openai@1.3.24", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8" }, "peerDependencies": { "zod": "^3.0.0" } }, "sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q=="],
@@ -98,6 +104,42 @@
     "@astrojs/telemetry": ["@astrojs/telemetry@3.3.1", "", { "dependencies": { "ci-info": "^4.4.0", "dlv": "^1.1.3", "dset": "^3.1.4", "is-docker": "^4.0.0", "is-wsl": "^3.1.1", "which-pm-runs": "^1.1.0" } }, "sha512-7fcIxXS9J4ls5tr8b3ww9rbAIz2+HrhNJYZdkAhhB4za/I5IZ/60g+Bs8q7zwG0tOIZfNB4JWhVJ1Qkl/OrNCw=="],
 
     "@astrojs/yaml2ts": ["@astrojs/yaml2ts@0.2.3", "", { "dependencies": { "yaml": "^2.8.2" } }, "sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg=="],
+
+    "@aws-sdk/client-bedrock": ["@aws-sdk/client-bedrock@3.1084.0", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/credential-provider-node": "^3.972.66", "@aws-sdk/token-providers": "3.1084.0", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/fetch-http-handler": "^5.6.4", "@smithy/node-http-handler": "^4.9.4", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-gUYAf3z4bpJZ3UqqZXqXH330Mqut9mZVl3/ftmFAOIRKXa8mv+akM0ao3YQurrxDHVMG2OsKpYmH2aVZmTKs8g=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.975.1", "", { "dependencies": { "@aws-sdk/types": "^3.974.0", "@aws-sdk/xml-builder": "^3.972.34", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.29.2", "@smithy/signature-v4": "^5.6.3", "@smithy/types": "^4.16.0", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q=="],
+
+    "@aws-sdk/credential-provider-cognito-identity": ["@aws-sdk/credential-provider-cognito-identity@3.972.56", "", { "dependencies": { "@aws-sdk/nested-clients": "^3.997.31", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-nedaZz6Wz2FGUBMsWhlvBPGIkTMfRuMJ99YDHJI4CaC31JS8WPyTavEAio74cfd5nGhi0A8XASB4fZA5VqTdOQ=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.57", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.59", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/fetch-http-handler": "^5.6.4", "@smithy/node-http-handler": "^4.9.4", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.973.1", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/credential-provider-env": "^3.972.57", "@aws-sdk/credential-provider-http": "^3.972.59", "@aws-sdk/credential-provider-login": "^3.972.63", "@aws-sdk/credential-provider-process": "^3.972.57", "@aws-sdk/credential-provider-sso": "^3.973.1", "@aws-sdk/credential-provider-web-identity": "^3.972.63", "@aws-sdk/nested-clients": "^3.997.31", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/credential-provider-imds": "^4.4.7", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.63", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/nested-clients": "^3.997.31", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.66", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.57", "@aws-sdk/credential-provider-http": "^3.972.59", "@aws-sdk/credential-provider-ini": "^3.973.1", "@aws-sdk/credential-provider-process": "^3.972.57", "@aws-sdk/credential-provider-sso": "^3.973.1", "@aws-sdk/credential-provider-web-identity": "^3.972.63", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/credential-provider-imds": "^4.4.7", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.57", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.973.1", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/nested-clients": "^3.997.31", "@aws-sdk/token-providers": "3.1083.0", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.63", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/nested-clients": "^3.997.31", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ=="],
+
+    "@aws-sdk/credential-providers": ["@aws-sdk/credential-providers@3.1084.0", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/credential-provider-cognito-identity": "^3.972.56", "@aws-sdk/credential-provider-env": "^3.972.57", "@aws-sdk/credential-provider-http": "^3.972.59", "@aws-sdk/credential-provider-ini": "^3.973.1", "@aws-sdk/credential-provider-login": "^3.972.63", "@aws-sdk/credential-provider-node": "^3.972.66", "@aws-sdk/credential-provider-process": "^3.972.57", "@aws-sdk/credential-provider-sso": "^3.973.1", "@aws-sdk/credential-provider-web-identity": "^3.972.63", "@aws-sdk/nested-clients": "^3.997.31", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/credential-provider-imds": "^4.4.7", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-6MT9xigrduBftpOEq2HKzGqp2Up0Jwe8dK5W3GyBpePywzgMK6029XEYXkCC5wRYwXwhSPzpjnjRlWUA7K/KNQ=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.31", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/signature-v4-multi-region": "^3.996.39", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/fetch-http-handler": "^5.6.4", "@smithy/node-http-handler": "^4.9.4", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.39", "", { "dependencies": { "@aws-sdk/types": "^3.974.0", "@smithy/signature-v4": "^5.6.3", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1084.0", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/nested-clients": "^3.997.31", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-gs0WwdzhYk4zN2vAji2KwXSo/fplAowqpoqzR+jpVoYo8Pzt3/Y+q8Z9meKbFpIgJbC9tRDh218j45KdGrfkJQ=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.974.0", "", { "dependencies": { "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.34", "", { "dependencies": { "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -605,6 +647,24 @@
 
     "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
 
+    "@smithy/core": ["@smithy/core@3.29.2", "", { "dependencies": { "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-DXUk6yU0C1Q1tYvJh1VCtl8QOBcSoZpKwjTPkxT6A4MUQYHvgeKGByL8mrEdxnvhdf9nq5GyzmRb5n/vPgu3Lw=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.4.7", "", { "dependencies": { "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-UEMLOoA0Fl4uYBxh6l0uN0H6EJe/A89OGeDNTteQeXpJ20BcpfIr4wlCY9pel1jEAUHAxaYwuqrYlrKdXE1GKQ=="],
+
+    "@smithy/eventstream-codec": ["@smithy/eventstream-codec@4.4.7", "", { "dependencies": { "@smithy/core": "^3.29.2", "tslib": "^2.6.2" } }, "sha512-YNodWVjMFOMAyjQgpHBBCz62DbYu4xwhpt+z5HRf7OZPwrfHgNDCyUZxaC0fy9/2TWcO+niOMHSl8aMgfbWZTQ=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.6.4", "", { "dependencies": { "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-psnst7NZWdAEvJvyW8YZEE7xNVMyLrQFfHtyrVFrxNyy+dKWkQ+rqC6oI5ZhxThpUy9RSfEshgm34zqbOxzsRw=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.4", "", { "dependencies": { "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-BNTop/fSOptmoVk8g+efwHCofFh37g70OWGAFES1TeAAJja1K5aAI8rTE26ETSc5k8IQuWY2kAIoPla01NgYrA=="],
+
+    "@smithy/shared-ini-file-loader": ["@smithy/shared-ini-file-loader@4.6.7", "", { "dependencies": { "@smithy/core": "^3.29.2", "tslib": "^2.6.2" } }, "sha512-HuFyahA9L+fPKTBJ16Ep3XFXDhQKXDepWQknzkem7ptEqetsmw4wnYgZec67ohbZiJDrCGeMMqV+Tzn32Zg78w=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.6.3", "", { "dependencies": { "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-8qVKKzqh7naF27ePmx0SkUfnGP/wBI9dyaeAmhHvopnbIlItUAmB/e6PkPCU3rRb2v9BY8D4EZXSoydSibatvw=="],
+
+    "@smithy/types": ["@smithy/types@4.16.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-aVUabzlBBmY0PfvVgLKQSOGFIL5/7R54JE3uD9a5Ay/jSED61SkuAcCYENNXJzYUvJ1NPrWO0P+rAXHCkbBUKw=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@4.4.7", "", { "dependencies": { "@smithy/core": "^3.29.2", "tslib": "^2.6.2" } }, "sha512-NskAyOBZcHO+fa1HwkwWuPbMUQE7NZ4IWBnAc71E4f9IdoQ65WLkdJ2ed/n4Q8vePSgZUN/CbyGZLBiI7dMI+w=="],
+
     "@speed-highlight/core": ["@speed-highlight/core@1.2.15", "", {}, "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.2.4", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.4" } }, "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA=="],
@@ -807,6 +867,8 @@
 
     "astro": ["astro@6.2.1", "", { "dependencies": { "@astrojs/compiler": "^4.0.0", "@astrojs/internal-helpers": "0.9.0", "@astrojs/markdown-remark": "7.1.1", "@astrojs/telemetry": "3.3.1", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.6.3", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.27.3", "flattie": "^1.1.1", "fontace": "~0.4.1", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "rehype": "^13.0.2", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "tsconfck": "^3.1.6", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unist-util-visit": "^5.1.0", "unstorage": "^1.17.5", "vfile": "^6.0.3", "vite": "^7.3.2", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "bin/astro.mjs" } }, "sha512-3g1sYNly+QAkuO5ErNEQBYvsxorNDSCUNIeStBs+kcXGchvKQl1Q9EuDNOvSg010XLlHJFLVFZs9LV18Jjp4Hg=="],
 
+    "aws4fetch": ["aws4fetch@1.0.20", "", {}, "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g=="],
+
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
@@ -818,6 +880,8 @@
     "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
@@ -1792,6 +1856,8 @@
     "@astrojs/markdown-remark/shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
 
     "@astrojs/telemetry/is-docker": ["is-docker@4.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA=="],
+
+    "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1083.0", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/nested-clients": "^3.997.31", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A=="],
 
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,9 +12,13 @@
     "bench:narrative": "bun run scripts/bench-narrative.ts"
   },
   "dependencies": {
+    "@ai-sdk/amazon-bedrock": "^2",
     "@ai-sdk/anthropic": "^1",
     "@ai-sdk/openai": "^1",
+    "@aws-sdk/client-bedrock": "^3",
+    "@aws-sdk/credential-providers": "^3",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@smithy/shared-ini-file-loader": "^4.6.7",
     "ai": "^4",
     "hono": "^4",
     "open": "^10",

--- a/packages/cli/src/__tests__/ai-runtime.test.ts
+++ b/packages/cli/src/__tests__/ai-runtime.test.ts
@@ -1,5 +1,7 @@
-import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
-import { callAi } from '../narrative/ai-runtime';
+import { afterAll, beforeAll, describe, expect, it, spyOn } from 'bun:test';
+import * as credentialProviders from '@aws-sdk/credential-providers';
+import { callAi, getModel, withResolvedBedrockRegion } from '../narrative/ai-runtime';
+import * as bedrockModels from '../narrative/bedrock-models';
 import type { DiffDadConfig } from '../config';
 
 /**
@@ -122,4 +124,106 @@ describe('callAi API path', () => {
     },
     { timeout: 10000 },
   );
+});
+
+describe('getModel amazon-bedrock case', () => {
+  it('builds a model from explicit keys without throwing (uses the configured model id)', () => {
+    const model = getModel({
+      aiProvider: 'amazon-bedrock',
+      aiRegion: 'us-east-1',
+      aiAccessKeyId: 'AKIAEXAMPLE',
+      aiSecretAccessKey: 'secret',
+      aiModel: 'us.anthropic.claude-custom-v1:0',
+    });
+    expect(model.modelId).toBe('us.anthropic.claude-custom-v1:0');
+  });
+
+  it('builds a model chain-first (no keys) and falls back to the default model id', () => {
+    const model = getModel({ aiProvider: 'amazon-bedrock', aiRegion: 'us-east-1' });
+    // Default Bedrock model is a current Claude Sonnet cross-region inference profile.
+    expect(model.modelId).toMatch(/^us\.anthropic\.claude-sonnet/);
+  });
+
+  it("treats an empty-string model as unset (the settings form saves '' to mean the default)", () => {
+    const model = getModel({ aiProvider: 'amazon-bedrock', aiRegion: 'us-east-1', aiModel: '' });
+    expect(model.modelId).toMatch(/^us\.anthropic\.claude-sonnet/);
+  });
+
+  it('keeps the default provider switch exhaustive (bedrock does not hit the unreachable default)', () => {
+    // If the switch fell through to `default`, this would throw "Unsupported aiProvider".
+    expect(() => getModel({ aiProvider: 'amazon-bedrock' })).not.toThrow();
+  });
+
+  it('scopes the credential chain to a named profile when one is set (no explicit keys)', () => {
+    const chain = spyOn(credentialProviders, 'fromNodeProviderChain').mockReturnValue((async () => ({
+      accessKeyId: 'x',
+      secretAccessKey: 'y',
+    })) as ReturnType<typeof credentialProviders.fromNodeProviderChain>);
+    try {
+      getModel({ aiProvider: 'amazon-bedrock', aiRegion: 'us-east-1', aiProfile: 'my-sso' });
+      expect(chain).toHaveBeenCalledWith({ profile: 'my-sso' });
+    } finally {
+      chain.mockRestore();
+    }
+  });
+});
+
+describe('withResolvedBedrockRegion', () => {
+  it('leaves a non-bedrock config untouched (no region resolution)', async () => {
+    const spy = spyOn(bedrockModels, 'resolveBedrockRegion');
+    try {
+      const config: DiffDadConfig = { aiProvider: 'anthropic', aiApiKey: 'k' };
+      expect(await withResolvedBedrockRegion(config)).toBe(config);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('leaves a bedrock config with an explicit region untouched', async () => {
+    const spy = spyOn(bedrockModels, 'resolveBedrockRegion');
+    try {
+      const config: DiffDadConfig = { aiProvider: 'amazon-bedrock', aiRegion: 'us-east-1' };
+      expect(await withResolvedBedrockRegion(config)).toBe(config);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('fills a blank region for a profile-only bedrock config from the resolved region', async () => {
+    const spy = spyOn(bedrockModels, 'resolveBedrockRegion').mockResolvedValue('eu-central-1');
+    try {
+      const result = await withResolvedBedrockRegion({ aiProvider: 'amazon-bedrock', aiProfile: 'my-sso' });
+      expect(result.aiRegion).toBe('eu-central-1');
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("treats an empty-string region as blank (a profile-mode save stores aiRegion as '')", async () => {
+    const spy = spyOn(bedrockModels, 'resolveBedrockRegion').mockResolvedValue('eu-central-1');
+    try {
+      const result = await withResolvedBedrockRegion({
+        aiProvider: 'amazon-bedrock',
+        aiProfile: 'my-sso',
+        aiRegion: '',
+      });
+      expect(result.aiRegion).toBe('eu-central-1');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('leaves the config unchanged when no region can be resolved', async () => {
+    const spy = spyOn(bedrockModels, 'resolveBedrockRegion').mockResolvedValue(undefined);
+    try {
+      const config: DiffDadConfig = { aiProvider: 'amazon-bedrock', aiProfile: 'my-sso' };
+      const result = await withResolvedBedrockRegion(config);
+      expect(result.aiRegion).toBeUndefined();
+    } finally {
+      spy.mockRestore();
+    }
+  });
 });

--- a/packages/cli/src/__tests__/aws-profiles.test.ts
+++ b/packages/cli/src/__tests__/aws-profiles.test.ts
@@ -3,29 +3,30 @@ import { mergeAwsProfiles } from '../narrative/aws-profiles';
 
 describe('mergeAwsProfiles', () => {
   it('lists config-file profiles with their region', () => {
-    const out = mergeAwsProfiles({ default: { region: 'us-east-1' }, PlatformDev: { region: 'us-west-2' } }, {});
-    // localeCompare sorts case-insensitively, so 'default' precedes 'PlatformDev'.
+    const out = mergeAwsProfiles({ default: { region: 'us-east-1' }, Production: { region: 'us-west-2' } }, {});
+    // localeCompare orders by base letter (d before p), using case only as a tiebreak, so 'default'
+    // precedes 'Production'. Code-unit order would invert this ('P' < 'd').
     expect(out).toEqual([
       { name: 'default', region: 'us-east-1' },
-      { name: 'PlatformDev', region: 'us-west-2' },
+      { name: 'Production', region: 'us-west-2' },
     ]);
   });
 
   it('surfaces credentials-only profiles with no region', () => {
-    const out = mergeAwsProfiles({}, { 'platform-dev': { aws_access_key_id: 'AKIA' } });
-    expect(out).toEqual([{ name: 'platform-dev' }]);
+    const out = mergeAwsProfiles({}, { staging: { aws_access_key_id: 'AKIA' } });
+    expect(out).toEqual([{ name: 'staging' }]);
   });
 
   it('filters out sso-session and services sections (they are not profiles)', () => {
     const out = mergeAwsProfiles(
       {
-        PlatformDev: { region: 'us-east-1' },
-        'sso-session.arbol-sso': { sso_region: 'us-east-1' },
+        Production: { region: 'us-east-1' },
+        'sso-session.my-sso': { sso_region: 'us-east-1' },
         'services.my-services': { s3: 'x' },
       },
       {},
     );
-    expect(out.map((p) => p.name)).toEqual(['PlatformDev']);
+    expect(out.map((p) => p.name)).toEqual(['Production']);
   });
 
   it('dedupes a profile present in both files, keeping the config-file region', () => {

--- a/packages/cli/src/__tests__/aws-profiles.test.ts
+++ b/packages/cli/src/__tests__/aws-profiles.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'bun:test';
+import { mergeAwsProfiles } from '../narrative/aws-profiles';
+
+describe('mergeAwsProfiles', () => {
+  it('lists config-file profiles with their region', () => {
+    const out = mergeAwsProfiles({ default: { region: 'us-east-1' }, PlatformDev: { region: 'us-west-2' } }, {});
+    // localeCompare sorts case-insensitively, so 'default' precedes 'PlatformDev'.
+    expect(out).toEqual([
+      { name: 'default', region: 'us-east-1' },
+      { name: 'PlatformDev', region: 'us-west-2' },
+    ]);
+  });
+
+  it('surfaces credentials-only profiles with no region', () => {
+    const out = mergeAwsProfiles({}, { 'platform-dev': { aws_access_key_id: 'AKIA' } });
+    expect(out).toEqual([{ name: 'platform-dev' }]);
+  });
+
+  it('filters out sso-session and services sections (they are not profiles)', () => {
+    const out = mergeAwsProfiles(
+      {
+        PlatformDev: { region: 'us-east-1' },
+        'sso-session.arbol-sso': { sso_region: 'us-east-1' },
+        'services.my-services': { s3: 'x' },
+      },
+      {},
+    );
+    expect(out.map((p) => p.name)).toEqual(['PlatformDev']);
+  });
+
+  it('dedupes a profile present in both files, keeping the config-file region', () => {
+    const out = mergeAwsProfiles({ shared: { region: 'eu-west-1' } }, { shared: { aws_access_key_id: 'AKIA' } });
+    expect(out).toEqual([{ name: 'shared', region: 'eu-west-1' }]);
+  });
+
+  it('omits region when a config profile has none', () => {
+    const out = mergeAwsProfiles({ noregion: { output: 'json' } }, {});
+    expect(out).toEqual([{ name: 'noregion' }]);
+  });
+
+  it('sorts profiles by name', () => {
+    const out = mergeAwsProfiles({ zed: { region: 'us-east-1' }, alpha: { region: 'us-east-1' } }, {});
+    expect(out.map((p) => p.name)).toEqual(['alpha', 'zed']);
+  });
+});

--- a/packages/cli/src/__tests__/bedrock-credentials.test.ts
+++ b/packages/cli/src/__tests__/bedrock-credentials.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'bun:test';
+import { resolveBedrockCreds } from '../narrative/bedrock-credentials';
+
+describe('resolveBedrockCreds', () => {
+  it('picks explicit static keys when both id and secret are present', () => {
+    const choice = resolveBedrockCreds({
+      aiProvider: 'amazon-bedrock',
+      aiAccessKeyId: 'AKIAEXAMPLE',
+      aiSecretAccessKey: 'secret',
+    });
+    expect(choice).toEqual({
+      kind: 'explicit',
+      accessKeyId: 'AKIAEXAMPLE',
+      secretAccessKey: 'secret',
+    });
+  });
+
+  it('lets explicit keys win even when a profile is also configured', () => {
+    const choice = resolveBedrockCreds({
+      aiAccessKeyId: 'AKIAEXAMPLE',
+      aiSecretAccessKey: 'secret',
+      aiProfile: 'my-sso',
+    });
+    expect(choice.kind).toBe('explicit');
+  });
+
+  it('picks the named profile when no explicit keys are present', () => {
+    const choice = resolveBedrockCreds({ aiProfile: 'my-sso', aiRegion: 'us-east-1' });
+    expect(choice).toEqual({ kind: 'profile', profile: 'my-sso' });
+  });
+
+  it('ignores a lone access key id (no secret) and falls through to the profile', () => {
+    const choice = resolveBedrockCreds({ aiAccessKeyId: 'AKIAEXAMPLE', aiProfile: 'my-sso' });
+    expect(choice).toEqual({ kind: 'profile', profile: 'my-sso' });
+  });
+
+  it('falls back to the default chain when neither keys nor a profile are set', () => {
+    const choice = resolveBedrockCreds({ aiProvider: 'amazon-bedrock', aiRegion: 'us-east-1' });
+    expect(choice).toEqual({ kind: 'default' });
+  });
+
+  it('picks the bearer API key when one is set', () => {
+    const choice = resolveBedrockCreds({ aiProvider: 'amazon-bedrock', aiBedrockApiKey: 'bedrock-api-key-abc' });
+    expect(choice).toEqual({ kind: 'api-key', apiKey: 'bedrock-api-key-abc' });
+  });
+
+  it('lets the API key win over explicit keys and a profile', () => {
+    const choice = resolveBedrockCreds({
+      aiBedrockApiKey: 'bedrock-api-key-abc',
+      aiAccessKeyId: 'AKIAEXAMPLE',
+      aiSecretAccessKey: 'secret',
+      aiProfile: 'my-sso',
+    });
+    expect(choice.kind).toBe('api-key');
+  });
+});

--- a/packages/cli/src/__tests__/bedrock-models.test.ts
+++ b/packages/cli/src/__tests__/bedrock-models.test.ts
@@ -230,8 +230,8 @@ describe('listBedrockModels', () => {
     const profileRegion = spyOn(awsProfiles, 'resolveProfileRegion').mockResolvedValue('us-east-1');
     try {
       // No aiRegion — the profile mode UI has no region field, so this is the real-world shape.
-      const out = await listBedrockModels({ aiProvider: 'amazon-bedrock', aiProfile: 'PlatformDev' });
-      expect(profileRegion).toHaveBeenCalledWith('PlatformDev');
+      const out = await listBedrockModels({ aiProvider: 'amazon-bedrock', aiProfile: 'Production' });
+      expect(profileRegion).toHaveBeenCalledWith('Production');
       // The profile's region flows into the client and back out for the UI to prefill.
       expect(out.region).toBe('us-east-1');
     } finally {

--- a/packages/cli/src/__tests__/bedrock-models.test.ts
+++ b/packages/cli/src/__tests__/bedrock-models.test.ts
@@ -1,0 +1,256 @@
+import { afterEach, describe, expect, it, spyOn } from 'bun:test';
+import {
+  BedrockClient,
+  type FoundationModelSummary,
+  type InferenceProfileSummary,
+  ListFoundationModelsCommand,
+  ListInferenceProfilesCommand,
+} from '@aws-sdk/client-bedrock';
+import * as credentialProviders from '@aws-sdk/credential-providers';
+import * as awsProfiles from '../narrative/aws-profiles';
+import {
+  listBedrockModels,
+  mergeBedrockModels,
+  resolveBedrockRegion,
+  toInvokeAuth,
+  toListClientAuth,
+} from '../narrative/bedrock-models';
+
+function fm(over: Partial<FoundationModelSummary>): FoundationModelSummary {
+  return {
+    modelArn: `arn:${over.modelId}`,
+    modelId: 'x',
+    outputModalities: ['TEXT'],
+    ...over,
+  } as FoundationModelSummary;
+}
+function ip(over: Partial<InferenceProfileSummary>): InferenceProfileSummary {
+  return {
+    inferenceProfileId: 'p',
+    inferenceProfileName: 'P',
+    inferenceProfileArn: `arn:${over.inferenceProfileId}`,
+    models: [],
+    status: 'ACTIVE',
+    type: 'SYSTEM_DEFINED',
+    ...over,
+  } as InferenceProfileSummary;
+}
+
+describe('mergeBedrockModels', () => {
+  it('drops foundation models that only support INFERENCE_PROFILE (not on-demand invokable)', () => {
+    const out = mergeBedrockModels(
+      [
+        // Current Claude: inference-profile-only. The bare id is NOT invokable on-demand, so drop it.
+        // Cast: the live API returns 'INFERENCE_PROFILE' but the SDK's InferenceType type lags it.
+        fm({
+          modelId: 'anthropic.claude-opus-4-8',
+          modelName: 'Opus',
+          inferenceTypesSupported: [
+            'INFERENCE_PROFILE',
+          ] as unknown as FoundationModelSummary['inferenceTypesSupported'],
+        }),
+        // An older model that supports on-demand directly — keep it.
+        fm({ modelId: 'anthropic.claude-v2', modelName: 'Claude v2', inferenceTypesSupported: ['ON_DEMAND'] }),
+      ],
+      [ip({ inferenceProfileId: 'us.anthropic.claude-opus-4-8', inferenceProfileName: 'US Opus' })],
+    );
+    expect(out.map((m) => m.id)).toEqual(['anthropic.claude-v2', 'us.anthropic.claude-opus-4-8']);
+  });
+
+  it('keeps a foundation model whose inferenceTypesSupported is unset (cannot classify → do not over-filter)', () => {
+    const out = mergeBedrockModels(
+      [fm({ modelId: 'some.model', modelName: 'X', inferenceTypesSupported: undefined })],
+      [],
+    );
+    expect(out.map((m) => m.id)).toEqual(['some.model']);
+  });
+
+  it('drops foundation models without TEXT output modality', () => {
+    const out = mergeBedrockModels(
+      [
+        fm({ modelId: 'text.model', modelName: 'Text Model', outputModalities: ['TEXT'] }),
+        fm({ modelId: 'embed.model', modelName: 'Embed Model', outputModalities: ['EMBEDDING'] }),
+      ],
+      [],
+    );
+    expect(out.map((m) => m.id)).toEqual(['text.model']);
+  });
+
+  it('dedupes an inference-profile id that collides with a foundation-model id (appears once)', () => {
+    const out = mergeBedrockModels(
+      [fm({ modelId: 'us.anthropic.claude', modelName: 'Claude' })],
+      [ip({ inferenceProfileId: 'us.anthropic.claude', inferenceProfileName: 'Claude Profile' })],
+    );
+    const matches = out.filter((m) => m.id === 'us.anthropic.claude');
+    expect(matches).toHaveLength(1);
+    // Foundation wins the collision.
+    expect(matches[0]!.label).toBe('Claude');
+  });
+
+  it('merges profiles that have no foundation-model equivalent and labels them', () => {
+    const out = mergeBedrockModels(
+      [],
+      [ip({ inferenceProfileId: 'us.anthropic.sonnet', inferenceProfileName: 'Claude Sonnet' })],
+    );
+    expect(out).toEqual([{ id: 'us.anthropic.sonnet', label: 'Claude Sonnet (inference profile)' }]);
+  });
+
+  it('sorts the merged result by id', () => {
+    const out = mergeBedrockModels(
+      [fm({ modelId: 'zeta', modelName: 'Z' }), fm({ modelId: 'alpha', modelName: 'A' })],
+      [ip({ inferenceProfileId: 'mid', inferenceProfileName: 'M' })],
+    );
+    expect(out.map((m) => m.id)).toEqual(['alpha', 'mid', 'zeta']);
+  });
+
+  it('falls back to the id when a foundation-model name is missing', () => {
+    const out = mergeBedrockModels([fm({ modelId: 'no.name', modelName: undefined })], []);
+    expect(out[0]).toEqual({ id: 'no.name', label: 'no.name' });
+  });
+
+  it('falls back to the id when an inference-profile name is missing', () => {
+    const out = mergeBedrockModels([], [ip({ inferenceProfileId: 'p.noname', inferenceProfileName: undefined })]);
+    expect(out[0]).toEqual({ id: 'p.noname', label: 'p.noname (inference profile)' });
+  });
+});
+
+describe('toListClientAuth', () => {
+  it('maps an api-key choice to bearer token config with bearer scheme preference', () => {
+    const auth = toListClientAuth({ kind: 'api-key', apiKey: 'bedrock-api-key-abc' });
+    expect(auth).toEqual({
+      token: { token: 'bedrock-api-key-abc' },
+      authSchemePreference: ['httpBearerAuth'],
+    });
+  });
+
+  it('maps an explicit choice to a static sigv4 credentials provider', async () => {
+    const auth = toListClientAuth({ kind: 'explicit', accessKeyId: 'AKIA', secretAccessKey: 's' });
+    if (!('credentials' in auth)) throw new Error('expected sigv4 credentials');
+    expect(await auth.credentials()).toEqual({ accessKeyId: 'AKIA', secretAccessKey: 's' });
+  });
+});
+
+describe('toInvokeAuth', () => {
+  it('maps sigv4 choices to a credentialProvider with no fetch override', async () => {
+    const auth = toInvokeAuth({ kind: 'explicit', accessKeyId: 'AKIA', secretAccessKey: 's' });
+    expect(auth.fetch).toBeUndefined();
+    expect(await auth.credentialProvider!()).toEqual({ accessKeyId: 'AKIA', secretAccessKey: 's' });
+  });
+
+  it('maps an api-key choice to a fetch that swaps the signed header for the bearer token', async () => {
+    const seen: { url?: string; auth?: string | null; body?: unknown } = {};
+    const inner = async (input: RequestInfo | URL, init?: RequestInit) => {
+      seen.url = String(input);
+      seen.auth = new Headers(init?.headers).get('authorization');
+      seen.body = init?.body;
+      return new Response('{}');
+    };
+    const auth = toInvokeAuth({ kind: 'api-key', apiKey: 'bedrock-api-key-abc' }, inner);
+
+    // The provider's SigV4 signer runs before our fetch and needs SOME credentials to not throw.
+    await expect(auth.credentialProvider!()).resolves.toBeDefined();
+
+    // Simulate the signed request the sigv4Fetch wrapper hands to the inner fetch.
+    await auth.fetch!('https://bedrock-runtime.us-east-1.amazonaws.com/model/m/converse', {
+      method: 'POST',
+      body: '{"messages":[]}',
+      headers: { authorization: 'AWS4-HMAC-SHA256 Credential=discarded', 'content-type': 'application/json' },
+    });
+    expect(seen.auth).toBe('Bearer bedrock-api-key-abc');
+    expect(seen.body).toBe('{"messages":[]}');
+  });
+});
+
+describe('resolveBedrockRegion', () => {
+  it('returns the explicit region unchanged (the client normalizes it, no AWS call)', async () => {
+    expect(await resolveBedrockRegion({ aiProvider: 'amazon-bedrock', aiRegion: 'us-west-2' })).toBe('us-west-2');
+  });
+});
+
+describe('listBedrockModels', () => {
+  afterEach(() => {
+    // spyOn restores are automatic per Bun's mock reset, but be explicit for clarity.
+  });
+
+  it('merges both AWS calls and follows inference-profile pagination', async () => {
+    const send = spyOn(BedrockClient.prototype, 'send').mockImplementation((command: unknown): Promise<unknown> => {
+      if (command instanceof ListFoundationModelsCommand) {
+        return Promise.resolve({ modelSummaries: [fm({ modelId: 'fm.text', modelName: 'FM Text' })] });
+      }
+      if (command instanceof ListInferenceProfilesCommand) {
+        const token = command.input.nextToken;
+        if (!token) {
+          return Promise.resolve({
+            inferenceProfileSummaries: [ip({ inferenceProfileId: 'ip.one', inferenceProfileName: 'IP One' })],
+            nextToken: 'page2',
+          });
+        }
+        return Promise.resolve({
+          inferenceProfileSummaries: [ip({ inferenceProfileId: 'ip.two', inferenceProfileName: 'IP Two' })],
+        });
+      }
+      throw new Error('unexpected command');
+    });
+
+    try {
+      const out = await listBedrockModels({ aiProvider: 'amazon-bedrock', aiRegion: 'us-east-1' });
+      expect(out.models.map((m) => m.id)).toEqual(['fm.text', 'ip.one', 'ip.two']);
+      // The resolved region rides along so the UI can prefill it after a successful list.
+      expect(out.region).toBe('us-east-1');
+    } finally {
+      send.mockRestore();
+    }
+  });
+
+  it('scopes the credential chain to a named profile when one is set (no explicit keys)', async () => {
+    const send = spyOn(BedrockClient.prototype, 'send').mockImplementation((): Promise<unknown> => {
+      return Promise.resolve({ modelSummaries: [], inferenceProfileSummaries: [] });
+    });
+    const chain = spyOn(credentialProviders, 'fromNodeProviderChain').mockReturnValue((async () => ({
+      accessKeyId: 'x',
+      secretAccessKey: 'y',
+    })) as ReturnType<typeof credentialProviders.fromNodeProviderChain>);
+    try {
+      await listBedrockModels({ aiProvider: 'amazon-bedrock', aiRegion: 'us-east-1', aiProfile: 'my-sso' });
+      expect(chain).toHaveBeenCalledWith({ profile: 'my-sso' });
+    } finally {
+      send.mockRestore();
+      chain.mockRestore();
+    }
+  });
+
+  it('resolves the region from the profile when aiRegion is blank (the SDK will not do this itself)', async () => {
+    const send = spyOn(BedrockClient.prototype, 'send').mockImplementation((): Promise<unknown> => {
+      return Promise.resolve({ modelSummaries: [], inferenceProfileSummaries: [] });
+    });
+    const chain = spyOn(credentialProviders, 'fromNodeProviderChain').mockReturnValue((async () => ({
+      accessKeyId: 'x',
+      secretAccessKey: 'y',
+    })) as ReturnType<typeof credentialProviders.fromNodeProviderChain>);
+    const profileRegion = spyOn(awsProfiles, 'resolveProfileRegion').mockResolvedValue('us-east-1');
+    try {
+      // No aiRegion — the profile mode UI has no region field, so this is the real-world shape.
+      const out = await listBedrockModels({ aiProvider: 'amazon-bedrock', aiProfile: 'PlatformDev' });
+      expect(profileRegion).toHaveBeenCalledWith('PlatformDev');
+      // The profile's region flows into the client and back out for the UI to prefill.
+      expect(out.region).toBe('us-east-1');
+    } finally {
+      send.mockRestore();
+      chain.mockRestore();
+      profileRegion.mockRestore();
+    }
+  });
+
+  it('propagates AWS errors to the caller', async () => {
+    const send = spyOn(BedrockClient.prototype, 'send').mockImplementation((): Promise<unknown> => {
+      return Promise.reject(new Error('User is not authorized to perform: bedrock:ListFoundationModels'));
+    });
+    try {
+      await expect(listBedrockModels({ aiProvider: 'amazon-bedrock', aiRegion: 'us-east-1' })).rejects.toThrow(
+        /not authorized/,
+      );
+    } finally {
+      send.mockRestore();
+    }
+  });
+});

--- a/packages/cli/src/__tests__/config-api.test.ts
+++ b/packages/cli/src/__tests__/config-api.test.ts
@@ -446,13 +446,13 @@ describe('GET /api/config/aws/profiles', () => {
   it('returns the injected profile list', async () => {
     const { app } = makeApp({
       testers: {
-        listAwsProfiles: async () => [{ name: 'default', region: 'us-east-1' }, { name: 'platform-dev' }],
+        listAwsProfiles: async () => [{ name: 'default', region: 'us-east-1' }, { name: 'staging' }],
       },
     });
     const res = await app.request('/api/config/aws/profiles');
     expect(res.status).toBe(200);
     const body = (await res.json()) as { profiles: { name: string; region?: string }[] };
-    expect(body.profiles).toEqual([{ name: 'default', region: 'us-east-1' }, { name: 'platform-dev' }]);
+    expect(body.profiles).toEqual([{ name: 'default', region: 'us-east-1' }, { name: 'staging' }]);
   });
 
   it('returns an empty list (200, not an error) when profile enumeration yields nothing', async () => {

--- a/packages/cli/src/__tests__/config-api.test.ts
+++ b/packages/cli/src/__tests__/config-api.test.ts
@@ -68,6 +68,32 @@ describe('redactConfig', () => {
     expect(redactConfig({}).githubTokenSet).toBe(false);
     expect(redactConfig({ githubToken: '' }).githubTokenSet).toBe(false);
   });
+
+  it('reduces the AWS secret access key to *Set and drops the raw value', () => {
+    const redacted = redactConfig({
+      aiProvider: 'amazon-bedrock',
+      aiRegion: 'us-east-1',
+      aiAccessKeyId: 'AKIAEXAMPLE',
+      aiSecretAccessKey: 'super-secret-key',
+    });
+    expect(redacted.aiSecretAccessKeySet).toBe(true);
+    // aiAccessKeyId is an identifier, not a secret — it survives in the clear.
+    expect(redacted.aiAccessKeyId).toBe('AKIAEXAMPLE');
+    expect(redacted.aiRegion).toBe('us-east-1');
+    expect(JSON.stringify(redacted)).not.toContain('super-secret-key');
+  });
+
+  it('reports missing AWS secrets as not-set', () => {
+    expect(redactConfig({}).aiSecretAccessKeySet).toBe(false);
+    expect(redactConfig({ aiSecretAccessKey: '' }).aiSecretAccessKeySet).toBe(false);
+  });
+
+  it('reduces the Bedrock API key to *Set and drops the raw value', () => {
+    const redacted = redactConfig({ aiProvider: 'amazon-bedrock', aiBedrockApiKey: 'bedrock-api-key-abc' });
+    expect(redacted.aiBedrockApiKeySet).toBe(true);
+    expect(JSON.stringify(redacted)).not.toContain('bedrock-api-key-abc');
+    expect(redactConfig({}).aiBedrockApiKeySet).toBe(false);
+  });
 });
 
 describe('GET /api/config', () => {
@@ -123,6 +149,43 @@ describe('PUT /api/config — merge + redaction', () => {
     expect(cleared.config.githubTokenSet).toBe(false);
     expect(cleared.github.active).toBe(false);
     expect((await readConfig()).githubToken).toBeUndefined();
+  });
+
+  it('accepts the amazon-bedrock provider + AWS fields, persisting keys but redacting the secret', async () => {
+    const { app } = makeApp();
+    const res = await put(app, {
+      aiProvider: 'amazon-bedrock',
+      aiRegion: 'us-east-1',
+      aiProfile: 'my-sso',
+      aiAccessKeyId: 'AKIAEXAMPLE',
+      aiSecretAccessKey: 'aws-secret-value',
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ConfigResponse;
+    expect(body.config.aiProvider).toBe('amazon-bedrock');
+    expect(body.config.aiRegion).toBe('us-east-1');
+    // aiProfile is an identifier, not a secret — it survives redaction in the clear.
+    expect(body.config.aiProfile).toBe('my-sso');
+    expect(body.config.aiAccessKeyId).toBe('AKIAEXAMPLE');
+    expect(body.config.aiSecretAccessKeySet).toBe(true);
+    // Raw AWS secret never crosses the wire…
+    expect(JSON.stringify(body)).not.toContain('aws-secret-value');
+    // …but is persisted on disk.
+    const saved = await readConfig();
+    expect(saved.aiSecretAccessKey).toBe('aws-secret-value');
+  });
+
+  it('persists the Bedrock API key write-only and clears it with an empty string', async () => {
+    const { app } = makeApp();
+    const res = await put(app, { aiProvider: 'amazon-bedrock', aiBedrockApiKey: 'bedrock-api-key-abc' });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ConfigResponse;
+    expect(body.config.aiBedrockApiKeySet).toBe(true);
+    expect(JSON.stringify(body)).not.toContain('bedrock-api-key-abc');
+    expect((await readConfig()).aiBedrockApiKey).toBe('bedrock-api-key-abc');
+
+    await put(app, { aiBedrockApiKey: '' });
+    expect((await readConfig()).aiBedrockApiKey).toBeUndefined();
   });
 
   it('is a merge patch — unrelated stored keys survive a partial PUT', async () => {
@@ -261,6 +324,32 @@ describe('POST /api/config/test', () => {
     expect(seen[0]!.aiModel).toBe('candidate-model'); // overlaid
   });
 
+  it('ai: overlays candidate bedrock region + AWS creds on the saved config', async () => {
+    await writeConfig({ aiProvider: 'amazon-bedrock', aiRegion: 'us-west-2' });
+    const seen: DiffDadConfig[] = [];
+    const { app } = makeApp({
+      testers: {
+        testAi: async (config) => {
+          seen.push(config);
+          return { ok: true, detail: 'ok' };
+        },
+      },
+    });
+    const res = await post(app, {
+      kind: 'ai',
+      aiRegion: 'eu-central-1',
+      aiProfile: 'my-sso',
+      aiAccessKeyId: 'AKIACAND',
+      aiSecretAccessKey: 'cand-secret',
+    });
+    expect(res.status).toBe(200);
+    expect(seen[0]!.aiProvider).toBe('amazon-bedrock'); // from saved config
+    expect(seen[0]!.aiRegion).toBe('eu-central-1'); // overlaid
+    expect(seen[0]!.aiProfile).toBe('my-sso');
+    expect(seen[0]!.aiAccessKeyId).toBe('AKIACAND');
+    expect(seen[0]!.aiSecretAccessKey).toBe('cand-secret');
+  });
+
   it('400s an unknown kind', async () => {
     const { app } = makeApp();
     expect((await post(app, { kind: 'frobnicate' })).status).toBe(400);
@@ -274,5 +363,102 @@ describe('POST /api/config/test', () => {
       body: '{ not json',
     });
     expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /api/config/bedrock/models', () => {
+  const post = (app: Hono, body: unknown) =>
+    app.request('/api/config/bedrock/models', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+  it('returns the injected model list + resolved region and overlays candidate creds on the saved config', async () => {
+    await writeConfig({ aiProvider: 'amazon-bedrock', aiRegion: 'us-east-1' });
+    const seen: DiffDadConfig[] = [];
+    const { app } = makeApp({
+      testers: {
+        listBedrockModels: async (config) => {
+          seen.push(config);
+          return {
+            models: [{ id: 'us.anthropic.claude-sonnet', label: 'Claude Sonnet (inference profile)' }],
+            region: 'eu-west-1',
+          };
+        },
+      },
+    });
+    const res = await post(app, {
+      aiRegion: 'eu-west-1',
+      aiProfile: 'my-sso',
+      aiAccessKeyId: 'AKIA',
+      aiSecretAccessKey: 'sk',
+      aiBedrockApiKey: 'bedrock-api-key-abc',
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { models: { id: string; label: string }[]; region?: string };
+    expect(body.models).toEqual([{ id: 'us.anthropic.claude-sonnet', label: 'Claude Sonnet (inference profile)' }]);
+    // The resolved region is surfaced so the UI can prefill it.
+    expect(body.region).toBe('eu-west-1');
+    expect(seen[0]!.aiRegion).toBe('eu-west-1'); // candidate overlaid
+    expect(seen[0]!.aiProfile).toBe('my-sso');
+    expect(seen[0]!.aiAccessKeyId).toBe('AKIA');
+    expect(seen[0]!.aiSecretAccessKey).toBe('sk');
+    expect(seen[0]!.aiBedrockApiKey).toBe('bedrock-api-key-abc');
+  });
+
+  it('returns 502 with the AWS message when the lister throws', async () => {
+    const { app } = makeApp({
+      testers: {
+        listBedrockModels: async () => {
+          throw new Error('User is not authorized to perform: bedrock:ListFoundationModels');
+        },
+      },
+    });
+    const res = await post(app, { aiRegion: 'us-east-1' });
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('not authorized');
+  });
+
+  it('tolerates an empty/missing body (falls back to saved config)', async () => {
+    await writeConfig({ aiProvider: 'amazon-bedrock', aiRegion: 'us-east-1' });
+    const seen: DiffDadConfig[] = [];
+    const { app } = makeApp({
+      testers: {
+        listBedrockModels: async (config) => {
+          seen.push(config);
+          return { models: [], region: 'us-east-1' };
+        },
+      },
+    });
+    const res = await app.request('/api/config/bedrock/models', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{ not json',
+    });
+    expect(res.status).toBe(200);
+    expect(seen[0]!.aiRegion).toBe('us-east-1'); // from saved config
+  });
+});
+
+describe('GET /api/config/aws/profiles', () => {
+  it('returns the injected profile list', async () => {
+    const { app } = makeApp({
+      testers: {
+        listAwsProfiles: async () => [{ name: 'default', region: 'us-east-1' }, { name: 'platform-dev' }],
+      },
+    });
+    const res = await app.request('/api/config/aws/profiles');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { profiles: { name: string; region?: string }[] };
+    expect(body.profiles).toEqual([{ name: 'default', region: 'us-east-1' }, { name: 'platform-dev' }]);
+  });
+
+  it('returns an empty list (200, not an error) when profile enumeration yields nothing', async () => {
+    const { app } = makeApp({ testers: { listAwsProfiles: async () => [] } });
+    const res = await app.request('/api/config/aws/profiles');
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { profiles: unknown[] }).profiles).toEqual([]);
   });
 });

--- a/packages/cli/src/__tests__/config.test.ts
+++ b/packages/cli/src/__tests__/config.test.ts
@@ -50,6 +50,19 @@ describe('writeConfig / readConfig round-trip', () => {
     expect(await readConfig()).toEqual(config);
   });
 
+  it('round-trips the amazon-bedrock provider and AWS credential fields', async () => {
+    const config: DiffDadConfig = {
+      aiProvider: 'amazon-bedrock',
+      aiRegion: 'us-east-1',
+      aiProfile: 'my-sso',
+      aiAccessKeyId: 'AKIAEXAMPLE',
+      aiSecretAccessKey: 'secret',
+      aiModel: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+    };
+    await writeConfig(config);
+    expect(await readConfig()).toEqual(config);
+  });
+
   it('creates the parent directory when it does not exist', async () => {
     // mkdtemp dir exists, but the diffdad/ subdir does not until writeConfig makes it.
     await writeConfig({ theme: 'light' });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -325,10 +325,9 @@ async function reviewCommand(prArg: string | undefined): Promise<number> {
     };
     render();
     const heartbeat = setInterval(render, 250);
-    let generated;
-    let usedProvider: string;
+    let result: Awaited<ReturnType<typeof generateNarrative>>;
     try {
-      const result = await generateNarrative(metadata, files, [], config, undefined, {
+      result = await generateNarrative(metadata, files, [], config, undefined, {
         cacheKey: {
           owner: parsed.owner,
           repo: parsed.repo,
@@ -354,12 +353,29 @@ async function reviewCommand(prArg: string | undefined): Promise<number> {
           broadcast('chapter-ready', { themeId, index, chapter });
         },
       });
-      generated = result.narrative;
-      usedProvider = result.provider;
-    } finally {
+    } catch (err) {
       clearInterval(heartbeat);
       if (isTty) process.stdout.write('\r\x1b[2K');
+      // Without this, a generation failure (expired AWS profile, network drop, model 4xx) escapes as an
+      // unhandled rejection and Bun dumps a raw stack trace — burying the actionable message. Surface it
+      // in the same clean format as the other review errors, and tell any open browser tab too.
+      const msg = err instanceof Error ? err.message : String(err);
+      broadcast('narrative-error', { message: msg });
+      console.error(`\n  ${a.red}${a.bold}error:${a.reset} ${msg}\n`);
+      // Message-only keeps expected failures readable; the stack is one env var away for real bugs.
+      if (process.env.DIFFDAD_DEBUG && err instanceof Error && err.stack) {
+        console.error(`${a.dim}${err.stack}${a.reset}\n`);
+      }
+      // broadcast() only enqueues into the SSE stream controllers; returning 1 hits process.exit(1)
+      // in main() before the socket flushes, and the open tab never sees the error. Give the write an
+      // I/O tick to reach the wire before the server dies.
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      return 1;
     }
+    clearInterval(heartbeat);
+    if (isTty) process.stdout.write('\r\x1b[2K');
+    const generated = result.narrative;
+    const usedProvider = result.provider;
     ctx.narrative = generated;
     await cacheNarrative(parsed.owner, parsed.repo, parsed.number, metadata.headSha, metaHash, providerKey, generated);
     console.log(

--- a/packages/cli/src/config-api.ts
+++ b/packages/cli/src/config-api.ts
@@ -4,6 +4,8 @@ import { type GitHubTokenSource, resolveGitHubTokenWithSource } from './auth';
 import { type DiffDadConfig, readConfig, writeConfig } from './config';
 import { GitHubClient } from './github/client';
 import type { Broadcast } from './mcp/broadcast';
+import { type AwsProfile, listAwsProfiles as defaultListAwsProfiles } from './narrative/aws-profiles';
+import { type BedrockModelOption, listBedrockModels as defaultListBedrockModels } from './narrative/bedrock-models';
 import { callAi } from './narrative/engine';
 
 /**
@@ -17,9 +19,14 @@ import { callAi } from './narrative/engine';
  */
 
 /** Wire shape sent to the browser — secrets reduced to flags. */
-export interface RedactedConfig extends Omit<DiffDadConfig, 'githubToken' | 'aiApiKey'> {
+export interface RedactedConfig extends Omit<
+  DiffDadConfig,
+  'githubToken' | 'aiApiKey' | 'aiSecretAccessKey' | 'aiBedrockApiKey'
+> {
   githubTokenSet: boolean;
   aiApiKeySet: boolean;
+  aiSecretAccessKeySet: boolean;
+  aiBedrockApiKeySet: boolean;
 }
 
 export interface ConfigResponse {
@@ -34,10 +41,15 @@ export interface ConfigResponse {
 export const configPatchSchema = z
   .object({
     githubToken: z.string(),
-    aiProvider: z.enum(['anthropic', 'openai', 'openai-compatible', 'ollama']),
+    aiProvider: z.enum(['anthropic', 'openai', 'openai-compatible', 'ollama', 'amazon-bedrock']),
     aiApiKey: z.string(),
     aiModel: z.string(),
     aiBaseUrl: z.string(),
+    aiRegion: z.string(),
+    aiProfile: z.string(),
+    aiAccessKeyId: z.string(),
+    aiSecretAccessKey: z.string(),
+    aiBedrockApiKey: z.string(),
     defaultCli: z.enum(['claude', 'codex', 'pi']),
     cliModels: z.record(z.enum(['claude', 'codex', 'pi']), z.string()),
     storyStructure: z.enum(['chapters', 'linear', 'outline']),
@@ -62,19 +74,57 @@ export type ConfigPatch = z.infer<typeof configPatchSchema>;
  */
 export type OnConfigChange = (prev: DiffDadConfig, next: DiffDadConfig) => Promise<{ githubActive: boolean }>;
 
-const SECRET_KEYS = ['githubToken', 'aiApiKey'] as const;
+// The candidate fields the test/list seams accept and overlay on the saved config (undefined =
+// keep saved). One list per endpoint, derived not hand-copied, so a new field (e.g. a session
+// token) can't be added to one seam and silently ignored by the other — that failure mode is
+// invisible: the test would quietly run against the stale saved value.
+const BEDROCK_OVERLAY_KEYS = [
+  'aiRegion',
+  'aiProfile',
+  'aiAccessKeyId',
+  'aiSecretAccessKey',
+  'aiBedrockApiKey',
+] as const;
+const AI_TEST_OVERLAY_KEYS = [
+  'aiProvider',
+  'aiApiKey',
+  'aiModel',
+  'aiBaseUrl',
+  'defaultCli',
+  ...BEDROCK_OVERLAY_KEYS,
+] as const;
+
+type OverlayBody<K extends keyof DiffDadConfig> = Partial<Pick<DiffDadConfig, K>>;
+
+/** Overlay the body's defined candidate keys on the saved config. */
+function overlayDefined<K extends keyof DiffDadConfig>(
+  saved: DiffDadConfig,
+  body: OverlayBody<K>,
+  keys: readonly K[],
+): DiffDadConfig {
+  const overlay: DiffDadConfig = { ...saved };
+  for (const key of keys) {
+    const value = body[key];
+    if (value !== undefined) (overlay as Record<string, unknown>)[key] = value;
+  }
+  return overlay;
+}
+
+const SECRET_KEYS = ['githubToken', 'aiApiKey', 'aiSecretAccessKey', 'aiBedrockApiKey'] as const;
 type SecretKey = (typeof SECRET_KEYS)[number];
 function isSecretKey(key: string): key is SecretKey {
-  return key === 'githubToken' || key === 'aiApiKey';
+  return (SECRET_KEYS as readonly string[]).includes(key);
 }
 
 /** Reduce a stored config to its redacted wire shape (secrets → `*Set` booleans). */
 export function redactConfig(config: DiffDadConfig): RedactedConfig {
-  const { githubToken, aiApiKey, ...rest } = config;
+  const { githubToken, aiApiKey, aiSecretAccessKey, aiBedrockApiKey, ...rest } = config;
   return {
     ...rest,
     githubTokenSet: typeof githubToken === 'string' && githubToken.length > 0,
     aiApiKeySet: typeof aiApiKey === 'string' && aiApiKey.length > 0,
+    aiSecretAccessKeySet: typeof aiSecretAccessKey === 'string' && aiSecretAccessKey.length > 0,
+    aiBedrockApiKeySet: typeof aiBedrockApiKey === 'string' && aiBedrockApiKey.length > 0,
   };
 }
 
@@ -92,10 +142,12 @@ function mergeConfig(prev: DiffDadConfig, patch: ConfigPatch): DiffDadConfig {
   return next;
 }
 
-/** Injectable connection testers — real implementations shell out; tests fake them. */
+/** Injectable connection testers — real implementations shell out / hit AWS; tests fake them. */
 export interface ConfigRouteTesters {
   testGitHub?: (token: string) => Promise<{ ok: boolean; detail: string }>;
   testAi?: (config: DiffDadConfig) => Promise<{ ok: boolean; detail: string }>;
+  listBedrockModels?: (config: DiffDadConfig) => Promise<{ models: BedrockModelOption[]; region: string | undefined }>;
+  listAwsProfiles?: () => Promise<AwsProfile[]>;
 }
 
 /** Injectable effective-token resolver (default probes env → gh → config); tests fake it. */
@@ -172,6 +224,8 @@ export function registerConfigRoutes(
   const resolveGitHub: ResolveGitHub = opts.resolveGitHub ?? (() => resolveGitHubTokenWithSource());
   const testGitHub = opts.testers?.testGitHub ?? defaultTestGitHub;
   const testAi = opts.testers?.testAi ?? defaultTestAi;
+  const listBedrockModels = opts.testers?.listBedrockModels ?? defaultListBedrockModels;
+  const listAwsProfiles = opts.testers?.listAwsProfiles ?? defaultListAwsProfiles;
 
   // Effective GitHub state rides every response. `active`/`source` come from probing env → gh →
   // config; when the daemon hook ran, its authoritative `githubActive` overrides (both derive from
@@ -240,15 +294,7 @@ export function registerConfigRoutes(
   });
 
   app.post('/api/config/test', async (c) => {
-    let body: {
-      kind?: string;
-      token?: string;
-      aiProvider?: DiffDadConfig['aiProvider'];
-      aiApiKey?: string;
-      aiModel?: string;
-      aiBaseUrl?: string;
-      defaultCli?: DiffDadConfig['defaultCli'];
-    };
+    let body: { kind?: string; token?: string } & OverlayBody<(typeof AI_TEST_OVERLAY_KEYS)[number]>;
     try {
       body = (await c.req.json()) as typeof body;
     } catch {
@@ -264,16 +310,41 @@ export function registerConfigRoutes(
 
     if (body.kind === 'ai') {
       // Overlay the candidate fields on the saved config, then run one live call.
-      const saved = await readConfig();
-      const overlay: DiffDadConfig = { ...saved };
-      if (body.aiProvider !== undefined) overlay.aiProvider = body.aiProvider;
-      if (body.aiApiKey !== undefined) overlay.aiApiKey = body.aiApiKey;
-      if (body.aiModel !== undefined) overlay.aiModel = body.aiModel;
-      if (body.aiBaseUrl !== undefined) overlay.aiBaseUrl = body.aiBaseUrl;
-      if (body.defaultCli !== undefined) overlay.defaultCli = body.defaultCli;
-      return c.json(await testAi(overlay));
+      return c.json(await testAi(overlayDefined(await readConfig(), body, AI_TEST_OVERLAY_KEYS)));
     }
 
     return c.json({ error: `unknown test kind: ${body.kind ?? '(none)'}` }, 400);
+  });
+
+  // List available Bedrock text models (foundation + inference profiles). Overlays candidate
+  // region/creds on the saved config so the UI can list BEFORE saving (same seam as /config/test).
+  // Failure returns 502 with the AWS message — the contract chose "block until fixed" (no free-text
+  // fallback), so the UI surfaces this and cannot proceed.
+  app.post('/api/config/bedrock/models', async (c) => {
+    let body: OverlayBody<(typeof BEDROCK_OVERLAY_KEYS)[number]>;
+    try {
+      body = (await c.req.json()) as typeof body;
+    } catch {
+      body = {};
+    }
+
+    const overlay = overlayDefined(await readConfig(), body, BEDROCK_OVERLAY_KEYS);
+
+    try {
+      // listBedrockModels returns { models, region } — pass it straight through so the UI can prefill
+      // the region field with what the SDK actually resolved (from the profile / chain when blank).
+      return c.json(await listBedrockModels(overlay));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // This path was silent before — a hang or AWS error left no trace in the daemon log.
+      console.error(`  \x1b[38;5;204m✗\x1b[0m Bedrock model list failed: ${msg}`);
+      return c.json({ error: msg }, 502);
+    }
+  });
+
+  // List the AWS profiles on this machine (name + region) so the Bedrock settings form can offer a
+  // dropdown instead of a free-text profile field. Never fails — an unreadable ~/.aws yields [].
+  app.get('/api/config/aws/profiles', async (c) => {
+    return c.json({ profiles: await listAwsProfiles() });
   });
 }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -2,7 +2,7 @@ import { mkdir } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
-export type AiProvider = 'anthropic' | 'openai' | 'openai-compatible' | 'ollama';
+export type AiProvider = 'anthropic' | 'openai' | 'openai-compatible' | 'ollama' | 'amazon-bedrock';
 
 export type LocalCli = 'claude' | 'codex' | 'pi';
 export const LOCAL_CLIS: readonly LocalCli[] = ['claude', 'codex', 'pi'] as const;
@@ -29,6 +29,16 @@ export interface DiffDadConfig {
   aiApiKey?: string;
   aiModel?: string;
   aiBaseUrl?: string;
+  /** AWS region for the amazon-bedrock provider (blank → resolve from the ambient chain / AWS_REGION). */
+  aiRegion?: string;
+  /** AWS access key id for amazon-bedrock. NOT a secret (an identifier, like a username). Blank → ambient chain. */
+  aiAccessKeyId?: string;
+  /** AWS secret access key for amazon-bedrock. Secret. Blank → ambient chain. */
+  aiSecretAccessKey?: string;
+  /** Named AWS profile (from `~/.aws/config`) for amazon-bedrock. Used only when no explicit keys are set. */
+  aiProfile?: string;
+  /** Bedrock bearer API key for amazon-bedrock. Secret. Dedicated field (not `aiApiKey`) so another provider's lingering key can never flip the Bedrock auth mode. */
+  aiBedrockApiKey?: string;
   defaultCli?: LocalCli;
   cliModels?: Partial<Record<LocalCli, string>>;
   storyStructure?: StoryStructure;

--- a/packages/cli/src/narrative/ai-runtime.ts
+++ b/packages/cli/src/narrative/ai-runtime.ts
@@ -1,9 +1,12 @@
 import { rm } from 'fs/promises';
 import { streamText, wrapLanguageModel } from 'ai';
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
 import type { FinishReason, LanguageModelUsage, LanguageModelV1, LanguageModelV1Middleware } from 'ai';
 import { DEFAULT_CLI_MODELS, LOCAL_CLIS, type DiffDadConfig, type LocalCli } from '../config';
+import { resolveBedrockCreds } from './bedrock-credentials';
+import { resolveBedrockRegion, toInvokeAuth } from './bedrock-models';
 
 export type AiChunkHandler = (delta: string) => void;
 export type AiUsage = { inputTokens?: number; outputTokens?: number };
@@ -14,6 +17,9 @@ const DEFAULT_ANTHROPIC_MODEL = 'claude-sonnet-4-6';
 const DEFAULT_OPENAI_MODEL = 'gpt-4o';
 const DEFAULT_OLLAMA_MODEL = 'llama3.1';
 const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434/v1';
+// Cross-region inference profile id — current Claude Sonnet on Bedrock. Fallback only; the settings
+// UI populates the model from the live account, so this applies when aiModel is unset.
+const DEFAULT_BEDROCK_MODEL = 'us.anthropic.claude-sonnet-4-5-20250929-v1:0';
 
 let cliOverride: string | undefined;
 
@@ -141,11 +147,67 @@ export function getModel(config: DiffDadConfig): LanguageModelV1 {
       });
       return compatible(config.aiModel ?? DEFAULT_OPENAI_MODEL);
     }
+    case 'amazon-bedrock': {
+      const bedrock = createAmazonBedrock({
+        // `''` (a profile-mode save clears aiRegion by storing the empty string) must become
+        // undefined: the SDK treats any string as a set region and would build the malformed host
+        // `bedrock-runtime..amazonaws.com` instead of falling back to AWS_REGION / its clear
+        // "region is missing" error.
+        region: config.aiRegion || undefined,
+        // The invoke half of the lockstep choice→auth mapping in bedrock-models.ts, so "Load
+        // models" and invoke can't authenticate differently. For an API key this carries a
+        // bearer-injecting fetch; otherwise a credentialProvider the SDK uses over its own env.
+        ...toInvokeAuth(resolveBedrockCreds(config)),
+      });
+      return wrapLanguageModel({
+        // Bedrock-hosted Claude has the same temperature-deprecation behavior as the direct API.
+        // `||` not `??`: the settings form saves '' to mean "use the default model".
+        model: bedrock(config.aiModel || DEFAULT_BEDROCK_MODEL),
+        middleware: stripTemperature,
+      });
+    }
     default: {
       const exhaustive: never = provider;
       throw new Error(`Unsupported aiProvider: ${exhaustive as string}`);
     }
   }
+}
+
+/**
+ * Fill a blank Bedrock region from the profile / ambient chain before `getModel` runs. `getModel` is a
+ * synchronous factory and `createAmazonBedrock` needs region as a resolved string (unlike the raw
+ * `BedrockClient`, which resolves region itself). So the invoke path resolves region here first — a
+ * profile-only config then generates without the user ever typing a region. A no-op for every other
+ * provider, and for a Bedrock config that already has an explicit region.
+ */
+export async function withResolvedBedrockRegion(config: DiffDadConfig): Promise<DiffDadConfig> {
+  if (config.aiProvider !== 'amazon-bedrock' || config.aiRegion) return config;
+  const region = await resolveBedrockRegion(config);
+  return region ? { ...config, aiRegion: region } : config;
+}
+
+// One narrative fans out a callAi per chapter (plus the planner), and rebuilding the Bedrock model
+// each time re-runs region resolution and discards the credential chain's per-instance memoization —
+// re-reading ~/.aws (and re-doing SSO/STS exchanges) N+1 times per PR. Cache the model keyed by the
+// fields that shape it; a settings save changes the key and so invalidates. The chain itself
+// refreshes expired credentials internally, so holding one instance long-term is safe.
+let bedrockModelCache: { key: string; model: LanguageModelV1 } | undefined;
+
+async function getBedrockModel(config: DiffDadConfig): Promise<LanguageModelV1> {
+  const key = [
+    config.aiModel,
+    config.aiRegion,
+    config.aiProfile,
+    config.aiAccessKeyId,
+    config.aiSecretAccessKey,
+    config.aiBedrockApiKey,
+  ]
+    .map((v) => v ?? '')
+    .join('\u0000');
+  if (bedrockModelCache?.key !== key) {
+    bedrockModelCache = { key, model: getModel(await withResolvedBedrockRegion(config)) };
+  }
+  return bedrockModelCache.model;
 }
 
 async function whichExists(cmd: string): Promise<boolean> {
@@ -350,7 +412,9 @@ export async function callAi(
   }
 
   const provider = effectiveConfig.aiProvider ?? 'anthropic';
-  const model = getModel(effectiveConfig);
+  // Bedrock invoke path needs region as a resolved string; fill it from the profile/chain when blank
+  // (cached across calls — see getBedrockModel).
+  const model = provider === 'amazon-bedrock' ? await getBedrockModel(effectiveConfig) : getModel(effectiveConfig);
   const cacheSystem = provider === 'anthropic';
   const stream = streamText({
     model,

--- a/packages/cli/src/narrative/aws-profiles.ts
+++ b/packages/cli/src/narrative/aws-profiles.ts
@@ -1,0 +1,62 @@
+import { loadSharedConfigFiles } from '@smithy/shared-ini-file-loader';
+
+export interface AwsProfile {
+  name: string;
+  region?: string;
+}
+
+type IniSection = Record<string, string | undefined>;
+type IniData = Record<string, IniSection>;
+
+// loadSharedConfigFiles folds non-profile `[sso-session x]` / `[services x]` blocks into configFile
+// under a `<type>.` prefix. Those are not selectable profiles, so drop them.
+const NON_PROFILE_PREFIXES = ['sso-session.', 'services.'];
+
+/**
+ * Merge the profile names from `~/.aws/config` and `~/.aws/credentials` into one deduped, sorted list.
+ * Region is read from the config file only (AWS resolves region there, not from the credentials file),
+ * so a credentials-only profile surfaces with no region. Non-profile sections are filtered out.
+ */
+export function mergeAwsProfiles(configFile: IniData, credentialsFile: IniData): AwsProfile[] {
+  const byName = new Map<string, AwsProfile>();
+  const add = (name: string, region?: string) => {
+    if (NON_PROFILE_PREFIXES.some((prefix) => name.startsWith(prefix))) return;
+    const existing = byName.get(name);
+    if (existing) {
+      if (region && !existing.region) existing.region = region;
+    } else {
+      byName.set(name, region ? { name, region } : { name });
+    }
+  };
+  for (const [name, section] of Object.entries(configFile)) add(name, section?.region);
+  for (const name of Object.keys(credentialsFile)) add(name);
+  return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Enumerate the AWS profiles available on this machine. Never throws — an unreadable / missing
+ * `~/.aws` yields an empty list, which the UI treats as "no profiles."
+ */
+export async function listAwsProfiles(): Promise<AwsProfile[]> {
+  try {
+    const { configFile, credentialsFile } = await loadSharedConfigFiles();
+    return mergeAwsProfiles(configFile, credentialsFile);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Read the region declared on a single profile in `~/.aws/config`. The AWS SDK scopes credentials to
+ * a profile but resolves region independently (from env / the default profile), so it never picks up
+ * the selected profile's `region =` — callers pass it explicitly. Never throws; returns undefined when
+ * the profile is missing, has no region, or `~/.aws` is unreadable.
+ */
+export async function resolveProfileRegion(profile: string): Promise<string | undefined> {
+  try {
+    const { configFile } = await loadSharedConfigFiles();
+    return configFile[profile]?.region;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/cli/src/narrative/bedrock-credentials.ts
+++ b/packages/cli/src/narrative/bedrock-credentials.ts
@@ -1,0 +1,40 @@
+import type { DiffDadConfig } from '../config';
+
+/**
+ * The credential resolution decision for the amazon-bedrock provider, as plain data.
+ *
+ * Precedence, highest first:
+ *   1. `api-key`  — a Bedrock bearer API key is present; requests use `Authorization: Bearer`, no SigV4.
+ *   2. `explicit` — both an access key id AND a secret access key are present (a partial pair does
+ *      not count; it falls through).
+ *   3. `profile`  — a named AWS profile is set; the caller scopes the node provider chain to it.
+ *   4. `default`  — nothing set; resolve the ambient chain (env, `~/.aws`, `AWS_PROFILE`, IAM role).
+ *
+ * The settings form keeps modes mutually exclusive on save (picking one clears the others' fields),
+ * so this order only decides hand-edited configs.
+ *
+ * Kept as a pure function (no AWS imports) so the branching is unit-testable and shared by both the
+ * list path (`bedrock-models.ts`) and the invoke path (`ai-runtime.ts`) instead of being duplicated.
+ */
+export type BedrockCredsChoice =
+  | { kind: 'api-key'; apiKey: string }
+  | { kind: 'explicit'; accessKeyId: string; secretAccessKey: string }
+  | { kind: 'profile'; profile: string }
+  | { kind: 'default' };
+
+export function resolveBedrockCreds(config: DiffDadConfig): BedrockCredsChoice {
+  if (config.aiBedrockApiKey) {
+    return { kind: 'api-key', apiKey: config.aiBedrockApiKey };
+  }
+  if (config.aiAccessKeyId && config.aiSecretAccessKey) {
+    return {
+      kind: 'explicit',
+      accessKeyId: config.aiAccessKeyId,
+      secretAccessKey: config.aiSecretAccessKey,
+    };
+  }
+  if (config.aiProfile) {
+    return { kind: 'profile', profile: config.aiProfile };
+  }
+  return { kind: 'default' };
+}

--- a/packages/cli/src/narrative/bedrock-models.ts
+++ b/packages/cli/src/narrative/bedrock-models.ts
@@ -1,0 +1,218 @@
+import {
+  BedrockClient,
+  type FoundationModelSummary,
+  type InferenceProfileSummary,
+  ListFoundationModelsCommand,
+  ListInferenceProfilesCommand,
+} from '@aws-sdk/client-bedrock';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+import type { DiffDadConfig } from '../config';
+import { resolveProfileRegion } from './aws-profiles';
+import { type BedrockCredsChoice, resolveBedrockCreds } from './bedrock-credentials';
+
+// Cap the AWS round-trip. With no credentials/region the SDK's chain falls through to the EC2
+// instance-metadata endpoint (169.254.169.254), which is unroutable off-EC2 and hangs on slow
+// connection-timeout retries. Racing a deadline turns that silent hang into a surfaced 502.
+const LIST_TIMEOUT_MS = 10_000;
+
+function withTimeout<T>(work: Promise<T>, ms: number, message: string): Promise<T> {
+  // When the deadline wins, `work` is still pending and may reject later (e.g. the credential chain
+  // giving up on IMDS seconds after the race settled) — absorb that so it can't become an unhandled
+  // rejection. Promise.race subscribes separately, so a caller still sees `work`'s own rejection.
+  work.catch(() => {});
+  let timer: ReturnType<typeof setTimeout>;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), ms);
+  });
+  return Promise.race([work, deadline]).finally(() => clearTimeout(timer)) as Promise<T>;
+}
+
+export interface BedrockModelOption {
+  id: string;
+  label: string;
+}
+
+/**
+ * Merge text-capable foundation models with inference profiles into one deduped, sorted list.
+ *
+ * - Foundation models are filtered to those advertising `TEXT` output (defensive — the API is also
+ *   asked with `byOutputModality: 'TEXT'`, but a mocked/older response may not honor it).
+ * - Foundation models that only support `INFERENCE_PROFILE` (no `ON_DEMAND`) are dropped: the bare id
+ *   can't be invoked directly, so offering it is a trap. Current Claude models are exactly this case —
+ *   they're reachable through the `us.anthropic.*` inference profiles, which are merged in below.
+ * - Dedupe by id (foundation wins a collision — same underlying model, one row); sort by id.
+ */
+export function mergeBedrockModels(
+  foundationModels: FoundationModelSummary[],
+  inferenceProfiles: InferenceProfileSummary[],
+): BedrockModelOption[] {
+  const byId = new Map<string, BedrockModelOption>();
+
+  for (const m of foundationModels) {
+    if (!m.modelId) continue;
+    if (!m.outputModalities?.includes('TEXT')) continue;
+    // Drop inference-profile-only models. We check ON_DEMAND *positively* rather than looking for
+    // 'INFERENCE_PROFILE' because the live API returns that value but the SDK's InferenceType type
+    // doesn't list it — so keep only what's provably on-demand invokable. An unset field means the API
+    // didn't classify the model, so keep it rather than over-filter.
+    if (m.inferenceTypesSupported && !m.inferenceTypesSupported.includes('ON_DEMAND')) continue;
+    if (byId.has(m.modelId)) continue;
+    const label = m.modelName && m.modelName.length > 0 ? m.modelName : m.modelId;
+    byId.set(m.modelId, { id: m.modelId, label });
+  }
+
+  for (const p of inferenceProfiles) {
+    if (!p.inferenceProfileId) continue;
+    if (byId.has(p.inferenceProfileId)) continue;
+    const name =
+      p.inferenceProfileName && p.inferenceProfileName.length > 0 ? p.inferenceProfileName : p.inferenceProfileId;
+    byId.set(p.inferenceProfileId, { id: p.inferenceProfileId, label: `${name} (inference profile)` });
+  }
+
+  return [...byId.values()].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/**
+ * Map a SigV4 credential choice to the SDK credential provider. Explicit keys become a static
+ * provider, a named profile scopes the node chain, and `default` resolves the ambient chain (env,
+ * `~/.aws`, `AWS_PROFILE`, IAM role). The `api-key` kind is excluded at the type level: a bearer
+ * key has no SigV4 identity, so routing it here would silently authenticate as the ambient chain.
+ */
+function toCredentialProvider(
+  choice: Exclude<BedrockCredsChoice, { kind: 'api-key' }>,
+): ReturnType<typeof fromNodeProviderChain> {
+  if (choice.kind === 'explicit') {
+    const identity = { accessKeyId: choice.accessKeyId, secretAccessKey: choice.secretAccessKey };
+    return async () => identity;
+  }
+  return choice.kind === 'profile' ? fromNodeProviderChain({ profile: choice.profile }) : fromNodeProviderChain();
+}
+
+/** Auth fragment for the raw `BedrockClient` (list path): SigV4 credentials or a bearer token. */
+export type BedrockListClientAuth =
+  | { credentials: ReturnType<typeof fromNodeProviderChain> }
+  | { token: { token: string }; authSchemePreference: ['httpBearerAuth'] };
+
+/** Plain fetch signature — Bun's `typeof fetch` drags in `preconnect`, which callers don't provide. */
+export type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+/** Auth fragment for `createAmazonBedrock` (invoke path). `fetch` is set only for bearer auth. */
+export interface BedrockInvokeAuth {
+  credentialProvider: () => Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken?: string }>;
+  fetch?: typeof globalThis.fetch;
+}
+
+/*
+ * The two mappers below are the ONLY translation from a creds choice to SDK auth config — one per
+ * SDK, because the raw client and the AI-SDK provider take different shapes. They must stay in
+ * lockstep: "Load models" succeeding has to imply generation authenticates the same way.
+ */
+
+export function toListClientAuth(choice: BedrockCredsChoice): BedrockListClientAuth {
+  if (choice.kind === 'api-key') {
+    return { token: { token: choice.apiKey }, authSchemePreference: ['httpBearerAuth'] };
+  }
+  return { credentials: toCredentialProvider(choice) };
+}
+
+// @ai-sdk/amazon-bedrock@2 has no bearer support (that landed in v3 / ai@5) and unconditionally
+// SigV4-signs every POST, throwing if the credential chain is empty. So bearer mode feeds the
+// signer a dummy identity and swaps the real bearer header in at the inner fetch — the signature
+// is computed, discarded, and never reaches the wire. Verified live against us-east-1.
+const BEARER_DUMMY_IDENTITY = { accessKeyId: 'bedrock-api-key', secretAccessKey: 'bedrock-api-key' };
+
+export function toInvokeAuth(choice: BedrockCredsChoice, fetchImpl: FetchLike = globalThis.fetch): BedrockInvokeAuth {
+  if (choice.kind !== 'api-key') {
+    return { credentialProvider: toCredentialProvider(choice) };
+  }
+  const bearerFetch: FetchLike = (input, init) => {
+    const headers = new Headers(init?.headers);
+    headers.set('authorization', `Bearer ${choice.apiKey}`);
+    return fetchImpl(input, { ...init, headers });
+  };
+  // Cast: Bun's `typeof fetch` demands a `preconnect` property the AI SDK never touches.
+  return { credentialProvider: async () => BEARER_DUMMY_IDENTITY, fetch: bearerFetch as typeof globalThis.fetch };
+}
+
+/**
+ * The region this config declares, without asking the SDK: explicit `aiRegion` wins, otherwise the
+ * selected profile's `region =` from `~/.aws` — which the SDK never reads on its own (it scopes
+ * credentials to the profile but resolves region from env / the default profile). `undefined` means
+ * "let the client's own default chain decide".
+ */
+async function resolveConfiguredRegion(config: DiffDadConfig, choice: BedrockCredsChoice): Promise<string | undefined> {
+  return config.aiRegion || (choice.kind === 'profile' ? await resolveProfileRegion(choice.profile) : undefined);
+}
+
+/**
+ * Build a BedrockClient for the config, returning the configured region alongside so callers don't
+ * re-derive it. `region` is `undefined` when the client is left to its ambient chain.
+ */
+async function makeBedrockClient(
+  config: DiffDadConfig,
+): Promise<{ client: BedrockClient; region: string | undefined }> {
+  const choice = resolveBedrockCreds(config);
+  const region = await resolveConfiguredRegion(config, choice);
+  return { client: new BedrockClient({ region, ...toListClientAuth(choice) }), region };
+}
+
+/**
+ * Resolve the region the SDK would actually use for this config — the explicit `aiRegion` if set,
+ * otherwise the profile's / ambient chain's region (env, `~/.aws/config`, SSO session). Returns
+ * `undefined` (never throws) when nothing resolves, so callers can fall through to their own error.
+ *
+ * This closes the asymmetry between the two Bedrock SDKs: the raw `BedrockClient` resolves region from
+ * the profile on its own, but `createAmazonBedrock` (the invoke path) needs an explicit string — so the
+ * invoke path resolves region through here first.
+ */
+export async function resolveBedrockRegion(config: DiffDadConfig): Promise<string | undefined> {
+  try {
+    const choice = resolveBedrockCreds(config);
+    const configured = await resolveConfiguredRegion(config, choice);
+    if (configured) return configured;
+    // Ambient case: only the SDK's own chain (env, the config file's default profile) can answer,
+    // and its region resolution lives in the client constructor — build one just for this fallback.
+    return await new BedrockClient({ ...toListClientAuth(choice) }).config.region();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * List available Bedrock text models for a config: text-capable foundation models merged with
+ * inference profiles (see {@link mergeBedrockModels}). The region the client ended up with rides
+ * along so the UI can prefill it after a successful list (transparency for profile users).
+ *
+ * Throws on any AWS error (missing permission, bad region, expired creds); the caller surfaces it.
+ */
+export async function listBedrockModels(
+  config: DiffDadConfig,
+): Promise<{ models: BedrockModelOption[]; region: string | undefined }> {
+  const { client, region: configured } = await makeBedrockClient(config);
+
+  // ListFoundationModels returns everything in one call (no nextToken). ListInferenceProfiles
+  // paginates, so follow nextToken until exhausted or nothing new comes back.
+  const [fm, profiles, region] = await withTimeout(
+    Promise.all([
+      client.send(new ListFoundationModelsCommand({ byOutputModality: 'TEXT' })),
+      collectInferenceProfiles(client),
+      // Only ask the SDK when the config didn't already answer (ambient-chain case).
+      configured ?? client.config.region().catch(() => undefined),
+    ]),
+    LIST_TIMEOUT_MS,
+    'Timed out reaching AWS — check the region and credentials for this profile',
+  );
+
+  return { models: mergeBedrockModels(fm.modelSummaries ?? [], profiles), region };
+}
+
+async function collectInferenceProfiles(client: BedrockClient): Promise<InferenceProfileSummary[]> {
+  const all: InferenceProfileSummary[] = [];
+  let nextToken: string | undefined;
+  do {
+    const page = await client.send(new ListInferenceProfilesCommand(nextToken ? { nextToken } : {}));
+    if (page.inferenceProfileSummaries) all.push(...page.inferenceProfileSummaries);
+    nextToken = page.nextToken;
+  } while (nextToken);
+  return all;
+}

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -430,6 +430,9 @@ export function createServer(ctx: ServerContext) {
               } catch (err) {
                 const msg = err instanceof Error ? err.message : String(err);
                 console.error(`  \x1b[38;5;204m✗\x1b[0m Regeneration failed: ${msg}`);
+                // The terminal log is invisible to the browser tab, which otherwise keeps showing stale
+                // content with no hint that the refresh failed. Push the error so the UI can surface it.
+                broadcast('narrative-error', { message: msg });
               } finally {
                 regenerating = false;
               }

--- a/packages/web/src/components/settings/AiSection.tsx
+++ b/packages/web/src/components/settings/AiSection.tsx
@@ -1,9 +1,13 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useReviewStore } from '../../state/review-store';
 import {
   type AiProvider,
+  type AwsProfile,
+  type BedrockModelOption,
   type ConfigPatch,
   isSaveError,
+  listAwsProfiles,
+  listBedrockModels,
   type LocalCli,
   saveConfig,
   testConnection,
@@ -12,20 +16,33 @@ import {
 import { Field, GhostButton, SaveBar, Section, Select, TestResultLine, TextInput } from './controls';
 
 /** The wizard's provider decision tree (`config.ts`), rendered. `local` maps to "no aiProvider". */
-type ProviderChoice = 'local' | 'anthropic' | 'openai' | 'ollama';
+type ProviderChoice = 'local' | 'anthropic' | 'openai' | 'ollama' | 'amazon-bedrock';
 
 // Mirror of PROVIDER_DEFAULTS (config.ts) — shown as placeholders so the user sees the effective model.
-const PROVIDER_DEFAULT_MODEL: Record<'anthropic' | 'openai' | 'ollama', string> = {
+const PROVIDER_DEFAULT_MODEL: Record<'anthropic' | 'openai' | 'ollama' | 'amazon-bedrock', string> = {
   anthropic: 'claude-sonnet-4-6',
   openai: 'gpt-4o',
   ollama: 'llama3.1',
+  // Mirror of DEFAULT_BEDROCK_MODEL (ai-runtime.ts).
+  'amazon-bedrock': 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
 };
 const OLLAMA_DEFAULT_BASE_URL = 'http://localhost:11434/v1';
 // Mirror of DEFAULT_CLI_MODELS (config.ts).
-const CLI_DEFAULT_MODEL: Record<LocalCli, string> = { claude: 'sonnet', codex: '', pi: '' };
+const CLI_DEFAULT_MODEL: Record<LocalCli, string> = {
+  claude: 'sonnet',
+  codex: '',
+  pi: '',
+};
 
 function providerChoiceOf(aiProvider: AiProvider | undefined): ProviderChoice {
-  if (aiProvider === 'anthropic' || aiProvider === 'openai' || aiProvider === 'ollama') return aiProvider;
+  if (
+    aiProvider === 'anthropic' ||
+    aiProvider === 'openai' ||
+    aiProvider === 'ollama' ||
+    aiProvider === 'amazon-bedrock'
+  ) {
+    return aiProvider;
+  }
   return 'local';
 }
 
@@ -69,6 +86,7 @@ export function AiSection() {
             { value: 'anthropic', label: 'Anthropic (Claude)' },
             { value: 'openai', label: 'OpenAI' },
             { value: 'ollama', label: 'Ollama (local)' },
+            { value: 'amazon-bedrock', label: 'Amazon Bedrock' },
           ]}
         />
       </Field>
@@ -79,7 +97,13 @@ export function AiSection() {
         </p>
       )}
 
-      {current === 'local' ? <LocalCliForm /> : <ApiProviderForm key={current} provider={current} />}
+      {current === 'local' ? (
+        <LocalCliForm />
+      ) : current === 'amazon-bedrock' ? (
+        <BedrockProviderForm />
+      ) : (
+        <ApiProviderForm key={current} provider={current} />
+      )}
     </Section>
   );
 }
@@ -174,18 +198,80 @@ function LocalCliForm() {
   );
 }
 
-/** API-provider config: a write-only key (anthropic/openai), a model, and a base URL (ollama). */
+/**
+ * A write-only secret input with the "•••••••• set ✓ / Replace… / Clear" affordance (mirrors the
+ * original API-key block). When a secret is already saved and not being replaced, it shows the masked
+ * state; otherwise it renders a password field. The raw value never leaves the browser except on save.
+ */
+function SecretField({
+  label,
+  htmlFor,
+  hint,
+  error,
+  set,
+  value,
+  onChange,
+  onReplace,
+  onClear,
+  replacing,
+  saving,
+  placeholder,
+}: {
+  label: string;
+  htmlFor: string;
+  hint?: string;
+  error?: string | null;
+  set: boolean;
+  value: string;
+  onChange: (value: string) => void;
+  onReplace: () => void;
+  onClear: () => void;
+  replacing: boolean;
+  saving: boolean;
+  placeholder?: string;
+}) {
+  return replacing || !set ? (
+    <Field label={label} htmlFor={htmlFor} hint={hint} error={error}>
+      <TextInput
+        id={htmlFor}
+        type="password"
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        disabled={saving}
+        ariaLabel={label}
+      />
+    </Field>
+  ) : (
+    <Field label={label}>
+      <span className="font-mono text-[13px] text-[var(--fg-2)]">•••••••• set ✓</span>
+      <GhostButton onClick={onReplace} disabled={saving}>
+        Replace…
+      </GhostButton>
+      <GhostButton onClick={onClear} disabled={saving}>
+        Clear
+      </GhostButton>
+    </Field>
+  );
+}
+
+/**
+ * API-provider config: a write-only key + model (anthropic/openai) or a base URL (ollama).
+ * Amazon Bedrock has its own form ({@link BedrockProviderForm}) — its auth modes and model listing
+ * don't fit the simple key+model shape.
+ */
 function ApiProviderForm({ provider }: { provider: 'anthropic' | 'openai' | 'ollama' }) {
   const serverConfig = useReviewStore((s) => s.serverConfig);
   const applyConfigResponse = useReviewStore((s) => s.applyConfigResponse);
-  const keySet = serverConfig?.aiApiKeySet ?? false;
-  const usesKey = provider !== 'ollama';
+  const usesKey = provider === 'anthropic' || provider === 'openai';
   const usesBaseUrl = provider === 'ollama';
+  const keySet = serverConfig?.aiApiKeySet ?? false;
 
   const [model, setModel] = useState(serverConfig?.aiModel ?? '');
   const [baseUrl, setBaseUrl] = useState(serverConfig?.aiBaseUrl ?? '');
   const [apiKey, setApiKey] = useState('');
   const [replacingKey, setReplacingKey] = useState(false);
+
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [testing, setTesting] = useState(false);
@@ -194,6 +280,7 @@ function ApiProviderForm({ provider }: { provider: 'anthropic' | 'openai' | 'oll
   const savedModel = serverConfig?.aiModel ?? '';
   const savedBaseUrl = serverConfig?.aiBaseUrl ?? '';
   const editingKey = usesKey && (replacingKey || !keySet);
+
   const dirty = model !== savedModel || (usesBaseUrl && baseUrl !== savedBaseUrl) || apiKey.length > 0;
 
   async function save() {
@@ -253,35 +340,22 @@ function ApiProviderForm({ provider }: { provider: 'anthropic' | 'openai' | 'oll
 
   return (
     <>
-      {usesKey &&
-        (editingKey ? (
-          <Field
-            label="API key"
-            htmlFor="ai-key"
-            hint="Stored write-only. Leave blank to use the provider's environment variable."
-            error={error}
-          >
-            <TextInput
-              id="ai-key"
-              type="password"
-              value={apiKey}
-              onChange={setApiKey}
-              placeholder="sk-…"
-              disabled={saving}
-              ariaLabel="API key"
-            />
-          </Field>
-        ) : (
-          <Field label="API key">
-            <span className="font-mono text-[13px] text-[var(--fg-2)]">•••••••• set ✓</span>
-            <GhostButton onClick={() => setReplacingKey(true)} disabled={saving}>
-              Replace…
-            </GhostButton>
-            <GhostButton onClick={() => void clearKey()} disabled={saving}>
-              Clear
-            </GhostButton>
-          </Field>
-        ))}
+      {usesKey && (
+        <SecretField
+          label="API key"
+          htmlFor="ai-key"
+          hint="Stored write-only. Leave blank to use the provider's environment variable."
+          error={editingKey ? error : undefined}
+          set={keySet}
+          value={apiKey}
+          onChange={setApiKey}
+          onReplace={() => setReplacingKey(true)}
+          onClear={() => void clearKey()}
+          replacing={replacingKey}
+          saving={saving}
+          placeholder="sk-…"
+        />
+      )}
 
       {usesBaseUrl && (
         <Field label="Base URL" htmlFor="ai-baseurl">
@@ -331,6 +405,467 @@ function ApiProviderForm({ provider }: { provider: 'anthropic' | 'openai' | 'oll
           setBaseUrl(savedBaseUrl);
           setApiKey('');
           setReplacingKey(false);
+          setError(null);
+        }}
+      />
+    </>
+  );
+}
+
+type BedrockAuthMode = 'profile' | 'keys' | 'api-key';
+
+/** Which auth mode a saved config represents — same precedence as `resolveBedrockCreds` (CLI side). */
+function bedrockAuthModeOf(config: { aiBedrockApiKeySet?: boolean; aiAccessKeyId?: string } | null): BedrockAuthMode {
+  if (config?.aiBedrockApiKeySet) return 'api-key';
+  return config?.aiAccessKeyId ? 'keys' : 'profile';
+}
+
+/**
+ * Amazon Bedrock config: three auth modes (AWS profile / access key & secret / Bedrock API key), a
+ * model picker fed by a live "Load models" call with a free-text fallback (invoke and list are two
+ * distinct IAM permissions, so listing can fail for accounts that can still invoke), and load/test
+ * requests that mirror save()'s clearing semantics so they can never silently run against another
+ * mode's saved credentials.
+ */
+function BedrockProviderForm() {
+  const serverConfig = useReviewStore((s) => s.serverConfig);
+  const applyConfigResponse = useReviewStore((s) => s.applyConfigResponse);
+  const secretKeySet = serverConfig?.aiSecretAccessKeySet ?? false;
+  const bedrockKeySet = serverConfig?.aiBedrockApiKeySet ?? false;
+
+  // Auth mode is derived from the saved config; secrets start blank and are write-only.
+  const [authMode, setAuthMode] = useState<BedrockAuthMode>(bedrockAuthModeOf(serverConfig));
+  const [region, setRegion] = useState(serverConfig?.aiRegion ?? '');
+  const [profile, setProfile] = useState(serverConfig?.aiProfile ?? '');
+  const [accessKeyId, setAccessKeyId] = useState(serverConfig?.aiAccessKeyId ?? '');
+  const [secretKey, setSecretKey] = useState('');
+  const [replacingSecret, setReplacingSecret] = useState(false);
+  const [bedrockKey, setBedrockKey] = useState('');
+  const [replacingBedrockKey, setReplacingBedrockKey] = useState(false);
+  const [profiles, setProfiles] = useState<AwsProfile[] | null>(null);
+  const [model, setModel] = useState(serverConfig?.aiModel ?? '');
+  const [modelOptions, setModelOptions] = useState<BedrockModelOption[] | null>(null);
+  const [loadingModels, setLoadingModels] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<TestResult | null>(null);
+
+  // Enumerate the machine's AWS profiles once, for the profile dropdown. Never throws (empty on failure).
+  useEffect(() => {
+    let live = true;
+    void listAwsProfiles().then((p) => {
+      if (live) setProfiles(p);
+    });
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  const savedModel = serverConfig?.aiModel ?? '';
+  const savedRegion = serverConfig?.aiRegion ?? '';
+  const savedProfile = serverConfig?.aiProfile ?? '';
+  const savedAccessKeyId = serverConfig?.aiAccessKeyId ?? '';
+
+  // Profile mode can only save with a usable profile: picked, present on this machine, and carrying
+  // a region. A blank profile would wipe working key-mode creds and save nothing in their place; a
+  // not-found or region-less one (e.g. a config synced from another machine) would save fine and
+  // then fail every generation.
+  const selectedProfile = profiles?.find((p) => p.name === profile);
+  const profileIssue =
+    authMode !== 'profile' || profile.length === 0 || profiles === null
+      ? null
+      : !selectedProfile
+        ? 'This profile wasn’t found on this machine — pick one from the list.'
+        : !selectedProfile.region
+          ? 'This profile has no region. Add a region to it in ~/.aws/config, or use access key & secret.'
+          : null;
+  const profileBlocked =
+    authMode === 'profile' &&
+    (profile.length === 0 || profiles === null || !selectedProfile || !selectedProfile.region);
+
+  // API-key mode with no key saved and none typed: saving would clear the other modes' creds and
+  // put nothing in their place. Same shape as profileBlocked.
+  const apiKeyBlocked = authMode === 'api-key' && !bedrockKeySet && bedrockKey.length === 0;
+
+  const credsDirty =
+    authMode === 'profile'
+      ? profile !== savedProfile
+      : authMode === 'api-key'
+        ? region !== savedRegion || bedrockKey.length > 0
+        : region !== savedRegion || accessKeyId !== savedAccessKeyId || secretKey.length > 0;
+  const hasEdits = credsDirty || model !== savedModel;
+  const dirty = hasEdits && !profileBlocked && !apiKeyBlocked;
+
+  /**
+   * The full candidate credential state for the selected mode, mirroring save()'s clears: the other
+   * modes' fields ride along as '' so the server overlay can't fall back to saved creds from those
+   * modes. An API key outranks explicit keys, which outrank a profile, in resolveBedrockCreds — so
+   * any lingering saved credential from another mode would otherwise silently hijack loads and tests.
+   */
+  function credOverlay() {
+    if (authMode === 'profile') {
+      return { aiProfile: profile, aiRegion: '', aiAccessKeyId: '', aiSecretAccessKey: '', aiBedrockApiKey: '' };
+    }
+    if (authMode === 'api-key') {
+      return {
+        aiRegion: region,
+        // Omitted (not cleared) when blank: the saved write-only key stays in play, like save().
+        ...(bedrockKey.length > 0 ? { aiBedrockApiKey: bedrockKey } : {}),
+        aiProfile: '',
+        aiAccessKeyId: '',
+        aiSecretAccessKey: '',
+      };
+    }
+    return {
+      aiRegion: region,
+      aiAccessKeyId: accessKeyId,
+      // Omitted (not cleared) when blank: the saved write-only secret stays in play, like save().
+      ...(secretKey.length > 0 ? { aiSecretAccessKey: secretKey } : {}),
+      aiProfile: '',
+      aiBedrockApiKey: '',
+    };
+  }
+
+  // Changing creds/region (or the auth mode) invalidates a loaded model list, and a model picked
+  // from that list may not exist under the new creds — drop it back to the saved one. A free-typed
+  // id (no list loaded) is kept; it was never tied to a listing.
+  function invalidateModelList() {
+    if (modelOptions !== null && model !== savedModel) setModel(savedModel);
+    setModelOptions(null);
+    setLoadError(null);
+  }
+
+  function changeCred(setter: (value: string) => void) {
+    return (value: string) => {
+      setter(value);
+      invalidateModelList();
+    };
+  }
+
+  function changeAuthMode(mode: BedrockAuthMode) {
+    setAuthMode(mode);
+    invalidateModelList();
+  }
+
+  async function loadModels() {
+    setLoadingModels(true);
+    setLoadError(null);
+    setModelOptions(null);
+    try {
+      const { models, region: resolvedRegion } = await listBedrockModels(credOverlay());
+      setModelOptions(models);
+      // Key / API-key modes: prefill the region the server resolved when the user left it blank.
+      // Profile mode has no region field (the profile supplies it), so nothing to prefill there.
+      if (authMode !== 'profile' && resolvedRegion && region.trim() === '') setRegion(resolvedRegion);
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : 'Failed to load models');
+    } finally {
+      setLoadingModels(false);
+    }
+  }
+
+  async function save() {
+    if (saving || !dirty) return;
+    setSaving(true);
+    setError(null);
+    setTestResult(null);
+    try {
+      const patch: ConfigPatch = {};
+      // Each mode clears the other modes' saved creds so precedence (api-key > keys > profile)
+      // can't resurrect them.
+      if (authMode === 'profile') {
+        patch.aiProfile = profile;
+        if (savedRegion) patch.aiRegion = '';
+        if (savedAccessKeyId) patch.aiAccessKeyId = '';
+        if (secretKeySet) patch.aiSecretAccessKey = '';
+        if (bedrockKeySet) patch.aiBedrockApiKey = '';
+      } else if (authMode === 'api-key') {
+        if (region !== savedRegion) patch.aiRegion = region;
+        if (bedrockKey.length > 0) patch.aiBedrockApiKey = bedrockKey;
+        if (savedProfile) patch.aiProfile = '';
+        if (savedAccessKeyId) patch.aiAccessKeyId = '';
+        if (secretKeySet) patch.aiSecretAccessKey = '';
+      } else {
+        if (region !== savedRegion) patch.aiRegion = region;
+        if (accessKeyId !== savedAccessKeyId) patch.aiAccessKeyId = accessKeyId;
+        if (secretKey.length > 0) patch.aiSecretAccessKey = secretKey;
+        if (savedProfile) patch.aiProfile = '';
+        if (bedrockKeySet) patch.aiBedrockApiKey = '';
+      }
+      if (model !== savedModel) patch.aiModel = model;
+      applyConfigResponse(await saveConfig(patch));
+      setSecretKey('');
+      setReplacingSecret(false);
+      setBedrockKey('');
+      setReplacingBedrockKey(false);
+    } catch (e) {
+      setError(isSaveError(e) ? (Object.values(e.fields)[0] ?? 'Save failed') : 'Save failed — check your connection.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function clearSecret() {
+    if (!window.confirm('Remove the saved secret access key?')) return;
+    setSaving(true);
+    setError(null);
+    try {
+      applyConfigResponse(await saveConfig({ aiSecretAccessKey: '' }));
+      setSecretKey('');
+      setReplacingSecret(false);
+    } catch (e) {
+      setError(
+        isSaveError(e) ? (Object.values(e.fields)[0] ?? 'Clear failed') : 'Clear failed — check your connection.',
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function clearBedrockKey() {
+    if (!window.confirm('Remove the saved Bedrock API key?')) return;
+    setSaving(true);
+    setError(null);
+    try {
+      applyConfigResponse(await saveConfig({ aiBedrockApiKey: '' }));
+      setBedrockKey('');
+      setReplacingBedrockKey(false);
+    } catch (e) {
+      setError(
+        isSaveError(e) ? (Object.values(e.fields)[0] ?? 'Clear failed') : 'Clear failed — check your connection.',
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function runTest() {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      setTestResult(
+        await testConnection({
+          kind: 'ai',
+          aiProvider: 'amazon-bedrock',
+          aiModel: model.length > 0 ? model : undefined,
+          ...credOverlay(),
+        }),
+      );
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  return (
+    <>
+      <Field label="Credentials" htmlFor="ai-auth-mode" hint="How Dad authenticates to Bedrock.">
+        <Select<BedrockAuthMode>
+          id="ai-auth-mode"
+          value={authMode}
+          onChange={changeAuthMode}
+          options={[
+            { value: 'profile', label: 'AWS profile' },
+            { value: 'api-key', label: 'Bedrock API key' },
+            { value: 'keys', label: 'Access key & secret' },
+          ]}
+        />
+      </Field>
+
+      {authMode === 'profile' ? (
+        profiles !== null && profiles.length === 0 ? (
+          <p className="text-[12px] leading-snug text-[var(--fg-3)]">
+            No AWS profiles found on this machine. Switch to “Access key & secret”, or add a profile to ~/.aws/config.
+          </p>
+        ) : (
+          <>
+            <Field
+              label="Profile"
+              htmlFor="ai-profile"
+              hint="A named profile from ~/.aws. Dad uses it and its region."
+              error={profileIssue}
+            >
+              <Select
+                id="ai-profile"
+                value={profile}
+                onChange={changeCred(setProfile)}
+                disabled={saving || profiles === null}
+                ariaLabel="AWS profile"
+                options={[
+                  ...(profile === ''
+                    ? [
+                        {
+                          value: '',
+                          label: profiles === null ? 'Loading profiles…' : 'Select a profile…',
+                        },
+                      ]
+                    : []),
+                  ...(profile !== '' && profiles && !profiles.some((p) => p.name === profile)
+                    ? [{ value: profile, label: `${profile} (not found)` }]
+                    : []),
+                  ...(profiles ?? []).map((p) => ({
+                    value: p.name,
+                    label: p.region ? `${p.name} (${p.region})` : `${p.name} (no region)`,
+                  })),
+                ]}
+              />
+            </Field>
+            {profile.length === 0 && hasEdits && (
+              <p className="text-[12px] leading-snug text-[var(--fg-3)]">Select a profile to enable Save.</p>
+            )}
+          </>
+        )
+      ) : (
+        <>
+          <Field label="Region" htmlFor="ai-region" hint="AWS region for Bedrock (e.g. us-east-1).">
+            <TextInput
+              id="ai-region"
+              value={region}
+              onChange={changeCred(setRegion)}
+              placeholder="us-east-1"
+              disabled={saving}
+              ariaLabel="Region"
+            />
+          </Field>
+
+          {authMode === 'api-key' ? (
+            <>
+              <SecretField
+                label="API key"
+                htmlFor="ai-bedrock-api-key"
+                hint="A Bedrock API key (bearer token) from the Bedrock console. Stored write-only."
+                set={bedrockKeySet}
+                value={bedrockKey}
+                onChange={changeCred(setBedrockKey)}
+                onReplace={() => setReplacingBedrockKey(true)}
+                onClear={() => void clearBedrockKey()}
+                replacing={replacingBedrockKey}
+                saving={saving}
+                placeholder="bedrock-api-key-…"
+              />
+              {apiKeyBlocked && hasEdits && (
+                <p className="text-[12px] leading-snug text-[var(--fg-3)]">Enter an API key to enable Save.</p>
+              )}
+            </>
+          ) : (
+            <>
+              <Field label="Access key ID" htmlFor="ai-access-key-id">
+                <TextInput
+                  id="ai-access-key-id"
+                  value={accessKeyId}
+                  onChange={changeCred(setAccessKeyId)}
+                  placeholder="AKIA…"
+                  disabled={saving}
+                  ariaLabel="Access key ID"
+                />
+              </Field>
+
+              <SecretField
+                label="Secret access key"
+                htmlFor="ai-secret-key"
+                hint="Stored write-only."
+                set={secretKeySet}
+                value={secretKey}
+                onChange={changeCred(setSecretKey)}
+                onReplace={() => setReplacingSecret(true)}
+                onClear={() => void clearSecret()}
+                replacing={replacingSecret}
+                saving={saving}
+                placeholder="••••"
+              />
+            </>
+          )}
+        </>
+      )}
+
+      <Field
+        label="Model"
+        htmlFor="ai-bedrock-model"
+        hint={
+          modelOptions
+            ? 'Pick from the models available to your account.'
+            : 'Load the models available to your account, or type a model id. Blank uses the default.'
+        }
+      >
+        {modelOptions ? (
+          <Select
+            id="ai-bedrock-model"
+            value={model}
+            onChange={setModel}
+            disabled={saving}
+            ariaLabel="Model"
+            options={[
+              ...(model === '' ? [{ value: '', label: 'Select a model…' }] : []),
+              ...(model !== '' && !modelOptions.some((o) => o.id === model)
+                ? [{ value: model, label: `${model} (saved)` }]
+                : []),
+              ...modelOptions.map((o) => ({ value: o.id, label: o.label })),
+            ]}
+          />
+        ) : (
+          <>
+            <TextInput
+              id="ai-bedrock-model"
+              value={model}
+              onChange={setModel}
+              placeholder={PROVIDER_DEFAULT_MODEL['amazon-bedrock']}
+              disabled={saving}
+              ariaLabel="Model"
+            />
+            <GhostButton onClick={() => void loadModels()} disabled={loadingModels || saving}>
+              {loadingModels ? 'Loading…' : 'Load models'}
+            </GhostButton>
+          </>
+        )}
+      </Field>
+
+      {modelOptions && (
+        <div className="flex justify-end">
+          <GhostButton onClick={() => void loadModels()} disabled={loadingModels || saving}>
+            {loadingModels ? 'Loading…' : 'Reload models'}
+          </GhostButton>
+        </div>
+      )}
+
+      {loadError && (
+        <p role="alert" className="text-[12px] font-medium" style={{ color: 'var(--red-11)' }}>
+          {loadError}
+        </p>
+      )}
+
+      {error && (
+        <p role="alert" className="text-[12px] font-medium" style={{ color: 'var(--red-11)' }}>
+          {error}
+        </p>
+      )}
+
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <GhostButton onClick={() => void runTest()} disabled={testing}>
+            {testing ? 'Testing…' : 'Test connection'}
+          </GhostButton>
+        </div>
+        <TestResultLine result={testResult} />
+      </div>
+
+      <SaveBar
+        dirty={dirty}
+        saving={saving}
+        onSave={() => void save()}
+        onCancel={() => {
+          setAuthMode(bedrockAuthModeOf(serverConfig));
+          setRegion(savedRegion);
+          setProfile(savedProfile);
+          setAccessKeyId(savedAccessKeyId);
+          setSecretKey('');
+          setReplacingSecret(false);
+          setBedrockKey('');
+          setReplacingBedrockKey(false);
+          setModel(savedModel);
+          setModelOptions(null);
+          setLoadError(null);
           setError(null);
         }}
       />

--- a/packages/web/src/hooks/useLiveStream.ts
+++ b/packages/web/src/hooks/useLiveStream.ts
@@ -194,6 +194,19 @@ export function useLiveStream() {
       }
     };
 
+    const onNarrativeError = (e: MessageEvent) => {
+      try {
+        const data = JSON.parse(e.data) as { message: string };
+        // Only a successful `narrative` event clears `regenerating`; without this the spinner would spin
+        // forever after a failed regeneration. Surface the reason in the activity feed too.
+        useReviewStore.getState().setRegenerating(false);
+        addLiveEvent(makeEvent('system', `Narrative generation failed: ${data.message}`));
+        setLastEventAt(Date.now());
+      } catch {
+        // ignore
+      }
+    };
+
     const onNarrative = (e: MessageEvent) => {
       try {
         const data = JSON.parse(e.data) as {
@@ -278,6 +291,7 @@ export function useLiveStream() {
     es.addEventListener('units', onUnits as EventListener);
     es.addEventListener('regenerating', onRegenerating as EventListener);
     es.addEventListener('narrative-progress', onNarrativeProgress as EventListener);
+    es.addEventListener('narrative-error', onNarrativeError as EventListener);
     es.addEventListener('narrative.partial', handleNarrativePartialEvent as EventListener);
     es.addEventListener('narrative', onNarrative as EventListener);
     es.addEventListener('plan-ready', onPlanReady as EventListener);
@@ -306,6 +320,7 @@ export function useLiveStream() {
       es.removeEventListener('units', onUnits as EventListener);
       es.removeEventListener('regenerating', onRegenerating as EventListener);
       es.removeEventListener('narrative-progress', onNarrativeProgress as EventListener);
+      es.removeEventListener('narrative-error', onNarrativeError as EventListener);
       es.removeEventListener('narrative.partial', handleNarrativePartialEvent as EventListener);
       es.removeEventListener('narrative', onNarrative as EventListener);
       es.removeEventListener('plan-ready', onPlanReady as EventListener);

--- a/packages/web/src/lib/__tests__/config-client.test.ts
+++ b/packages/web/src/lib/__tests__/config-client.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { fetchConfig, isSaveError, saveConfig, testConnection, type ConfigResponse } from '../config-client';
+import {
+  type ConfigResponse,
+  fetchConfig,
+  isSaveError,
+  listAwsProfiles,
+  listBedrockModels,
+  saveConfig,
+  testConnection,
+} from '../config-client';
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
@@ -7,7 +15,15 @@ function jsonResponse(body: unknown, status = 200): Response {
 
 function mkResponse(over: Partial<ConfigResponse> = {}): ConfigResponse {
   return {
-    config: { githubTokenSet: false, aiApiKeySet: false, theme: 'auto', accent: 'classic', ...over.config },
+    config: {
+      githubTokenSet: false,
+      aiApiKeySet: false,
+      aiSecretAccessKeySet: false,
+      aiBedrockApiKeySet: false,
+      theme: 'auto',
+      accent: 'classic',
+      ...over.config,
+    },
     github: over.github ?? { active: false, source: null },
   };
 }
@@ -33,11 +49,19 @@ describe('fetchConfig', () => {
 
 describe('saveConfig', () => {
   it('PUTs a one-key patch as JSON and returns the fresh response', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(
-        jsonResponse(mkResponse({ config: { githubTokenSet: false, aiApiKeySet: false, theme: 'dark' } })),
-      );
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(
+        mkResponse({
+          config: {
+            githubTokenSet: false,
+            aiApiKeySet: false,
+            aiSecretAccessKeySet: false,
+            aiBedrockApiKeySet: false,
+            theme: 'dark',
+          },
+        }),
+      ),
+    );
     vi.stubGlobal('fetch', fetchMock);
     const res = await saveConfig({ theme: 'dark' });
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -93,5 +117,52 @@ describe('testConnection', () => {
     const res = await testConnection({ kind: 'ai' });
     expect(res.ok).toBe(false);
     expect(res.detail).toMatch(/500/);
+  });
+});
+
+describe('listBedrockModels', () => {
+  it('POSTs the region/creds body and returns the models + resolved region on 200', async () => {
+    const models = [
+      { id: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0', label: 'Claude Sonnet 4.5' },
+      { id: 'us.meta.llama3-1-70b-instruct-v1:0', label: 'Llama 3.1 70B' },
+    ];
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ models, region: 'us-east-1' }));
+    vi.stubGlobal('fetch', fetchMock);
+    const res = await listBedrockModels({ aiProfile: 'my-sso' });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('/api/config/bedrock/models');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({ aiProfile: 'my-sso' });
+    // The resolved region rides along so the caller can prefill the region field.
+    expect(res).toEqual({ models, region: 'us-east-1' });
+  });
+
+  it('throws with the server error message on a non-2xx (e.g. the 502 AWS-failure path)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(jsonResponse({ error: 'The security token included in the request is invalid.' }, 502)),
+    );
+    await expect(listBedrockModels({ aiRegion: 'us-east-1' })).rejects.toThrow(/security token/);
+  });
+
+  it('falls back to an HTTP-status message when a failure omits an error body', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status: 500 })));
+    await expect(listBedrockModels({})).rejects.toThrow(/HTTP 500/);
+  });
+});
+
+describe('listAwsProfiles', () => {
+  it('GETs the profiles endpoint and returns the profile array', async () => {
+    const profiles = [{ name: 'default', region: 'us-east-1' }, { name: 'platform-dev' }];
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ profiles }));
+    vi.stubGlobal('fetch', fetchMock);
+    const res = await listAwsProfiles();
+    expect(fetchMock).toHaveBeenCalledWith('/api/config/aws/profiles');
+    expect(res).toEqual(profiles);
+  });
+
+  it('returns an empty list on a non-2xx rather than throwing', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status: 500 })));
+    expect(await listAwsProfiles()).toEqual([]);
   });
 });

--- a/packages/web/src/lib/__tests__/config-client.test.ts
+++ b/packages/web/src/lib/__tests__/config-client.test.ts
@@ -153,7 +153,7 @@ describe('listBedrockModels', () => {
 
 describe('listAwsProfiles', () => {
   it('GETs the profiles endpoint and returns the profile array', async () => {
-    const profiles = [{ name: 'default', region: 'us-east-1' }, { name: 'platform-dev' }];
+    const profiles = [{ name: 'default', region: 'us-east-1' }, { name: 'staging' }];
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ profiles }));
     vi.stubGlobal('fetch', fetchMock);
     const res = await listAwsProfiles();

--- a/packages/web/src/lib/config-client.ts
+++ b/packages/web/src/lib/config-client.ts
@@ -13,7 +13,7 @@ export type StoryStructure = 'chapters' | 'linear' | 'outline';
 export type LayoutMode = 'toc' | 'linear';
 export type DisplayDensity = 'comfortable' | 'compact';
 export type NarrationDensity = 'terse' | 'normal' | 'verbose';
-export type AiProvider = 'anthropic' | 'openai' | 'openai-compatible' | 'ollama';
+export type AiProvider = 'anthropic' | 'openai' | 'openai-compatible' | 'ollama' | 'amazon-bedrock';
 export type LocalCli = 'claude' | 'codex' | 'pi';
 export type GitHubTokenSource = 'env' | 'gh' | 'config' | null;
 
@@ -21,9 +21,14 @@ export type GitHubTokenSource = 'env' | 'gh' | 'config' | null;
 export interface RedactedConfig {
   githubTokenSet: boolean;
   aiApiKeySet: boolean;
+  aiSecretAccessKeySet: boolean;
+  aiBedrockApiKeySet: boolean;
   aiProvider?: AiProvider;
   aiModel?: string;
   aiBaseUrl?: string;
+  aiRegion?: string;
+  aiProfile?: string;
+  aiAccessKeyId?: string;
   defaultCli?: LocalCli;
   cliModels?: Partial<Record<LocalCli, string>>;
   storyStructure?: StoryStructure;
@@ -55,6 +60,11 @@ export type ConfigPatch = Partial<{
   aiApiKey: string;
   aiModel: string;
   aiBaseUrl: string;
+  aiRegion: string;
+  aiProfile: string;
+  aiAccessKeyId: string;
+  aiSecretAccessKey: string;
+  aiBedrockApiKey: string;
   defaultCli: LocalCli;
   cliModels: Partial<Record<LocalCli, string>>;
   storyStructure: StoryStructure;
@@ -85,12 +95,29 @@ export type TestRequest =
       aiApiKey?: string;
       aiModel?: string;
       aiBaseUrl?: string;
+      aiRegion?: string;
+      aiProfile?: string;
+      aiAccessKeyId?: string;
+      aiSecretAccessKey?: string;
+      aiBedrockApiKey?: string;
       defaultCli?: LocalCli;
     };
 
 export interface TestResult {
   ok: boolean;
   detail: string;
+}
+
+/** One entry in the Bedrock model dropdown — `id` is the invoke id, `label` a display name. */
+export interface BedrockModelOption {
+  id: string;
+  label: string;
+}
+
+/** An AWS profile discovered on the machine — `region` is absent when the profile sets none. */
+export interface AwsProfile {
+  name: string;
+  region?: string;
 }
 
 /** Bootstrap read — the single source of prefs for both PR and command-center modes. */
@@ -133,4 +160,44 @@ export async function testConnection(body: TestRequest): Promise<TestResult> {
   });
   if (!res.ok) return { ok: false, detail: `test failed: HTTP ${res.status}` };
   return (await res.json()) as TestResult;
+}
+
+/**
+ * List the Bedrock foundation models + inference profiles reachable with the given region/credentials
+ * (Phase 1's `POST /api/config/bedrock/models`). Unlike {@link testConnection}, this throws on any
+ * non-2xx so the Bedrock form renders a single error surface (matching how {@link saveConfig} throws) —
+ * the contract blocks model selection until listing succeeds. Blank fields fall back to the server's
+ * ambient AWS credential chain.
+ */
+export async function listBedrockModels(body: {
+  aiRegion?: string;
+  aiProfile?: string;
+  aiAccessKeyId?: string;
+  aiSecretAccessKey?: string;
+  aiBedrockApiKey?: string;
+}): Promise<{ models: BedrockModelOption[]; region?: string }> {
+  const res = await fetch('/api/config/bedrock/models', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const detail = ((await res.json().catch(() => ({}))) as { error?: string }).error ?? `HTTP ${res.status}`;
+    throw new Error(detail);
+  }
+  // `region` is what the server's SDK actually resolved (from the profile / chain when blank) — the UI
+  // prefills the region field with it so a profile-only user sees and can persist a concrete region.
+  const data = (await res.json()) as { models: BedrockModelOption[]; region?: string };
+  return { models: data.models, region: data.region };
+}
+
+/**
+ * List the AWS profiles available on the machine (name + region) so the Bedrock form can offer a
+ * profile dropdown. Never throws — a non-2xx yields an empty list, which the UI treats as "no
+ * profiles" (steering the user to the access-key/secret mode).
+ */
+export async function listAwsProfiles(): Promise<AwsProfile[]> {
+  const res = await fetch('/api/config/aws/profiles');
+  if (!res.ok) return [];
+  return ((await res.json()) as { profiles: AwsProfile[] }).profiles;
 }

--- a/packages/web/src/state/__tests__/config-actions.test.ts
+++ b/packages/web/src/state/__tests__/config-actions.test.ts
@@ -11,6 +11,8 @@ function mkConfigResponse(over: Partial<ConfigResponse> = {}): ConfigResponse {
     config: {
       githubTokenSet: false,
       aiApiKeySet: false,
+      aiSecretAccessKeySet: false,
+      aiBedrockApiKeySet: false,
       theme: 'dark',
       accent: 'forest',
       storyStructure: 'linear',
@@ -69,7 +71,7 @@ describe('applyConfigResponse', () => {
 
   it('does not clobber a good default when a key is absent from the config', () => {
     useReviewStore.getState().applyConfigResponse({
-      config: { githubTokenSet: false, aiApiKeySet: false },
+      config: { githubTokenSet: false, aiApiKeySet: false, aiSecretAccessKeySet: false, aiBedrockApiKeySet: false },
       github: { active: false, source: null },
     });
     const s = useReviewStore.getState();
@@ -81,11 +83,19 @@ describe('applyConfigResponse', () => {
 
 describe('setTheme write-through', () => {
   it('flips the store optimistically AND issues exactly one PUT with a one-key body', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(
-        jsonResponse(mkConfigResponse({ config: { githubTokenSet: false, aiApiKeySet: false, theme: 'dark' } })),
-      );
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(
+        mkConfigResponse({
+          config: {
+            githubTokenSet: false,
+            aiApiKeySet: false,
+            aiSecretAccessKeySet: false,
+            aiBedrockApiKeySet: false,
+            theme: 'dark',
+          },
+        }),
+      ),
+    );
     vi.stubGlobal('fetch', fetchMock);
 
     useReviewStore.getState().setTheme('dark');


### PR DESCRIPTION
## What

Adds **Amazon Bedrock** as a first-class, selectable AI provider alongside Anthropic, OpenAI, and Ollama. Teams who reach Claude through Bedrock can now use Diff Dad with their own AWS credentials, wired through the same `callAi()` entry point as the other providers.

## Why

Every existing provider fits one config shape: an API key, a model string, an optional base URL. Bedrock doesn't. Access can be AWS-shaped (a region plus an IAM key/secret pair, a named profile, or an ambient credential chain) or a Bedrock bearer API key, and the newest Claude models are reachable only through cross-region inference profiles. The existing abstraction couldn't represent any of that.

## Ways to authenticate

Four modes, resolved highest-priority first in `resolveBedrockCreds`. The settings form keeps them mutually exclusive on save; the precedence only decides hand-edited configs.

1. **Bedrock API key (bearer token)** — requests use `Authorization: Bearer`, no SigV4. Built for IAM Identity Center orgs that can't mint long-term SigV4 keys and whose temporary SSO creds don't fit a key/secret form. The bearer key lives in its own `aiBedrockApiKey` secret (not the shared `aiApiKey`) so another provider's lingering key can never flip the Bedrock auth mode.
2. **Explicit access key id + secret** — standard SigV4, entered in settings.
3. **Named AWS profile** from `~/.aws` (SSO profiles included).
4. **Ambient AWS chain** — env vars, `AWS_PROFILE`, IAM role — for configs written by hand.

Region resolves from the profile / chain when left blank, so profile-based setups never hand-enter a region. The AWS secret and the Bedrock API key are both write-only, redacted by the config API like the existing API keys.

## How it works

### Models
The dropdown merges `ListFoundationModels` (TEXT) with `ListInferenceProfiles`. Foundation models that only support `INFERENCE_PROFILE` (not on-demand invocation) are filtered out, so the list only offers ids that can actually be invoked. Current Claude models are exactly this case: they appear as their `us.*` / `global.*` inference profiles.

### Bearer-token wiring
Auth maps through two lockstep helpers in `bedrock-models.ts`: `toListClientAuth` gives the raw `BedrockClient` token config, and `toInvokeAuth` gives `createAmazonBedrock` its settings. For bearer mode that means a dummy identity to satisfy the v2 provider's unconditional SigV4 signer, plus an inner `fetch` that swaps the real bearer header in on the wire (native `apiKey` support only landed in the v3 / `ai@5` line).

### Settings UI
- Amazon Bedrock provider option
- A three-way credentials selector: **AWS profile**, **access key & secret**, or **Bedrock API key**
- Profile mode picks from a dropdown of the machine's profiles, each labeled with its region
- Key mode takes region, access key id, and secret access key
- API-key mode takes region plus the Bedrock bearer key
- Model dropdown gated behind an explicit "Load models"

New routes: `POST /api/config/bedrock/models`, `GET /api/config/aws/profiles`, plus Bedrock support in `POST /api/config/test`.

## Testing

Unit tests cover credential resolution across all four modes (including precedence and the lone-access-key fall-through), region inference, model merging/filtering, bearer-token list/invoke auth mapping, AWS profile enumeration, config schema + redaction of both secrets, and the web client helpers.

- CLI tests, web vitest, lint, typecheck (cli + web), and build all pass.
- Verified end to end against a live Bedrock account: SSO profile enumeration, region inference, model listing/filtering, and narrative generation; plus bearer-token model listing and invoke through `/api/config/test` (and a bad key failing fast with AWS's auth message) against `us-east-1`.

## Notes

- Adds `@ai-sdk/amazon-bedrock`, `@aws-sdk/client-bedrock`, `@aws-sdk/credential-providers`, `@smithy/shared-ini-file-loader`.
- Out of scope (possible follow-ups): Bedrock prompt caching, Bedrock as an eval judge provider.
