### PR TITLE
fix(release): publish Linux ARM64 binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
           - os: ubuntu-latest
             target: bun-linux-x64
             artifact: dad-linux-x86_64
+          - os: ubuntu-latest
+            target: bun-linux-arm64
+            artifact: dad-linux-aarch64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/packages/cli/src/__tests__/release-workflow.test.ts
+++ b/packages/cli/src/__tests__/release-workflow.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Guards the release matrix so a target/artifact can't be dropped or misnamed.
+// mise's `github:` backend (ubi) matches release assets by OS + arch tokens, so
+// the artifact name for each bun target must carry the arch token ubi recognizes.
+const workflow = readFileSync(join(import.meta.dir, '../../../../.github/workflows/release.yml'), 'utf8');
+
+// Extract every `target:`/`artifact:` pair from the build matrix include block.
+function matrixPairs(yaml: string): Array<{ target: string; artifact: string }> {
+  const pairs: Array<{ target: string; artifact: string }> = [];
+  const re = /target:\s*(\S+)\s*\n\s*artifact:\s*(\S+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(yaml)) !== null) {
+    pairs.push({ target: m[1]!, artifact: m[2]! });
+  }
+  return pairs;
+}
+
+describe('release workflow build matrix', () => {
+  const pairs = matrixPairs(workflow);
+
+  it('covers every published target/artifact pair', () => {
+    expect(new Set(pairs.map((p) => `${p.target}=${p.artifact}`))).toEqual(
+      new Set([
+        'bun-darwin-arm64=dad-darwin-arm64',
+        'bun-darwin-x64=dad-darwin-x86_64',
+        'bun-linux-x64=dad-linux-x86_64',
+        'bun-linux-arm64=dad-linux-aarch64',
+      ]),
+    );
+  });
+
+  it('names each artifact with an OS + arch token mise/ubi can resolve', () => {
+    // Tokens ubi accepts per platform/arch; the artifact name must contain one.
+    const osToken: Record<string, string> = { darwin: 'darwin', linux: 'linux' };
+    const archTokens: Record<string, string[]> = {
+      arm64: ['aarch64', 'arm64'],
+      x64: ['x86_64', 'amd64', 'x64'],
+    };
+    for (const { target, artifact } of pairs) {
+      const match = target.match(/^bun-(darwin|linux)-(arm64|x64)$/);
+      expect(match, `unexpected target ${target}`).not.toBeNull();
+      const os = match![1]!;
+      const arch = match![2]!;
+      expect(artifact).toContain(osToken[os]);
+      expect(
+        archTokens[arch]!.some((t: string) => artifact.includes(t)),
+        `${artifact} lacks an arch token for ${arch}`,
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
The release pipeline built darwin arm64/x86_64 and linux x86_64 but no Linux ARM64 artifact, so mise's `github:` backend had nothing to resolve on aarch64 Linux. This adds the missing target.

- Add a `bun-linux-arm64` entry to the `build` matrix producing `dad-linux-aarch64.tar.gz`, the exact ARM64 counterpart to `dad-linux-x86_64`.
- Cross-compiled with bun's `--target` flag (the mechanism already used to build darwin-x64 on an arm macOS runner), so no new/ARM runner is required.
- `attach-binaries` already globs `*.tar.gz`, so the new asset uploads with no further change. `aarch64` is the token ubi (mise's backend) matches for Linux ARM64, matching the existing `x86_64` naming style.
- Added `packages/cli/src/__tests__/release-workflow.test.ts` guarding matrix coverage and OS+arch artifact naming so a target can't be dropped or misnamed silently.

The Homebrew tap formula step is intentionally untouched (unrelated distribution channel; changing it would edit another repo's formula).

## Test evidence
- `bun run lint` -> 0 warnings, 0 errors
- `bun run format:check` -> all files formatted
- `bun run typecheck` -> 0 errors
- `bun run test:cli` -> 664 pass / 0 fail (includes the 2 new release-workflow tests)
- `bun run test:web` -> 235 pass / 0 fail
- `bun run build` -> web frontend built
- Local cross-compile: `bun build packages/cli/src/cli.ts --compile --target=bun-linux-arm64` -> bun reports `bun-linux-aarch64-v1.4.0`; `file` on the output: `ELF 64-bit LSB executable, ARM aarch64 ... for GNU/Linux`

Do not merge.
