### PR TITLE
fix(cli): make Bedrock Claude Opus 5 generation work (reasoning stream crash + thinking token burn)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ bun run dev              # vite dev server (frontend only)
 bun run test             # run every suite (CLI + web)
 bun run test:cli         # bun test, whole packages/cli/src tree
 bun run test:web         # vitest, packages/web
+bun run typecheck        # tsc across cli, web, and site (CI-gating — run before pushing)
 bun run lint             # oxlint
 bun run format           # oxfmt
 bun run release          # bump version, tag, push (triggers CI release)

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Open the settings page (`/settings` in the command center, or the Settings view 
 dad --with=claude owner/repo#123    # force the Claude CLI even if a key is set
 ```
 
+Set `DIFFDAD_DEBUG_AI=1` (also accepts `true`) to print one stderr summary per AI call — provider, model, why the stream stopped, token usage, and a tally of stream part types. Use it to spot model-behavior surprises, like thinking burning the token budget (a `reasoning` count next to `finishReason=length` and `textChars=0`).
+
 ### GitHub Token
 
 Diff Dad needs a GitHub token to fetch PR data and post comments. It checks, in order:

--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,8 @@
         "zod": "^3",
       },
       "devDependencies": {
+        "@smithy/eventstream-codec": "^4.4.7",
+        "@smithy/util-utf8": "^4.4.7",
         "@types/bun": "latest",
         "vitest": "^3",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,6 +26,8 @@
     "zod": "^3"
   },
   "devDependencies": {
+    "@smithy/eventstream-codec": "^4.4.7",
+    "@smithy/util-utf8": "^4.4.7",
     "@types/bun": "latest",
     "vitest": "^3"
   }

--- a/packages/cli/src/__tests__/ai-runtime.test.ts
+++ b/packages/cli/src/__tests__/ai-runtime.test.ts
@@ -2,8 +2,15 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, spyOn } from 'bu
 import * as credentialProviders from '@aws-sdk/credential-providers';
 import { EventStreamCodec } from '@smithy/eventstream-codec';
 import { fromUtf8, toUtf8 } from '@smithy/util-utf8';
-import { callAi, getModel, resetBedrockModelCache, withResolvedBedrockRegion } from '../narrative/ai-runtime';
+import {
+  callAi,
+  disableThinkingFetch,
+  getModel,
+  resetBedrockModelCache,
+  withResolvedBedrockRegion,
+} from '../narrative/ai-runtime';
 import * as bedrockModels from '../narrative/bedrock-models';
+import type { FetchLike } from '../narrative/bedrock-models';
 import type { DiffDadConfig } from '../config';
 
 /**
@@ -432,6 +439,131 @@ describe('callAi amazon-bedrock stream path', () => {
       } finally {
         delete process.env.DIFFDAD_DEBUG_AI;
         errorSpy.mockRestore();
+        fetchSpy.mockRestore();
+      }
+    },
+    { timeout: 10000 },
+  );
+});
+
+describe('disableThinkingFetch', () => {
+  function captureFetch(): { fetch: FetchLike; body: () => string | undefined } {
+    let sent: string | undefined;
+    const fetch: FetchLike = async (_input, init) => {
+      sent = typeof init?.body === 'string' ? init.body : undefined;
+      return new Response('{}', { status: 200 });
+    };
+    return { fetch, body: () => sent };
+  }
+
+  it('injects thinking:{type:disabled} into a JSON message body', async () => {
+    const cap = captureFetch();
+    await disableThinkingFetch(cap.fetch)('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      body: JSON.stringify({ model: 'claude-opus-5', messages: [] }),
+    });
+    expect(JSON.parse(cap.body()!)).toMatchObject({ thinking: { type: 'disabled' } });
+  });
+
+  it('does not clobber a request that already sets thinking', async () => {
+    const cap = captureFetch();
+    await disableThinkingFetch(cap.fetch)('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      body: JSON.stringify({ thinking: { type: 'enabled', budgetTokens: 100 } }),
+    });
+    expect(JSON.parse(cap.body()!).thinking).toEqual({ type: 'enabled', budgetTokens: 100 });
+  });
+
+  it('forwards a non-JSON body untouched', async () => {
+    let sent: unknown;
+    const base: FetchLike = async (_input, init) => {
+      sent = init?.body;
+      return new Response('{}', { status: 200 });
+    };
+    await disableThinkingFetch(base)('https://api.anthropic.com/v1/messages', { method: 'POST', body: 'not-json' });
+    expect(sent).toBe('not-json');
+  });
+});
+
+describe('callAi anthropic disable-thinking wiring', () => {
+  // Cast: Bun's `typeof fetch` demands a `preconnect` property plain mock closures lack (same cast
+  // as the Bedrock stream tests above).
+  function mockFetch(impl: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>) {
+    return spyOn(globalThis, 'fetch').mockImplementation(impl as unknown as typeof fetch);
+  }
+
+  // Minimal Anthropic Messages SSE stream that yields a single text block and ends the turn.
+  function anthropicSse(): Response {
+    const events: [string, unknown][] = [
+      [
+        'message_start',
+        {
+          type: 'message_start',
+          message: {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            model: 'claude-opus-5',
+            content: [],
+            stop_reason: null,
+            stop_sequence: null,
+            usage: { input_tokens: 5, output_tokens: 0 },
+          },
+        },
+      ],
+      ['content_block_start', { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } }],
+      ['content_block_delta', { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'OK' } }],
+      ['content_block_stop', { type: 'content_block_stop', index: 0 }],
+      [
+        'message_delta',
+        { type: 'message_delta', delta: { stop_reason: 'end_turn', stop_sequence: null }, usage: { output_tokens: 1 } },
+      ],
+      ['message_stop', { type: 'message_stop' }],
+    ];
+    const body = events.map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`).join('');
+    return new Response(body, { headers: { 'content-type': 'text/event-stream' } });
+  }
+
+  it(
+    'sends thinking disabled in the request body for a Claude model on the direct Anthropic API',
+    async () => {
+      let requestBody: string | undefined;
+      const fetchSpy = mockFetch(async (_input, init) => {
+        requestBody = typeof init?.body === 'string' ? init.body : undefined;
+        return anthropicSse();
+      });
+      try {
+        const result = await callAi(
+          { aiProvider: 'anthropic', aiApiKey: 'k', aiModel: 'claude-opus-5' },
+          'system',
+          'user',
+          256,
+        );
+        expect(result.text).toBe('OK');
+        expect(requestBody).toBeDefined();
+        const parsed = JSON.parse(requestBody!) as { thinking?: { type?: string } };
+        expect(parsed.thinking?.type).toBe('disabled');
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    },
+    { timeout: 10000 },
+  );
+
+  it(
+    'does not disable thinking for Fable/Mythos models (they reject an explicit disable)',
+    async () => {
+      let requestBody: string | undefined;
+      const fetchSpy = mockFetch(async (_input, init) => {
+        requestBody = typeof init?.body === 'string' ? init.body : undefined;
+        return anthropicSse();
+      });
+      try {
+        await callAi({ aiProvider: 'anthropic', aiApiKey: 'k', aiModel: 'claude-fable-5' }, 'system', 'user', 256);
+        expect(requestBody).toBeDefined();
+        const parsed = JSON.parse(requestBody!) as { thinking?: unknown };
+        expect(parsed.thinking).toBeUndefined();
+      } finally {
         fetchSpy.mockRestore();
       }
     },

--- a/packages/cli/src/__tests__/ai-runtime.test.ts
+++ b/packages/cli/src/__tests__/ai-runtime.test.ts
@@ -1,5 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it, spyOn } from 'bun:test';
 import * as credentialProviders from '@aws-sdk/credential-providers';
+import { EventStreamCodec } from '@smithy/eventstream-codec';
+import { fromUtf8, toUtf8 } from '@smithy/util-utf8';
 import { callAi, getModel, withResolvedBedrockRegion } from '../narrative/ai-runtime';
 import * as bedrockModels from '../narrative/bedrock-models';
 import type { DiffDadConfig } from '../config';
@@ -226,4 +228,119 @@ describe('withResolvedBedrockRegion', () => {
       spy.mockRestore();
     }
   });
