### PR TITLE
fix(release): update Homebrew for Linux ARM64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,20 +108,32 @@ jobs:
           TAP_PATH: ${{ matrix.path }}
         run: |
           VER="${VERSION#v}"
-          SHA_ARM64=$(shasum -a 256 dad-darwin-arm64.tar.gz | cut -d' ' -f1)
-          SHA_X86_64=$(shasum -a 256 dad-darwin-x86_64.tar.gz | cut -d' ' -f1)
-          SHA_LINUX=$(shasum -a 256 dad-linux-x86_64.tar.gz | cut -d' ' -f1)
+          export SHA_DARWIN_ARM64=$(shasum -a 256 dad-darwin-arm64.tar.gz | cut -d' ' -f1)
+          export SHA_DARWIN_X86_64=$(shasum -a 256 dad-darwin-x86_64.tar.gz | cut -d' ' -f1)
+          export SHA_LINUX_X86_64=$(shasum -a 256 dad-linux-x86_64.tar.gz | cut -d' ' -f1)
+          export SHA_LINUX_ARM64=$(shasum -a 256 dad-linux-aarch64.tar.gz | cut -d' ' -f1)
           cd "$TAP_PATH"
           sed -i "s/version \".*\"/version \"${VER}\"/" Formula/dad.rb
-          python3 -c "
-          import re
+          # Map each exact artifact filename to its checksum. Each substitution
+          # must hit exactly one formula branch; a missing/renamed branch (count
+          # != 1) fails the release instead of publishing a wrong checksum.
+          python3 - <<'PY'
+          import os, re, sys
           f = 'Formula/dad.rb'
           txt = open(f).read()
-          shas = {'arm64': '${SHA_ARM64}', 'x86_64': '${SHA_X86_64}', 'linux': '${SHA_LINUX}'}
-          for arch, sha in shas.items():
-              txt = re.sub(r'(dad-.*' + arch + r'.*\n\s*sha256 \")([a-fA-F0-9]+|PLACEHOLDER_\w+)(\")', lambda m: m.group(1) + sha + m.group(3), txt)
+          mapping = {
+              'dad-darwin-arm64.tar.gz': os.environ['SHA_DARWIN_ARM64'],
+              'dad-darwin-x86_64.tar.gz': os.environ['SHA_DARWIN_X86_64'],
+              'dad-linux-x86_64.tar.gz': os.environ['SHA_LINUX_X86_64'],
+              'dad-linux-aarch64.tar.gz': os.environ['SHA_LINUX_ARM64'],
+          }
+          for artifact, sha in mapping.items():
+              pattern = re.compile(r'(' + re.escape(artifact) + r'"\n\s*sha256 ")([a-fA-F0-9]+|PLACEHOLDER_\w+)(")')
+              txt, n = pattern.subn(lambda m: m.group(1) + sha + m.group(3), txt)
+              if n != 1:
+                  sys.exit(f'expected exactly one sha256 substitution for {artifact}, got {n}')
           open(f, 'w').write(txt)
-          "
+          PY
 
       - name: Commit formula
         env:

--- a/packages/cli/src/__tests__/release-workflow.test.ts
+++ b/packages/cli/src/__tests__/release-workflow.test.ts
@@ -52,3 +52,45 @@ describe('release workflow build matrix', () => {
     }
   });
 });
+
+// Guards the Homebrew tap update so each published artifact's checksum is mapped
+// to exactly one formula branch by exact filename. A broad arch/OS regex could
+// match the wrong branch (e.g. `x86_64` hitting both darwin and linux) or a
+// missing branch could silently publish a stale/wrong sha256.
+describe('release workflow homebrew formula update', () => {
+  const updateStep = workflow.slice(workflow.indexOf('name: Update formula'));
+
+  it('computes a checksum for every published artifact, including linux aarch64', () => {
+    for (const artifact of [
+      'dad-darwin-arm64.tar.gz',
+      'dad-darwin-x86_64.tar.gz',
+      'dad-linux-x86_64.tar.gz',
+      'dad-linux-aarch64.tar.gz',
+    ]) {
+      expect(updateStep, `no shasum for ${artifact}`).toContain(`shasum -a 256 ${artifact}`);
+    }
+  });
+
+  it('maps each exact artifact filename to its checksum env var', () => {
+    const expected: Record<string, string> = {
+      'dad-darwin-arm64.tar.gz': 'SHA_DARWIN_ARM64',
+      'dad-darwin-x86_64.tar.gz': 'SHA_DARWIN_X86_64',
+      'dad-linux-x86_64.tar.gz': 'SHA_LINUX_X86_64',
+      'dad-linux-aarch64.tar.gz': 'SHA_LINUX_ARM64',
+    };
+    for (const [artifact, envVar] of Object.entries(expected)) {
+      expect(updateStep).toContain(`'${artifact}': os.environ['${envVar}']`);
+    }
+    // Reject any residual broad arch/OS regex that could match multiple branches.
+    expect(updateStep).not.toContain("'arm64':");
+    expect(updateStep).not.toContain('dad-.*');
+  });
+
+  it('honors the tap PLACEHOLDER_LINUX_ARM64 contract and fails on count != 1', () => {
+    // The coordinated homebrew-formulae PR adds the linux ARM branch with this
+    // placeholder; the substitution must accept it and require exactly one hit.
+    expect(updateStep).toContain('PLACEHOLDER_\\w+');
+    expect(updateStep).toContain('if n != 1:');
+    expect(updateStep).toContain('expected exactly one sha256 substitution');
+  });
+});


### PR DESCRIPTION
## Summary
- calculate the Linux ARM64 release checksum
- map all Homebrew checksums by exact artifact filename
- fail releases when a formula branch is missing

Coordinates with nicknisi/homebrew-formulae#1. Follow-up to #60.

## Verification
- bun run lint
- bun run format:check
- bun run typecheck
- bun run test
- bun run build