### PR TITLE
fix: stop losing reviews mid-flight and quiet false-positive narrative validation

### DIFF
--- a/packages/cli/src/__tests__/validator.test.ts
+++ b/packages/cli/src/__tests__/validator.test.ts
@@ -74,6 +74,41 @@ describe('validateNarrative', () => {
     expect(dups[0]).toMatchObject({ file: 'a.ts', hunkIndex: 0, chapters: [0, 1] });
   });
 
+  it('does not flag duplicate-primary when one chapter re-windows the same hunk in multiple sections', () => {
+    const files = [file('a.ts', 1)];
+    const n = narrative([
+      {
+        title: '1',
+        summary: '',
+        whyMatters: '',
+        risk: 'low',
+        // Progressive reveal of one big hunk — the writer prompt tells the model to do exactly this.
+        sections: [diffSection('a.ts', 0), diffSection('a.ts', 0), diffSection('a.ts', 0)],
+      },
+    ]);
+    const r = validateNarrative(n, files);
+    expect(findKind(r.violations, 'duplicate-primary')).toHaveLength(0);
+    expect(r.ok).toBe(true);
+  });
+
+  it('lists each chapter once when a cross-chapter duplicate is also re-windowed', () => {
+    const files = [file('a.ts', 1)];
+    const n = narrative([
+      {
+        title: '1',
+        summary: '',
+        whyMatters: '',
+        risk: 'low',
+        sections: [diffSection('a.ts', 0), diffSection('a.ts', 0)],
+      },
+      { title: '2', summary: '', whyMatters: '', risk: 'low', sections: [diffSection('a.ts', 0)] },
+    ]);
+    const r = validateNarrative(n, files);
+    const dups = findKind(r.violations, 'duplicate-primary');
+    expect(dups).toHaveLength(1);
+    expect(dups[0]!.chapters).toEqual([0, 1]); // distinct chapters, not one entry per section
+  });
+
   it('flags orphan-hunk for hunks no chapter references', () => {
     const files = [file('a.ts', 3)];
     const n = narrative([{ title: '1', summary: '', whyMatters: '', risk: 'low', sections: [diffSection('a.ts', 0)] }]);

--- a/packages/cli/src/__tests__/writer.test.ts
+++ b/packages/cli/src/__tests__/writer.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { buildSuppressedChapter, normalizeChapter, parseChapterResponse } from '../narrative/writer';
 import type { PlanTheme } from '../narrative/plan-types';
+import type { DiffFile, DiffHunk } from '../github/types';
 
 const baseTheme: PlanTheme = {
   id: 'theme-0',
@@ -12,6 +13,25 @@ const baseTheme: PlanTheme = {
     { file: 'src/middleware.ts', hunkIndex: 2 },
   ],
 };
+
+function hunk(o: Partial<DiffHunk> = {}): DiffHunk {
+  return { header: '@@', oldStart: 1, oldCount: 1, newStart: 1, newCount: 1, lines: [], ...o };
+}
+
+const themeFiles: DiffFile[] = [
+  {
+    file: 'src/auth.ts',
+    isNewFile: false,
+    isDeleted: false,
+    hunks: [hunk({ newStart: 10, newCount: 8 })],
+  },
+  {
+    file: 'src/middleware.ts',
+    isNewFile: false,
+    isDeleted: false,
+    hunks: [hunk(), hunk(), hunk({ newStart: 30, newCount: 4 })],
+  },
+];
 
 describe('normalizeChapter', () => {
   it('keeps narrative and valid diff sections, drops fabricated diff refs', () => {
@@ -45,13 +65,76 @@ describe('normalizeChapter', () => {
     expect(out.risk).toBe('high');
   });
 
-  it('coerces missing fields to safe defaults', () => {
+  it('coerces missing fields to safe defaults (planned hunks still backfilled)', () => {
     const out = normalizeChapter({}, baseTheme);
     expect(out.title).toBe('Auth boundary');
     expect(out.summary).toBe('');
     expect(out.whyMatters).toBe('');
-    expect(out.sections).toEqual([]);
+    // No sections came back at all — the theme's hunks are backfilled so they still surface.
+    expect(out.sections).toEqual([
+      { type: 'diff', file: 'src/auth.ts', hunkIndex: 0, startLine: 1, endLine: 1 },
+      { type: 'diff', file: 'src/middleware.ts', hunkIndex: 2, startLine: 1, endLine: 1 },
+    ]);
     expect(out.themeId).toBe('theme-0');
+  });
+
+  it('backfills a planned hunk the output lost, at the full new-side range', () => {
+    const out = normalizeChapter(
+      {
+        title: 'Auth boundary',
+        sections: [
+          { type: 'narrative', content: 'only covers auth' },
+          { type: 'diff', file: 'src/auth.ts', hunkIndex: 0, startLine: 11, endLine: 14 },
+        ],
+      },
+      baseTheme,
+      themeFiles,
+    );
+    // The writer's own window on auth.ts is preserved verbatim; the lost middleware hunk is
+    // appended spanning its whole new-side range.
+    expect(out.sections).toEqual([
+      { type: 'narrative', content: 'only covers auth' },
+      { type: 'diff', file: 'src/auth.ts', hunkIndex: 0, startLine: 11, endLine: 14 },
+      { type: 'diff', file: 'src/middleware.ts', hunkIndex: 2, startLine: 30, endLine: 33 },
+    ]);
+  });
+
+  it('backfills a deletion-only hunk using the old-side range', () => {
+    const files: DiffFile[] = [
+      { file: 'src/auth.ts', isNewFile: false, isDeleted: false, hunks: [hunk({ newStart: 10, newCount: 8 })] },
+      {
+        file: 'src/middleware.ts',
+        isNewFile: false,
+        isDeleted: false,
+        hunks: [hunk(), hunk(), hunk({ oldStart: 40, oldCount: 6, newCount: 0 })],
+      },
+    ];
+    const out = normalizeChapter(
+      { sections: [{ type: 'diff', file: 'src/auth.ts', hunkIndex: 0, startLine: 10, endLine: 17 }] },
+      baseTheme,
+      files,
+    );
+    expect(out.sections.at(-1)).toEqual({
+      type: 'diff',
+      file: 'src/middleware.ts',
+      hunkIndex: 2,
+      startLine: 40,
+      endLine: 45,
+    });
+  });
+
+  it('does not backfill a hunk the writer covered under an a/-prefixed path', () => {
+    const out = normalizeChapter(
+      {
+        sections: [
+          { type: 'diff', file: 'a/src/auth.ts', hunkIndex: 0, startLine: 1, endLine: 2 },
+          { type: 'diff', file: 'src/middleware.ts', hunkIndex: 2, startLine: 30, endLine: 31 },
+        ],
+      },
+      baseTheme,
+      themeFiles,
+    );
+    expect(out.sections).toHaveLength(2); // normalized paths match — nothing re-appended
   });
 });
 

--- a/packages/cli/src/daemon/__tests__/poller.test.ts
+++ b/packages/cli/src/daemon/__tests__/poller.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { pollOnce } from '../poller';
 import { UnitStore } from '../../units/store';
 import type { PRMetadata } from '../../github/types';
+import type { NarrativeResponse } from '../../narrative/types';
 import type { PolledPr, ReviewUnit } from '../../units/types';
 
 // --- fixtures -------------------------------------------------------------
@@ -329,6 +330,11 @@ function seedUnit(store: UnitStore, over: { number?: number; headSha?: string } 
 const openState = () => Promise.resolve({ open: true });
 const closedState = () => Promise.resolve({ open: false });
 
+/** Minimal walkthrough — what `attachReview` stores when a unit hydrates. */
+function mkNarrative(): NarrativeResponse {
+  return { title: 't', tldr: '', verdict: 'safe', readingPlan: [], concerns: [], chapters: [] };
+}
+
 describe('pollOnce reconciliation', () => {
   it('removes a github unit immediately when its PR is closed/merged', async () => {
     const store = new UnitStore([], det());
@@ -448,6 +454,72 @@ describe('pollOnce reconciliation', () => {
     expect(result.removed).toBe(0);
     expect(store.get(u.unitId)!.status).toBe('approved'); // kept: it's the resurface machinery's memory
     expect(fetched).toBe(0); // present in the search → no direct fetch needed
+  });
+
+  it('never removes an open-but-unrequested unit that is hydrated and undecided (mid-review)', async () => {
+    const store = new UnitStore([], det());
+    const u = seedUnit(store);
+    store.attachReview(u.unitId, [], mkNarrative(), 0); // reviewer opened it — walkthrough generated
+    const streaks = new Map<string, number>();
+
+    // Well past the two-miss threshold: reviewing the PR (comments/review submit) dismisses the
+    // review request on GitHub, so the search stops listing it while the reviewer is still reading.
+    for (let pass = 0; pass < 3; pass++) {
+      const r = await pollOnce({
+        search: search([]),
+        store,
+        broadcast: () => {},
+        fetchPrState: openState,
+        missStreaks: streaks,
+      });
+      expect(r.removed).toBe(0);
+    }
+    expect(store.get(u.unitId)).toBeDefined(); // the walkthrough survives the whole time
+    expect(streaks.size).toBe(0); // no streak accrues against a mid-review unit
+  });
+
+  it('still removes a hydrated mid-review unit when its PR closes', async () => {
+    const store = new UnitStore([], det());
+    const u = seedUnit(store);
+    store.attachReview(u.unitId, [], mkNarrative(), 0);
+
+    const result = await pollOnce({
+      search: search([]),
+      store,
+      broadcast: () => {},
+      fetchPrState: closedState,
+      missStreaks: new Map(),
+    });
+
+    expect(result.removed).toBe(1);
+    expect(store.get(u.unitId)).toBeUndefined(); // closed/merged is unambiguous — the work is moot
+  });
+
+  it('removes a hydrated unit normally once decided (reviewed off-plate)', async () => {
+    const store = new UnitStore([], det());
+    const u = seedUnit(store);
+    store.attachReview(u.unitId, [], mkNarrative(), 0);
+    (store.get(u.unitId) as { decision?: unknown }).decision = { kind: 'approved' };
+    (store.get(u.unitId) as { status: string }).status = 'approved';
+    const streaks = new Map<string, number>();
+
+    const p1 = await pollOnce({
+      search: search([]),
+      store,
+      broadcast: () => {},
+      fetchPrState: openState,
+      missStreaks: streaks,
+    });
+    expect(p1.removed).toBe(0); // first miss — not evidence yet
+    const p2 = await pollOnce({
+      search: search([]),
+      store,
+      broadcast: () => {},
+      fetchPrState: openState,
+      missStreaks: streaks,
+    });
+    expect(p2.removed).toBe(1); // decided units keep the two-miss cleanup
+    expect(store.get(u.unitId)).toBeUndefined();
   });
 
   it('removes nothing when no fetchPrState dep is wired (reconciliation skipped)', async () => {

--- a/packages/cli/src/daemon/daemon.ts
+++ b/packages/cli/src/daemon/daemon.ts
@@ -7,7 +7,8 @@ import { DEFAULT_POLL_INTERVAL_MS, readConfig } from '../config';
 import { GitHubClient, type PostCommentOptions } from '../github/client';
 import { parseDiff } from '../github/diff-parser';
 import type { CheckRun, PRComment, PRReview } from '../github/types';
-import { callAi, generateNarrative } from '../narrative/engine';
+import { cacheNarrative, computePromptMetaHash, getCachedNarrative } from '../narrative/cache';
+import { callAi, generateNarrative, resolveProviderKey } from '../narrative/engine';
 import { UnitStore } from '../units/store';
 import type { ReviewUnit } from '../units/types';
 import { createDaemonApp, type GitHubWiring, type ReviewInlineComment, SseHub } from './app';
@@ -214,6 +215,10 @@ export function makeConfigChangeHandler(deps: {
  * Phase-1 narrative, attach both to the unit (no status transition — it stays `queued`), and return
  * the updated unit. Wired only when a GitHub client exists; otherwise the hydrate route no-ops.
  *
+ * The narrative round-trips through the shared cache (`~/.cache/diffdad`) under the same key scheme
+ * as `dad <pr>` — the unit file is not the only copy, so a reconciled/deleted unit costs a cache read
+ * to restore, not a full regeneration, and daemon and CLI reuse each other's walkthroughs.
+ *
  * `force` powers the per-PR re-read: fetch the PR live first to advance the unit to the current head
  * SHA (+ fresh title/branch), then bypass the narrative cache READ so a same-SHA regeneration yields
  * new prose instead of replaying the cached walkthrough. The non-force path is unchanged.
@@ -228,23 +233,45 @@ function makeHydrate(
     if (prNumber === undefined) {
       throw new Error(`unit ${unit.unitId} has no PR number`);
     }
-    // Re-read: pull the live PR to advance the head SHA (+ refresh title/branch) so the cache key and
-    // diff track the current push, not the SHA frozen at mint.
+    // Pull the live PR: on force it advances the head SHA (+ refreshes title/branch) so the cache key
+    // and diff track the current push; on both paths it supplies the real title/body/labels — the
+    // mint-time metadata has an empty body, which would both starve the prompt and hash to a metaHash
+    // no `dad <pr>` run ever produces.
+    const meta = await client.getPR(owner, name, prNumber);
     let target = unit;
     if (force) {
-      const meta = await client.getPR(owner, name, prNumber);
       target = store.advanceHead(unit.unitId, meta.headSha, meta);
     }
+    const config = await readConfig();
+    const metaHash = computePromptMetaHash(meta);
+    const providerKey = await resolveProviderKey(config);
+    const sha = target.diffContentKey;
+
     const diff = await client.getPRDiff(owner, name, prNumber);
     const files = parseDiff(diff);
-    const { narrative } = await generateNarrative(target.metadata, files, [], await readConfig(), undefined, {
+
+    if (!force) {
+      const cached = await getCachedNarrative(owner, name, prNumber, sha, metaHash, providerKey);
+      if (cached) {
+        store.attachReview(unit.unitId, files, cached, cached.concerns?.length ?? 0);
+        return store.get(unit.unitId)!;
+      }
+    }
+
+    const promptMeta = { ...target.metadata, title: meta.title, body: meta.body, labels: meta.labels };
+    const { narrative } = await generateNarrative(promptMeta, files, [], config, undefined, {
       // contentKey-style cache key: keyed on the head SHA carried in diffContentKey (advanced above on
       // a re-read). `force` skips the cache read but still writes, so the fresh prose replaces it.
-      cacheKey: { owner, repo: name, number: prNumber, sha: target.diffContentKey },
+      cacheKey: { owner, repo: name, number: prNumber, sha },
       comments: [],
       force,
     });
     store.attachReview(unit.unitId, files, narrative, narrative.concerns?.length ?? 0);
+    try {
+      await cacheNarrative(owner, name, prNumber, sha, metaHash, providerKey, narrative);
+    } catch {
+      // best-effort: the unit carries the narrative; a failed cache write must not fail the hydrate
+    }
     return store.get(unit.unitId)!;
   };
 }

--- a/packages/cli/src/daemon/poller.ts
+++ b/packages/cli/src/daemon/poller.ts
@@ -51,7 +51,8 @@ function countsDiffer(meta: PRMetadata, pr: PolledPr): boolean {
  *
  * With `fetchPrState` wired, the pass also reconciles the store against the search: a github unit whose
  * PR the search stopped returning is dropped — immediately if GitHub reports it closed/merged, else
- * after two consecutive missing polls (the miss streak absorbs the search's eventual consistency). The
+ * after two consecutive missing polls (the miss streak absorbs the search's eventual consistency).
+ * Exception: a still-open unit that is hydrated but undecided (mid-review) is never dropped. The
  * streak map is caller-owned so the interval poller and the manual /api/poll share one streak state.
  * Without the dep, reconciliation is skipped entirely (mint/resurface behavior is byte-identical).
  *
@@ -136,6 +137,12 @@ export async function pollOnce(deps: {
         streaks.delete(unit.unitId);
         removals.push(`${key} (closed)`);
         removed++;
+      } else if (unit.status === 'queued' && unit.narrative) {
+        // Mid-review: hydrated but undecided. "Unrequested" here is usually the reviewer's own
+        // doing — submitting comments or a review dismisses the review request on GitHub — so
+        // removal would destroy the walkthrough under the person reading it. Keep the unit; it
+        // retires through the normal paths (a decision, the PR closing, or a manual delete).
+        streaks.delete(unit.unitId);
       } else {
         // Still open but unrequested (withdrawn / reviewed off-plate / search lag) → remove only
         // after two consecutive missing polls.

--- a/packages/cli/src/narrative/engine.ts
+++ b/packages/cli/src/narrative/engine.ts
@@ -303,7 +303,9 @@ async function generateNarrativeTwoPass(
   await runWithConcurrency(tasks, writerConcurrency);
 
   const narrative = normalizeNarrative(assembleNarrative(plan, chapters));
-  logNarrativeViolations(narrative, fullFiles);
+  // Validate against the same filtered set the plan was built from — mechanical files (lockfiles,
+  // generated) are deliberately unplanned, so checking fullFiles would report them all as orphans.
+  logNarrativeViolations(narrative, narrate);
   const provider = writerProvider ? `${plannerProvider} + ${writerProvider}` : plannerProvider;
   return { narrative, provider };
 }

--- a/packages/cli/src/narrative/validator.ts
+++ b/packages/cli/src/narrative/validator.ts
@@ -102,13 +102,16 @@ export function validateNarrative(narrative: NarrativeResponse, files: DiffFile[
   });
 
   for (const [key, chapters] of primaryRefs) {
-    if (chapters.length > 1) {
+    // Multiple sections in the SAME chapter legitimately re-window one hunk (the writer prompt says
+    // to slice a big hunk with startLine/endLine), so only distinct chapters count as duplicates.
+    const distinct = [...new Set(chapters)];
+    if (distinct.length > 1) {
       const sep = key.lastIndexOf(':');
       violations.push({
         kind: 'duplicate-primary',
         file: key.slice(0, sep),
         hunkIndex: Number(key.slice(sep + 1)),
-        chapters,
+        chapters: distinct,
       });
     }
   }

--- a/packages/cli/src/narrative/writer.ts
+++ b/packages/cli/src/narrative/writer.ts
@@ -39,7 +39,7 @@ export async function writeChapter(input: WriterInput): Promise<WriterResult> {
 
   const result = await callAi(config, prompt.system, prompt.user, WRITER_MAX_TOKENS);
   const parsed = parseChapterResponse(result.text, theme.id);
-  const chapter = normalizeChapter(parsed, theme);
+  const chapter = normalizeChapter(parsed, theme, files);
   return { chapter, provider: result.provider, usage: result.usage };
 }
 
@@ -81,11 +81,30 @@ export function buildSuppressedChapter(theme: PlanTheme): NarrativeChapter {
   };
 }
 
+/** The hunk's full display range: new side, or old side for a deletion-only hunk (newCount 0). */
+function hunkRange(
+  files: DiffFile[] | undefined,
+  file: string,
+  hunkIndex: number,
+): {
+  startLine: number;
+  endLine: number;
+} {
+  const norm = normalizePath(file);
+  const h = files?.find((f) => normalizePath(f.file) === norm)?.hunks[hunkIndex];
+  if (!h) return { startLine: 1, endLine: 1 };
+  return h.newCount > 0
+    ? { startLine: h.newStart, endLine: h.newStart + h.newCount - 1 }
+    : { startLine: h.oldStart, endLine: h.oldStart + Math.max(h.oldCount - 1, 0) };
+}
+
 /**
- * Coerce a parsed writer output into a valid NarrativeChapter, filtering
- * sections to those that reference this theme's hunks.
+ * Coerce a parsed writer output into a valid NarrativeChapter: filter sections to those that
+ * reference this theme's hunks, then backfill any planned hunk the output lost (truncation at
+ * WRITER_MAX_TOKENS, fabricated-ref filtering) as a bare full-range diff section — a hunk the plan
+ * assigned to this theme must never silently vanish from the walkthrough.
  */
-export function normalizeChapter(input: unknown, theme: PlanTheme): NarrativeChapter {
+export function normalizeChapter(input: unknown, theme: PlanTheme, files?: DiffFile[]): NarrativeChapter {
   const obj = (input ?? {}) as Record<string, unknown>;
   const allowedKeys = new Set(theme.hunkRefs.map((r) => `${normalizePath(r.file)}:${r.hunkIndex}`));
   const fileByNorm = new Map<string, string>();
@@ -93,6 +112,7 @@ export function normalizeChapter(input: unknown, theme: PlanTheme): NarrativeCha
 
   const sectionsRaw = Array.isArray(obj.sections) ? (obj.sections as Record<string, unknown>[]) : [];
   const sections: NarrativeSection[] = [];
+  const covered = new Set<string>();
   for (const s of sectionsRaw) {
     if (s.type === 'narrative' && typeof s.content === 'string') {
       sections.push({ type: 'narrative', content: s.content });
@@ -106,6 +126,7 @@ export function normalizeChapter(input: unknown, theme: PlanTheme): NarrativeCha
       const norm = normalizePath(s.file);
       const key = `${norm}:${s.hunkIndex}`;
       if (!allowedKeys.has(key)) continue; // silently drop fabricated refs
+      covered.add(key);
       sections.push({
         type: 'diff',
         file: fileByNorm.get(norm) ?? s.file,
@@ -114,6 +135,12 @@ export function normalizeChapter(input: unknown, theme: PlanTheme): NarrativeCha
         endLine: s.endLine,
       });
     }
+  }
+
+  for (const r of theme.hunkRefs) {
+    const key = `${normalizePath(r.file)}:${r.hunkIndex}`;
+    if (covered.has(key)) continue;
+    sections.push({ type: 'diff', file: r.file, hunkIndex: r.hunkIndex, ...hunkRange(files, r.file, r.hunkIndex) });
   }
 
   return {


### PR DESCRIPTION
## Post-mortem

A daemon review of this repo's own PR #49 "died mid-review": the queue reconciler dropped the unit (`no longer requested`) while it was being read, destroying the generated walkthrough. The recovery run (`dad <pr>`) then re-paid the full writer cost (`cached + anthropic` — plan cache hit, narrative cache miss, because the daemon never wrote the shared narrative cache) and printed a wall of validation warnings that turned out to be mostly validator false positives.

## Fixes

**1. Poller: mid-review units are no longer reconciled away** (`daemon/poller.ts`)
Submitting comments or a review dismisses your review request on GitHub, so the `review-requested:@me` search stops listing the PR *while you're still reading it* — and the two-miss cleanup deleted the walkthrough under the reviewer. A still-open unit that is hydrated but undecided (`status === 'queued' && narrative`) is now exempt. Decided units keep the existing off-plate cleanup; closed/merged PRs are still removed immediately.

**2. Daemon hydrate round-trips the shared narrative cache** (`daemon/daemon.ts`)
Narratives were stored only on the unit file, so removal destroyed them. Hydrate now reads/writes `~/.cache/diffdad` under the same key scheme as `dad <pr>`, fetching real PR title/body/labels so the `metaHash` matches the CLI's — daemon and CLI now reuse each other's walkthroughs, and a dropped unit costs a cache read to restore. Side benefit: the daemon's narrative prompt now sees the PR body (mint-time metadata has `body: ''`).

**3. Validator: only distinct chapters count as duplicate-primary** (`narrative/validator.ts`)
The writer prompt tells the model to re-window a big hunk with `startLine`/`endLine`, so same-chapter progressive reveal was flagged as `appears in chapters 1, 1, 1, 1`.

**4. Two-pass validation file set + writer backfill** (`narrative/engine.ts`, `narrative/writer.ts`)
The two-pass path validated against `fullFiles` while the plan is deliberately built from the mechanical-filtered set — every `bun.lock` hunk was reported as an orphan on every run (the single-pass path already used the filtered set). And `normalizeChapter`'s docstring promised to backfill sections lost to `WRITER_MAX_TOKENS` truncation, but no backfill existed — planned hunks could silently vanish from the walkthrough. They now reappear as bare full-range diff sections (old-side range for deletion-only hunks).

## Test plan

- New poller tests: mid-review unit survives repeated unrequested polls; still removed when the PR closes; decided units keep the two-miss cleanup.
- New validator tests: same-chapter re-windowing not flagged; cross-chapter duplicates report each chapter once.
- New writer tests: backfill at full new-side range, old-side range for deletion-only hunks, normalized-path matching.
- `bun run test` (374 pass), `bun run typecheck`, `bun run lint`, `bun run format:check` all green.