+});
+
+/**
+ * These tests exercise callAi's Bedrock ConverseStream path against canned AWS
+ * eventstream responses, encoded with the same @smithy codec the provider
+ * decodes with. The frames mirror what Claude Opus 5 actually sends: thinking
+ * is on by default and its display defaults to "omitted", so reasoning blocks
+ * arrive as a bare signature delta with no reasoning text.
+ */
+describe('callAi amazon-bedrock stream path', () => {
+  // Each test gets a distinct access key: the Bedrock model is cached at module scope keyed by the
+  // credential/model fields, and the cached model holds the fetch that was current when it was
+  // built. A shared config would make later tests silently reuse the first test's (restored) fetch
+  // spy instead of their own.
+  function bedrockConfig(cacheBuster: string): DiffDadConfig {
+    return {
+      aiProvider: 'amazon-bedrock',
+      aiRegion: 'us-east-1',
+      aiAccessKeyId: `AKIAEXAMPLE${cacheBuster}`,
+      aiSecretAccessKey: 'secret',
+      aiModel: 'us.anthropic.claude-opus-5',
+    };
+  }
+
+  function eventFrame(eventType: string, payload: unknown): Uint8Array {
+    const codec = new EventStreamCodec(toUtf8, fromUtf8);
+    return codec.encode({
+      headers: {
+        ':event-type': { type: 'string', value: eventType },
+        ':content-type': { type: 'string', value: 'application/json' },
+        ':message-type': { type: 'string', value: 'event' },
+      },
+      body: new TextEncoder().encode(JSON.stringify(payload)),
+    });
+  }
+
+  function converseStreamResponse(frames: Uint8Array[]): Response {
+    const total = frames.reduce((n, f) => n + f.length, 0);
+    const body = new Uint8Array(total);
+    let offset = 0;
+    for (const f of frames) {
+      body.set(f, offset);
+      offset += f.length;
+    }
+    return new Response(body, {
+      headers: { 'content-type': 'application/vnd.amazon.eventstream' },
+    });
+  }
+
+  it(
+    'survives an omitted-thinking stream (reasoning signature with no reasoning text)',
+    async () => {
+      // Opus 5 shape: the model thinks, but display defaults to "omitted" — the
+      // stream carries the reasoning block's signature and never any reasoning
+      // text. ai@4's accumulator throws InvalidStreamPart ("reasoning-signature
+      // without reasoning") on that sequence unless the signature is stripped.
+      const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(async () =>
+        converseStreamResponse([
+          eventFrame('contentBlockDelta', {
+            contentBlockIndex: 0,
+            delta: { reasoningContent: { signature: 'sig-abc' } },
+          }),
+          eventFrame('contentBlockStop', { contentBlockIndex: 0 }),
+          eventFrame('contentBlockDelta', { contentBlockIndex: 1, delta: { text: 'OK' } }),
+          eventFrame('contentBlockStop', { contentBlockIndex: 1 }),
+          eventFrame('messageStop', { stopReason: 'end_turn' }),
+          eventFrame('metadata', { usage: { inputTokens: 5, outputTokens: 2 } }),
+        ]),
+      );
+      try {
+        const deltas: string[] = [];
+        const result = await callAi(bedrockConfig('OMITTED'), 'system', 'user', 256, (d) => deltas.push(d));
+
+        expect(fetchSpy.mock.calls[0]?.[0]).toContain('bedrock-runtime.us-east-1.amazonaws.com');
+        expect(result.text).toBe('OK');
+        expect(deltas).toEqual(['OK']);
+        expect(result.truncated).toBe(false);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    },
+    { timeout: 10000 },
+  );
+
+  it(
+    'keeps reasoning text out of the returned text when thinking is streamed with content',
+    async () => {
+      // Summarized-display shape: reasoning text deltas precede the signature.
+      // Only the answer text may reach the caller — reasoning is discarded.
+      const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(async () =>
+        converseStreamResponse([
+          eventFrame('contentBlockDelta', {
+            contentBlockIndex: 0,
+            delta: { reasoningContent: { text: 'Let me think about this.' } },
+          }),
+          eventFrame('contentBlockDelta', {
+            contentBlockIndex: 0,
+            delta: { reasoningContent: { signature: 'sig-abc' } },
+          }),
+          eventFrame('contentBlockStop', { contentBlockIndex: 0 }),
+          eventFrame('contentBlockDelta', { contentBlockIndex: 1, delta: { text: 'OK' } }),
+          eventFrame('contentBlockStop', { contentBlockIndex: 1 }),
+          eventFrame('messageStop', { stopReason: 'end_turn' }),
+          eventFrame('metadata', { usage: { inputTokens: 5, outputTokens: 2 } }),
+        ]),
+      );
+      try {
+        const result = await callAi(bedrockConfig('SUMMARIZED'), 'system', 'user', 256);
+        expect(result.text).toBe('OK');
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    },
+    { timeout: 10000 },
+  );
 });

--- a/packages/cli/src/__tests__/ai-runtime.test.ts
+++ b/packages/cli/src/__tests__/ai-runtime.test.ts
@@ -343,4 +343,89 @@ describe('callAi amazon-bedrock stream path', () => {
     },
     { timeout: 10000 },
   );
+
+  it(
+    'requests thinking disabled for Claude models (maxTokens must budget visible text, not thinking)',
+    async () => {
+      // From Opus 5 onward Claude thinks by default and maxTokens caps thinking + text together —
+      // a writer-sized budget can be consumed entirely by omitted thinking, yielding the
+      // empty-response error (finishReason: length). The request must turn thinking off.
+      let requestBody: string | undefined;
+      const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(async (_input, init) => {
+        requestBody = typeof init?.body === 'string' ? init.body : undefined;
+        return converseStreamResponse([
+          eventFrame('contentBlockDelta', { contentBlockIndex: 0, delta: { text: 'OK' } }),
+          eventFrame('contentBlockStop', { contentBlockIndex: 0 }),
+          eventFrame('messageStop', { stopReason: 'end_turn' }),
+          eventFrame('metadata', { usage: { inputTokens: 5, outputTokens: 2 } }),
+        ]);
+      });
+      try {
+        await callAi(bedrockConfig('THINKINGOFF'), 'system', 'user', 256);
+        expect(requestBody).toBeDefined();
+        const parsed = JSON.parse(requestBody!) as {
+          additionalModelRequestFields?: { thinking?: { type?: string } };
+        };
+        expect(parsed.additionalModelRequestFields?.thinking?.type).toBe('disabled');
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    },
+    { timeout: 10000 },
+  );
+
+  it(
+    'does not send the Anthropic thinking field to non-Claude Bedrock models',
+    async () => {
+      let requestBody: string | undefined;
+      const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(async (_input, init) => {
+        requestBody = typeof init?.body === 'string' ? init.body : undefined;
+        return converseStreamResponse([
+          eventFrame('contentBlockDelta', { contentBlockIndex: 0, delta: { text: 'OK' } }),
+          eventFrame('contentBlockStop', { contentBlockIndex: 0 }),
+          eventFrame('messageStop', { stopReason: 'end_turn' }),
+          eventFrame('metadata', { usage: { inputTokens: 5, outputTokens: 2 } }),
+        ]);
+      });
+      try {
+        const config = { ...bedrockConfig('NONCLAUDE'), aiModel: 'us.meta.llama4-maverick-17b-instruct-v1:0' };
+        await callAi(config, 'system', 'user', 256);
+        expect(requestBody).toBeDefined();
+        const parsed = JSON.parse(requestBody!) as { additionalModelRequestFields?: Record<string, unknown> };
+        expect(parsed.additionalModelRequestFields?.thinking).toBeUndefined();
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    },
+    { timeout: 10000 },
+  );
+
+  it(
+    'emits a DIFFDAD_DEBUG_AI summary line with finishReason, usage, and stream part tallies',
+    async () => {
+      const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(async () =>
+        converseStreamResponse([
+          eventFrame('contentBlockDelta', { contentBlockIndex: 0, delta: { text: 'OK' } }),
+          eventFrame('contentBlockStop', { contentBlockIndex: 0 }),
+          eventFrame('messageStop', { stopReason: 'end_turn' }),
+          eventFrame('metadata', { usage: { inputTokens: 5, outputTokens: 2 } }),
+        ]),
+      );
+      const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+      process.env.DIFFDAD_DEBUG_AI = '1';
+      try {
+        await callAi(bedrockConfig('DEBUGLINE'), 'system', 'user', 256);
+        const line = errorSpy.mock.calls.map((c) => String(c[0])).find((s) => s.includes('[diffdad:ai]'));
+        expect(line).toBeDefined();
+        expect(line).toContain('finishReason=stop');
+        expect(line).toContain('textChars=2');
+        expect(line).toContain('"text-delta":1');
+      } finally {
+        delete process.env.DIFFDAD_DEBUG_AI;
+        errorSpy.mockRestore();
+        fetchSpy.mockRestore();
+      }
+    },
+    { timeout: 10000 },
+  );
 });

--- a/packages/cli/src/__tests__/ai-runtime.test.ts
+++ b/packages/cli/src/__tests__/ai-runtime.test.ts
@@ -1,8 +1,8 @@
-import { afterAll, beforeAll, describe, expect, it, spyOn } from 'bun:test';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import * as credentialProviders from '@aws-sdk/credential-providers';
 import { EventStreamCodec } from '@smithy/eventstream-codec';
 import { fromUtf8, toUtf8 } from '@smithy/util-utf8';
-import { callAi, getModel, withResolvedBedrockRegion } from '../narrative/ai-runtime';
+import { callAi, getModel, resetBedrockModelCache, withResolvedBedrockRegion } from '../narrative/ai-runtime';
 import * as bedrockModels from '../narrative/bedrock-models';
 import type { DiffDadConfig } from '../config';
 
@@ -238,15 +238,18 @@ describe('withResolvedBedrockRegion', () => {
  * arrive as a bare signature delta with no reasoning text.
  */
 describe('callAi amazon-bedrock stream path', () => {
-  // Each test gets a distinct access key: the Bedrock model is cached at module scope keyed by the
-  // credential/model fields, and the cached model holds the fetch that was current when it was
-  // built. A shared config would make later tests silently reuse the first test's (restored) fetch
-  // spy instead of their own.
-  function bedrockConfig(cacheBuster: string): DiffDadConfig {
+  // The Bedrock model is cached at module scope, and the cached model holds the fetch that was
+  // current when it was built. Reset the cache before each case so a test builds its model against
+  // its own fetch spy rather than reusing a prior test's (restored) one.
+  beforeEach(() => {
+    resetBedrockModelCache();
+  });
+
+  function bedrockConfig(): DiffDadConfig {
     return {
       aiProvider: 'amazon-bedrock',
       aiRegion: 'us-east-1',
-      aiAccessKeyId: `AKIAEXAMPLE${cacheBuster}`,
+      aiAccessKeyId: 'AKIAEXAMPLE',
       aiSecretAccessKey: 'secret',
       aiModel: 'us.anthropic.claude-opus-5',
     };
@@ -305,7 +308,7 @@ describe('callAi amazon-bedrock stream path', () => {
       );
       try {
         const deltas: string[] = [];
-        const result = await callAi(bedrockConfig('OMITTED'), 'system', 'user', 256, (d) => deltas.push(d));
+        const result = await callAi(bedrockConfig(), 'system', 'user', 256, (d) => deltas.push(d));
 
         expect(fetchSpy.mock.calls[0]?.[0]).toContain('bedrock-runtime.us-east-1.amazonaws.com');
         expect(result.text).toBe('OK');
@@ -341,7 +344,7 @@ describe('callAi amazon-bedrock stream path', () => {
         ]),
       );
       try {
-        const result = await callAi(bedrockConfig('SUMMARIZED'), 'system', 'user', 256);
+        const result = await callAi(bedrockConfig(), 'system', 'user', 256);
         expect(result.text).toBe('OK');
       } finally {
         fetchSpy.mockRestore();
@@ -367,7 +370,7 @@ describe('callAi amazon-bedrock stream path', () => {
         ]);
       });
       try {
-        await callAi(bedrockConfig('THINKINGOFF'), 'system', 'user', 256);
+        await callAi(bedrockConfig(), 'system', 'user', 256);
         expect(requestBody).toBeDefined();
         const parsed = JSON.parse(requestBody!) as {
           additionalModelRequestFields?: { thinking?: { type?: string } };
@@ -394,7 +397,7 @@ describe('callAi amazon-bedrock stream path', () => {
         ]);
       });
       try {
-        const config = { ...bedrockConfig('NONCLAUDE'), aiModel: 'us.meta.llama4-maverick-17b-instruct-v1:0' };
+        const config = { ...bedrockConfig(), aiModel: 'us.meta.llama4-maverick-17b-instruct-v1:0' };
         await callAi(config, 'system', 'user', 256);
         expect(requestBody).toBeDefined();
         const parsed = JSON.parse(requestBody!) as { additionalModelRequestFields?: Record<string, unknown> };
@@ -420,7 +423,7 @@ describe('callAi amazon-bedrock stream path', () => {
       const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
       process.env.DIFFDAD_DEBUG_AI = '1';
       try {
-        await callAi(bedrockConfig('DEBUGLINE'), 'system', 'user', 256);
+        await callAi(bedrockConfig(), 'system', 'user', 256);
         const line = errorSpy.mock.calls.map((c) => String(c[0])).find((s) => s.includes('[diffdad:ai]'));
         expect(line).toBeDefined();
         expect(line).toContain('finishReason=stop');

--- a/packages/cli/src/__tests__/ai-runtime.test.ts
+++ b/packages/cli/src/__tests__/ai-runtime.test.ts
@@ -264,6 +264,12 @@ describe('callAi amazon-bedrock stream path', () => {
     });
   }
 
+  // Cast: Bun's `typeof fetch` demands a `preconnect` property that plain mock closures lack and
+  // the AI SDK never touches (same cast as toInvokeAuth in bedrock-models.ts).
+  function mockFetch(impl: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>) {
+    return spyOn(globalThis, 'fetch').mockImplementation(impl as unknown as typeof fetch);
+  }
+
   function converseStreamResponse(frames: Uint8Array[]): Response {
     const total = frames.reduce((n, f) => n + f.length, 0);
     const body = new Uint8Array(total);
@@ -284,7 +290,7 @@ describe('callAi amazon-bedrock stream path', () => {
       // stream carries the reasoning block's signature and never any reasoning
       // text. ai@4's accumulator throws InvalidStreamPart ("reasoning-signature
       // without reasoning") on that sequence unless the signature is stripped.
-      const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      const fetchSpy = mockFetch(async () =>
         converseStreamResponse([
           eventFrame('contentBlockDelta', {
             contentBlockIndex: 0,
@@ -317,7 +323,7 @@ describe('callAi amazon-bedrock stream path', () => {
     async () => {
       // Summarized-display shape: reasoning text deltas precede the signature.
       // Only the answer text may reach the caller — reasoning is discarded.
-      const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      const fetchSpy = mockFetch(async () =>
         converseStreamResponse([
           eventFrame('contentBlockDelta', {
             contentBlockIndex: 0,
@@ -351,7 +357,7 @@ describe('callAi amazon-bedrock stream path', () => {
       // a writer-sized budget can be consumed entirely by omitted thinking, yielding the
       // empty-response error (finishReason: length). The request must turn thinking off.
       let requestBody: string | undefined;
-      const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(async (_input, init) => {
+      const fetchSpy = mockFetch(async (_input, init) => {
         requestBody = typeof init?.body === 'string' ? init.body : undefined;
         return converseStreamResponse([
           eventFrame('contentBlockDelta', { contentBlockIndex: 0, delta: { text: 'OK' } }),
@@ -378,7 +384,7 @@ describe('callAi amazon-bedrock stream path', () => {
     'does not send the Anthropic thinking field to non-Claude Bedrock models',
     async () => {
       let requestBody: string | undefined;
-      const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(async (_input, init) => {
+      const fetchSpy = mockFetch(async (_input, init) => {
         requestBody = typeof init?.body === 'string' ? init.body : undefined;
         return converseStreamResponse([
           eventFrame('contentBlockDelta', { contentBlockIndex: 0, delta: { text: 'OK' } }),
@@ -403,7 +409,7 @@ describe('callAi amazon-bedrock stream path', () => {
   it(
     'emits a DIFFDAD_DEBUG_AI summary line with finishReason, usage, and stream part tallies',
     async () => {
-      const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      const fetchSpy = mockFetch(async () =>
         converseStreamResponse([
           eventFrame('contentBlockDelta', { contentBlockIndex: 0, delta: { text: 'OK' } }),
           eventFrame('contentBlockStop', { contentBlockIndex: 0 }),

--- a/packages/cli/src/narrative/ai-runtime.ts
+++ b/packages/cli/src/narrative/ai-runtime.ts
@@ -190,10 +190,20 @@ export function getModel(config: DiffDadConfig): LanguageModelV1 {
         // bearer-injecting fetch; otherwise a credentialProvider the SDK uses over its own env.
         ...toInvokeAuth(resolveBedrockCreds(config)),
       });
+      // `||` not `??`: the settings form saves '' to mean "use the default model".
+      const modelId = config.aiModel || DEFAULT_BEDROCK_MODEL;
+      // Claude thinks by default from Opus 5 onward, and maxTokens caps thinking + visible text
+      // together — our budgets are sized for the deliverable text, so omitted thinking can consume
+      // the whole budget and yield an empty response (finishReason: length). Turn thinking off for
+      // Claude models. Fable/Mythos reject an explicit disable (400) and non-Claude models don't
+      // know the field, so both are skipped.
+      const disableThinking = /anthropic\.claude/.test(modelId) && !/fable|mythos/.test(modelId);
       return wrapLanguageModel({
         // Bedrock-hosted Claude has the same temperature-deprecation behavior as the direct API.
-        // `||` not `??`: the settings form saves '' to mean "use the default model".
-        model: bedrock(config.aiModel || DEFAULT_BEDROCK_MODEL),
+        model: bedrock(
+          modelId,
+          disableThinking ? { additionalModelRequestFields: { thinking: { type: 'disabled' } } } : undefined,
+        ),
         middleware: [stripTemperature, stripReasoningSignature],
       });
     }
@@ -478,16 +488,33 @@ export async function callAi(
   let text = '';
   let finishReason: FinishReason | undefined;
   let usage: LanguageModelUsage | undefined;
-  for await (const part of stream.fullStream) {
-    if (part.type === 'text-delta') {
-      if (part.textDelta.length === 0) continue;
-      text += part.textDelta;
-      onChunk?.(part.textDelta);
-    } else if (part.type === 'error') {
-      throw asError(part.error);
-    } else if (part.type === 'finish') {
-      finishReason = part.finishReason;
-      usage = part.usage;
+  // DIFFDAD_DEBUG_AI=1 prints one stderr summary per AI call — which provider/model ran, why the
+  // stream stopped, token usage, and a tally of every stream part type. The tally is the signal
+  // for model-behavior surprises: e.g. thinking burning the token budget shows up as 'reasoning'
+  // counts next to finishReason=length with textChars=0.
+  const debugAi = Boolean(process.env.DIFFDAD_DEBUG_AI);
+  const partCounts: Record<string, number> = {};
+  try {
+    for await (const part of stream.fullStream) {
+      if (debugAi) partCounts[part.type] = (partCounts[part.type] ?? 0) + 1;
+      if (part.type === 'text-delta') {
+        if (part.textDelta.length === 0) continue;
+        text += part.textDelta;
+        onChunk?.(part.textDelta);
+      } else if (part.type === 'error') {
+        throw asError(part.error);
+      } else if (part.type === 'finish') {
+        finishReason = part.finishReason;
+        usage = part.usage;
+      }
+    }
+  } finally {
+    if (debugAi) {
+      console.error(
+        `[diffdad:ai] provider=${provider} model=${effectiveConfig.aiModel ?? 'default'} maxTokens=${maxTokens ?? 'unset'} ` +
+          `finishReason=${finishReason ?? 'none'} textChars=${text.length} ` +
+          `usage=${usage ? JSON.stringify(usage) : 'none'} parts=${JSON.stringify(partCounts)}`,
+      );
     }
   }
 

--- a/packages/cli/src/narrative/ai-runtime.ts
+++ b/packages/cli/src/narrative/ai-runtime.ts
@@ -12,7 +12,7 @@ import type {
 } from 'ai';
 import { DEFAULT_CLI_MODELS, LOCAL_CLIS, type DiffDadConfig, type LocalCli } from '../config';
 import { resolveBedrockCreds } from './bedrock-credentials';
-import { resolveBedrockRegion, toInvokeAuth } from './bedrock-models';
+import { type FetchLike, resolveBedrockRegion, toInvokeAuth } from './bedrock-models';
 
 export type AiChunkHandler = (delta: string) => void;
 export type AiUsage = { inputTokens?: number; outputTokens?: number };
@@ -149,18 +149,56 @@ const stripReasoningSignature: LanguageModelV1Middleware = {
   },
 };
 
+/**
+ * Injects `thinking: { type: 'disabled' }` into the outgoing Anthropic Messages request body.
+ * @ai-sdk/anthropic only serializes a `thinking` field when its type is 'enabled' (it drops
+ * `{type:'disabled'}` on the floor), so providerOptions can't turn thinking off — this fetch shim
+ * adds the raw field the same way the Bedrock case uses additionalModelRequestFields. A no-op on
+ * any body that isn't a JSON object or that already carries a `thinking` field. `createAnthropic`
+ * exposes `fetch` explicitly as a request-interception hook, so this is the supported seam.
+ */
+export function disableThinkingFetch(fetchImpl?: FetchLike): FetchLike {
+  return (input, init) => {
+    // Resolve the delegate per call rather than binding it once: `createAmazonBedrock`'s fetch is
+    // captured at construction, but this shim is built inside getModel and must honor a later
+    // `globalThis.fetch` swap (a test replacing fetch after the model is built).
+    const base = fetchImpl ?? globalThis.fetch;
+    const body = init?.body;
+    if (typeof body === 'string') {
+      try {
+        const parsed = JSON.parse(body) as Record<string, unknown>;
+        if (parsed !== null && typeof parsed === 'object' && !('thinking' in parsed)) {
+          return base(input, { ...init, body: JSON.stringify({ ...parsed, thinking: { type: 'disabled' } }) });
+        }
+      } catch {
+        // Body isn't JSON we can rewrite — forward it untouched.
+      }
+    }
+    return base(input, init);
+  };
+}
+
 export function getModel(config: DiffDadConfig): LanguageModelV1 {
   const provider = config.aiProvider ?? 'anthropic';
 
   switch (provider) {
     case 'anthropic': {
-      // Shared caveat with the Bedrock case below: we send no thinking config here either, so a
-      // thinking-by-default Claude (e.g. claude-opus-5) burns the maxTokens budget on hidden
-      // reasoning against writer-sized limits (WRITER_MAX_TOKENS = 3_000). Not Bedrock-specific.
-      // Deferred — the direct-API path has no disable-thinking fix yet.
-      const anthropic = createAnthropic({ apiKey: config.aiApiKey });
+      const modelId = config.aiModel ?? DEFAULT_ANTHROPIC_MODEL;
+      // Same token-burn guard as the Bedrock case below, and for the same reason: a
+      // thinking-by-default Claude (e.g. claude-opus-5) spends the shared maxTokens budget on
+      // hidden reasoning against writer-sized limits (WRITER_MAX_TOKENS = 3_000), which can yield
+      // an empty response (finishReason: length). Both providers disable thinking for Claude
+      // models. The direct API can't take the field through providerOptions (see
+      // disableThinkingFetch), so it goes in via the request-body fetch shim — the direct-API
+      // equivalent of Bedrock's additionalModelRequestFields passthrough. Fable/Mythos reject an
+      // explicit disable (400), so they're excluded here just as they are on Bedrock.
+      const disableThinking = /claude/.test(modelId) && !/fable|mythos/.test(modelId);
+      const anthropic = createAnthropic({
+        apiKey: config.aiApiKey,
+        fetch: disableThinking ? (disableThinkingFetch() as typeof globalThis.fetch) : undefined,
+      });
       return wrapLanguageModel({
-        model: anthropic(config.aiModel ?? DEFAULT_ANTHROPIC_MODEL),
+        model: anthropic(modelId),
         middleware: stripTemperature,
       });
     }

--- a/packages/cli/src/narrative/ai-runtime.ts
+++ b/packages/cli/src/narrative/ai-runtime.ts
@@ -154,6 +154,10 @@ export function getModel(config: DiffDadConfig): LanguageModelV1 {
 
   switch (provider) {
     case 'anthropic': {
+      // Shared caveat with the Bedrock case below: we send no thinking config here either, so a
+      // thinking-by-default Claude (e.g. claude-opus-5) burns the maxTokens budget on hidden
+      // reasoning against writer-sized limits (WRITER_MAX_TOKENS = 3_000). Not Bedrock-specific.
+      // Deferred — the direct-API path has no disable-thinking fix yet.
       const anthropic = createAnthropic({ apiKey: config.aiApiKey });
       return wrapLanguageModel({
         model: anthropic(config.aiModel ?? DEFAULT_ANTHROPIC_MODEL),
@@ -197,6 +201,8 @@ export function getModel(config: DiffDadConfig): LanguageModelV1 {
       // the whole budget and yield an empty response (finishReason: length). Turn thinking off for
       // Claude models. Fable/Mythos reject an explicit disable (400) and non-Claude models don't
       // know the field, so both are skipped.
+      // Safe only while we don't send output_config.effort — Opus 5 accepts thinking:{type:'disabled'}
+      // at effort 'high' or below, but pairing it with 'xhigh'/'max' is a 400.
       const disableThinking = /anthropic\.claude/.test(modelId) && !/fable|mythos/.test(modelId);
       return wrapLanguageModel({
         // Bedrock-hosted Claude has the same temperature-deprecation behavior as the direct API.
@@ -233,6 +239,15 @@ export async function withResolvedBedrockRegion(config: DiffDadConfig): Promise<
 // fields that shape it; a settings save changes the key and so invalidates. The chain itself
 // refreshes expired credentials internally, so holding one instance long-term is safe.
 let bedrockModelCache: { key: string; model: LanguageModelV1 } | undefined;
+
+/**
+ * Clears the module-scoped Bedrock model cache. Exists for tests: the cached model captures the
+ * `fetch` that was current when it was built, so a suite that swaps `fetch` per case must reset
+ * between cases to avoid reusing a prior test's (restored) fetch spy.
+ */
+export function resetBedrockModelCache(): void {
+  bedrockModelCache = undefined;
+}
 
 async function getBedrockModel(config: DiffDadConfig): Promise<LanguageModelV1> {
   const key = [
@@ -492,7 +507,7 @@ export async function callAi(
   // stream stopped, token usage, and a tally of every stream part type. The tally is the signal
   // for model-behavior surprises: e.g. thinking burning the token budget shows up as 'reasoning'
   // counts next to finishReason=length with textChars=0.
-  const debugAi = Boolean(process.env.DIFFDAD_DEBUG_AI);
+  const debugAi = process.env.DIFFDAD_DEBUG_AI === '1' || process.env.DIFFDAD_DEBUG_AI === 'true';
   const partCounts: Record<string, number> = {};
   try {
     for await (const part of stream.fullStream) {

--- a/packages/cli/src/narrative/ai-runtime.ts
+++ b/packages/cli/src/narrative/ai-runtime.ts
@@ -3,7 +3,13 @@ import { streamText, wrapLanguageModel } from 'ai';
 import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
-import type { FinishReason, LanguageModelUsage, LanguageModelV1, LanguageModelV1Middleware } from 'ai';
+import type {
+  FinishReason,
+  LanguageModelUsage,
+  LanguageModelV1,
+  LanguageModelV1Middleware,
+  LanguageModelV1StreamPart,
+} from 'ai';
 import { DEFAULT_CLI_MODELS, LOCAL_CLIS, type DiffDadConfig, type LocalCli } from '../config';
 import { resolveBedrockCreds } from './bedrock-credentials';
 import { resolveBedrockRegion, toInvokeAuth } from './bedrock-models';
@@ -118,6 +124,31 @@ const stripTemperature: LanguageModelV1Middleware = {
   transformParams: async ({ params }) => ({ ...params, temperature: undefined }),
 };
 
+/**
+ * Claude Opus 5 thinks by default with its thinking display "omitted": the stream carries a
+ * reasoning block's signature delta but never any reasoning text. ai@4's accumulator throws
+ * InvalidStreamPart ("reasoning-signature without reasoning") on a signature with no preceding
+ * reasoning text, killing the whole generation. We are single-turn and never replay assistant
+ * messages, so the signature (a replay-integrity token) is dead weight — drop it before the
+ * accumulator sees it.
+ */
+const stripReasoningSignature: LanguageModelV1Middleware = {
+  wrapStream: async ({ doStream }) => {
+    const { stream, ...rest } = await doStream();
+    return {
+      stream: stream.pipeThrough(
+        new TransformStream<LanguageModelV1StreamPart, LanguageModelV1StreamPart>({
+          transform(part, controller) {
+            if (part.type === 'reasoning-signature') return;
+            controller.enqueue(part);
+          },
+        }),
+      ),
+      ...rest,
+    };
+  },
+};
+
 export function getModel(config: DiffDadConfig): LanguageModelV1 {
   const provider = config.aiProvider ?? 'anthropic';
 
@@ -163,7 +194,7 @@ export function getModel(config: DiffDadConfig): LanguageModelV1 {
         // Bedrock-hosted Claude has the same temperature-deprecation behavior as the direct API.
         // `||` not `??`: the settings form saves '' to mean "use the default model".
         model: bedrock(config.aiModel || DEFAULT_BEDROCK_MODEL),
-        middleware: stripTemperature,
+        middleware: [stripTemperature, stripReasoningSignature],
       });
     }
     default: {


### PR DESCRIPTION
## Problem

With the Bedrock provider pointed at `us.anthropic.claude-opus-5`, every narrative generation failed while Opus 4.8 worked fine. Two distinct failures, same root: **Opus 5 thinks by default** (4.8 does not), and its thinking display defaults to omitted.

1. **`InvalidStreamPart: reasoning-signature without reasoning`** — with omitted display, the ConverseStream carries a reasoning block's signature delta but no reasoning text. `@ai-sdk/amazon-bedrock@2` drops the empty text but forwards the signature, and `ai@4`'s accumulator throws on a signature with no preceding reasoning part, killing the generation.
2. **`AI returned an empty response (finishReason: length)`** — `maxTokens` caps thinking + visible text together. Our budgets (3k writer / 16k planner+narrative) are sized for the deliverable text, so omitted thinking could consume the entire budget and produce zero visible output.

## Fix

- `stripReasoningSignature` middleware on the Bedrock model: drops `reasoning-signature` stream parts before the accumulator sees them. We are single-turn and never replay assistant messages, so the signature is dead weight.
- Send `thinking: {type: "disabled"}` via `additionalModelRequestFields` for Bedrock Claude models — restores the pre-Opus-5 behavior the pipeline budgets and prompts were tuned for. Gated off for Fable/Mythos (they reject an explicit disable) and non-Claude Bedrock models (the field is Anthropic-specific).
- New `DIFFDAD_DEBUG_AI=1` env: one stderr summary line per AI call (provider, model, maxTokens, finishReason, text length, token usage, stream part tallies) so failures like these are diagnosable from user output alone.

## Testing

- Regression tests drive canned AWS eventstream frames (encoded with the same `@smithy/eventstream-codec` the provider decodes with) through `callAi`'s Bedrock path: the omitted-thinking shape, the summarized shape, the thinking-disabled request field (present for Claude, absent for non-Claude), and the debug summary line. Both bug tests were watched failing before the fixes.
- Verified live against Bedrock `us-east-1`: the previously-failing thinking-heavy prompts now complete, and a real PR review generated 6 chapters cleanly with all writer calls finishing `stop`.
- Full suite: 444 pass / 0 fail; oxlint and oxfmt clean.