### PR TITLE
feat(narrative): enforce anchor validation with retry and repair

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}

--- a/packages/cli/src/__tests__/engine-single-pass-retry.test.ts
+++ b/packages/cli/src/__tests__/engine-single-pass-retry.test.ts
@@ -1,0 +1,130 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { generateNarrative } from '../narrative/engine';
+import type { DiffDadConfig } from '../config';
+import type { DiffFile, PRMetadata } from '../github/types';
+import type { NarrativeResponse } from '../narrative/types';
+
+/**
+ * Exercises the single-pass validation-retry + repair boundary hermetically. The AI layer points at a
+ * local mock speaking the OpenAI chat-completions SSE protocol (same pattern as engine-plan-cache.test.ts).
+ * First response anchors a diff section to a nonexistent hunk (validation fails → retry); second response
+ * is clean. The shipped narrative must contain no reference to a nonexistent hunk.
+ */
+
+let server: ReturnType<typeof Bun.serve>;
+let baseUrl: string;
+let requestCount = 0;
+
+function chunk(content: string | undefined, finishReason: string | null = null): string {
+  return JSON.stringify({
+    id: 'chatcmpl-test',
+    object: 'chat.completion.chunk',
+    created: 1,
+    model: 'gpt-4o',
+    choices: [{ index: 0, delta: content !== undefined ? { content } : {}, finish_reason: finishReason }],
+  });
+}
+
+function sse(lines: string[]): Response {
+  const body = [...lines.map((line) => `data: ${line}\n\n`), 'data: [DONE]\n\n'].join('');
+  return new Response(body, {
+    headers: { 'content-type': 'text/event-stream; charset=utf-8', 'cache-control': 'no-cache' },
+  });
+}
+
+function mkNarrative(title: string, hunkIndex: number): NarrativeResponse {
+  return {
+    title,
+    tldr: 'does a thing',
+    verdict: 'caution',
+    readingPlan: [],
+    concerns: [],
+    chapters: [
+      {
+        title: 'C',
+        summary: 's',
+        whyMatters: 'w',
+        risk: 'low',
+        sections: [{ type: 'diff', file: 'src/a.ts', hunkIndex, startLine: 1, endLine: 1 }],
+      },
+    ],
+  };
+}
+
+beforeAll(() => {
+  server = Bun.serve({
+    port: 0,
+    fetch() {
+      requestCount++;
+      // First call: reference a hunk that does not exist (only hunkIndex 0 is valid) → validation fails.
+      // Second call (retry): a clean narrative.
+      const narrative = requestCount === 1 ? mkNarrative('bad attempt', 5) : mkNarrative('clean retry', 0);
+      return sse([chunk(JSON.stringify(narrative)), chunk(undefined, 'stop')]);
+    },
+  });
+  baseUrl = `http://localhost:${server.port}/v1`;
+});
+
+afterAll(() => {
+  server.stop(true);
+});
+
+function config(): DiffDadConfig {
+  return { aiProvider: 'openai-compatible', aiBaseUrl: baseUrl, aiApiKey: 'test', aiModel: 'gpt-4o' };
+}
+
+// One file, one hunk → the small-PR short-circuit takes the single-pass path.
+const FILES: DiffFile[] = [
+  {
+    file: 'src/a.ts',
+    isNewFile: false,
+    isDeleted: false,
+    hunks: [
+      {
+        header: '@@ -1,1 +1,2 @@',
+        oldStart: 1,
+        oldCount: 1,
+        newStart: 1,
+        newCount: 2,
+        lines: [{ type: 'add', content: 'const b = 2;', lineNumber: { new: 2 } }],
+      },
+    ],
+  },
+];
+
+function mkPR(): PRMetadata {
+  return {
+    number: 7,
+    title: 'Single pass retry test',
+    body: '',
+    state: 'open',
+    draft: false,
+    author: { login: 'me', avatarUrl: '' },
+    branch: 'feat',
+    base: 'main',
+    labels: [],
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    additions: 1,
+    deletions: 0,
+    changedFiles: 1,
+    commits: 1,
+    headSha: 'sha-single',
+  };
+}
+
+describe('generateNarrative single-pass validation retry', () => {
+  it('retries once on anchoring failure and ships a repaired narrative', async () => {
+    requestCount = 0;
+    const { narrative } = await generateNarrative(mkPR(), FILES, [], config());
+
+    expect(requestCount).toBe(2); // first attempt failed validation → one retry
+    expect(narrative.title).toBe('clean retry');
+    // No shipped diff section references a nonexistent hunk.
+    for (const ch of narrative.chapters) {
+      for (const s of ch.sections) {
+        if (s.type === 'diff') expect(s.hunkIndex).toBeLessThan(FILES[0]!.hunks.length);
+      }
+    }
+  }, 10_000);
+});

--- a/packages/cli/src/__tests__/eval-judge.test.ts
+++ b/packages/cli/src/__tests__/eval-judge.test.ts
@@ -99,7 +99,7 @@ function runWith(hotspotPlacement: HotspotPlacementResult, fixtureId = 'syntheti
     provider: 'test',
     totalMs: 1000,
     proseWordCount: 100,
-    scores: { comprehensiveness: 4, rationality: 4, conciseness: 4, expressiveness: 4 },
+    scores: { comprehensiveness: 4, rationality: 4, conciseness: 4, expressiveness: 4, omission: 4 },
     scoreNotes: '',
     defectDetection: { surfaced: 1, expected: 1, detail: [] },
     hotspotPlacement,

--- a/packages/cli/src/__tests__/repair.test.ts
+++ b/packages/cli/src/__tests__/repair.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import { repairNarrative, validateNarrative } from '../narrative/validator';
+import type { NarrativeResponse } from '../narrative/types';
+import type { DiffFile, DiffHunk } from '../github/types';
+
+function hunk(): DiffHunk {
+  return { header: '@@', oldStart: 1, oldCount: 1, newStart: 1, newCount: 1, lines: [] };
+}
+
+function file(path: string, hunkCount: number): DiffFile {
+  return { file: path, isNewFile: false, isDeleted: false, hunks: Array.from({ length: hunkCount }, hunk) };
+}
+
+function diffSection(f: string, hunkIndex: number) {
+  return { type: 'diff' as const, file: f, hunkIndex, startLine: 1, endLine: 1 };
+}
+
+function narrative(chapters: NarrativeResponse['chapters']): NarrativeResponse {
+  return { title: 't', tldr: '', verdict: 'caution', readingPlan: [], concerns: [], chapters };
+}
+
+describe('repairNarrative', () => {
+  it('leaves a clean narrative untouched and drops nothing', () => {
+    const files = [file('a.ts', 2)];
+    const n = narrative([
+      {
+        title: 'A',
+        summary: 's',
+        whyMatters: 'w',
+        risk: 'low',
+        sections: [diffSection('a.ts', 0), diffSection('a.ts', 1)],
+      },
+    ]);
+    const { narrative: out, dropped } = repairNarrative(n, files);
+    expect(dropped).toEqual([]);
+    expect(out).toEqual(n);
+  });
+
+  it('strips an unknown-file diff section but keeps prose and valid refs', () => {
+    const files = [file('a.ts', 1)];
+    const n = narrative([
+      {
+        title: 'A',
+        summary: 's',
+        whyMatters: 'w',
+        risk: 'low',
+        sections: [{ type: 'narrative', content: 'keep me' }, diffSection('ghost.ts', 0), diffSection('a.ts', 0)],
+      },
+    ]);
+    const { narrative: out, dropped } = repairNarrative(n, files);
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0]).toMatchObject({ kind: 'unknown-file', file: 'ghost.ts', chapter: 0 });
+    expect(out.chapters[0]!.sections).toEqual([{ type: 'narrative', content: 'keep me' }, diffSection('a.ts', 0)]);
+  });
+
+  it('strips an invalid-hunk-index diff section', () => {
+    const files = [file('a.ts', 1)];
+    const n = narrative([
+      {
+        title: 'A',
+        summary: '',
+        whyMatters: '',
+        risk: 'low',
+        sections: [diffSection('a.ts', 5), diffSection('a.ts', 0)],
+      },
+    ]);
+    const { narrative: out, dropped } = repairNarrative(n, files);
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0]).toMatchObject({ kind: 'invalid-hunk-index', file: 'a.ts', hunkIndex: 5, chapter: 0 });
+    expect(out.chapters[0]!.sections).toEqual([diffSection('a.ts', 0)]);
+  });
+
+  it('strips an unresolvable reshow entry (ref out of range)', () => {
+    const files = [file('a.ts', 1)];
+    const n = narrative([
+      { title: '1', summary: '', whyMatters: '', risk: 'low', sections: [diffSection('a.ts', 0)] },
+      { title: '2', summary: '', whyMatters: '', risk: 'low', sections: [], reshow: [{ ref: 9, file: 'a.ts' }] },
+    ]);
+    const { narrative: out, dropped } = repairNarrative(n, files);
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0]).toMatchObject({ kind: 'reshow-unresolved', chapter: 1, ref: 9 });
+    expect(out.chapters[1]!.reshow).toBeUndefined();
+  });
+
+  it('strips a reshow pointing at an unknown file', () => {
+    const files = [file('a.ts', 1)];
+    const n = narrative([
+      { title: '1', summary: '', whyMatters: '', risk: 'low', sections: [diffSection('a.ts', 0)] },
+      { title: '2', summary: '', whyMatters: '', risk: 'low', sections: [], reshow: [{ ref: 0, file: 'ghost.ts' }] },
+    ]);
+    const { narrative: out, dropped } = repairNarrative(n, files);
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0]).toMatchObject({ kind: 'reshow-unresolved', chapter: 1, ref: 0, file: 'ghost.ts' });
+    expect(out.chapters[1]!.reshow).toBeUndefined();
+  });
+
+  it('keeps a valid reshow that points back at an earlier chapter', () => {
+    const files = [file('a.ts', 2)];
+    const n = narrative([
+      { title: '1', summary: '', whyMatters: '', risk: 'low', sections: [diffSection('a.ts', 0)] },
+      {
+        title: '2',
+        summary: '',
+        whyMatters: '',
+        risk: 'low',
+        sections: [diffSection('a.ts', 1)],
+        reshow: [{ ref: 0, file: 'a.ts' }],
+      },
+    ]);
+    const { narrative: out, dropped } = repairNarrative(n, files);
+    expect(dropped).toEqual([]);
+    expect(out.chapters[1]!.reshow).toEqual([{ ref: 0, file: 'a.ts' }]);
+  });
+
+  it('does not strip a forward-ref reshow (the hunk exists)', () => {
+    const files = [file('a.ts', 2)];
+    const n = narrative([
+      {
+        title: '1',
+        summary: '',
+        whyMatters: '',
+        risk: 'low',
+        sections: [diffSection('a.ts', 0)],
+        reshow: [{ ref: 1, file: 'a.ts' }],
+      },
+      { title: '2', summary: '', whyMatters: '', risk: 'low', sections: [diffSection('a.ts', 1)] },
+    ]);
+    const { narrative: out, dropped } = repairNarrative(n, files);
+    expect(dropped).toEqual([]);
+    expect(out.chapters[0]!.reshow).toEqual([{ ref: 1, file: 'a.ts' }]);
+  });
+
+  it('produces a narrative with no unresolvable refs left (validator agrees)', () => {
+    const files = [file('a.ts', 2)];
+    const n = narrative([
+      {
+        title: 'A',
+        summary: '',
+        whyMatters: '',
+        risk: 'low',
+        sections: [diffSection('a.ts', 0), diffSection('ghost.ts', 0), diffSection('a.ts', 7)],
+        reshow: [{ ref: 42, file: 'a.ts' }],
+      },
+      { title: 'B', summary: '', whyMatters: '', risk: 'low', sections: [diffSection('a.ts', 1)] },
+    ]);
+    const { narrative: out } = repairNarrative(n, files);
+    const kinds = new Set(validateNarrative(out, files).violations.map((v) => v.kind));
+    expect(kinds.has('unknown-file')).toBe(false);
+    expect(kinds.has('invalid-hunk-index')).toBe(false);
+    expect(kinds.has('reshow-unresolved')).toBe(false);
+  });
+});

--- a/packages/cli/src/eval/judge.ts
+++ b/packages/cli/src/eval/judge.ts
@@ -12,12 +12,13 @@ import type {
 
 const JUDGE_SYSTEM = `You are a strict code-review-quality judge. You evaluate AI-generated PR review narratives against ground truth.
 
-Use this 4-axis rubric (1-5 each, integer):
+Use this 5-axis rubric (1-5 each, integer):
 
 - COMPREHENSIVENESS: did the narrative cover the meaningful changes? Penalize if it missed major behavior changes the diff makes. (1=missed most, 5=covered all material changes)
 - RATIONALITY: did each chapter explain WHY (whyMatters) the change matters, not just describe WHAT? Penalize "describes the code" output. (1=mostly describes, 5=consistently explains consequences)
 - CONCISENESS: tight prose, no padding, no repetition? Penalize bloated narration with low insight density. (1=very padded, 5=very tight)
 - EXPRESSIVENESS: clear, specific, well-anchored to file:line? Penalize vague "it does several things" prose. (1=vague, 5=specific and anchored)
+- OMISSION: were words spent proportional to importance? Distinct from CONCISENESS (tightness of the prose that exists): OMISSION judges what got prose AT ALL. Penalize any narration of mechanical or low-risk changes — renames, formatting, lockfiles, generated code, boilerplate, test scaffolding — that deserved silence or a one-line mention. Reward narratives that skip or compress the unimportant even when the diff includes plenty of it. (1=narrates everything equally, 5=every word lands where the risk is)
 
 Return ONLY this JSON, no markdown fences, no prose:
 {
@@ -25,6 +26,7 @@ Return ONLY this JSON, no markdown fences, no prose:
   "rationality": <1-5>,
   "conciseness": <1-5>,
   "expressiveness": <1-5>,
+  "omission": <1-5>,
   "notes": "<2-3 sentences explaining the lowest score>"
 }`;
 
@@ -134,6 +136,7 @@ export async function scoreNarrative(
     rationality: number;
     conciseness: number;
     expressiveness: number;
+    omission: number;
     notes?: string;
   }>(result.text);
 
@@ -153,6 +156,7 @@ export async function scoreNarrative(
       rationality: clamp(parsed.rationality),
       conciseness: clamp(parsed.conciseness),
       expressiveness: clamp(parsed.expressiveness),
+      omission: clamp(parsed.omission),
     },
     notes: typeof parsed.notes === 'string' ? parsed.notes : '',
   };

--- a/packages/cli/src/eval/run.ts
+++ b/packages/cli/src/eval/run.ts
@@ -104,7 +104,7 @@ async function runOne(
     const totalMs = Date.now() - startedAt;
     provider = result.provider;
     const proseWordCount = countProseWords(result.narrative);
-    let scores = { comprehensiveness: 0, rationality: 0, conciseness: 0, expressiveness: 0 };
+    let scores = { comprehensiveness: 0, rationality: 0, conciseness: 0, expressiveness: 0, omission: 0 };
     let scoreNotes = '';
     try {
       const judged = await scoreNarrative(result.narrative, fixture, judgeConfig);
@@ -146,7 +146,7 @@ async function runOne(
       provider,
       totalMs: 0,
       proseWordCount: 0,
-      scores: { comprehensiveness: 0, rationality: 0, conciseness: 0, expressiveness: 0 },
+      scores: { comprehensiveness: 0, rationality: 0, conciseness: 0, expressiveness: 0, omission: 0 },
       scoreNotes: '',
       defectDetection: { surfaced: 0, expected: fixture.groundTruth.expectedConcerns.length, detail: [] },
       hotspotPlacement: HOTSPOTS_UNSCORED,
@@ -166,6 +166,7 @@ export function aggregate(runs: EvalRun[]): Baseline['aggregate'] {
       avgRationality: 0,
       avgConciseness: 0,
       avgExpressiveness: 0,
+      avgOmission: 0,
       avgTimeToFirstPartialMs: null,
       avgTotalMs: 0,
       avgProseWordCount: 0,
@@ -189,6 +190,7 @@ export function aggregate(runs: EvalRun[]): Baseline['aggregate'] {
     avgRationality: avg(runs.map((r) => r.scores.rationality)),
     avgConciseness: avg(runs.map((r) => r.scores.conciseness)),
     avgExpressiveness: avg(runs.map((r) => r.scores.expressiveness)),
+    avgOmission: avg(runs.map((r) => r.scores.omission)),
     avgTimeToFirstPartialMs: ttfp.length > 0 ? Math.round(avg(ttfp)) : null,
     avgTotalMs: Math.round(avg(runs.map((r) => r.totalMs))),
     avgProseWordCount: Math.round(avg(runs.map((r) => r.proseWordCount))),
@@ -249,7 +251,7 @@ async function main() {
     }
     const s = run.scores;
     console.log(
-      `  scores: comp=${s.comprehensiveness} rat=${s.rationality} con=${s.conciseness} exp=${s.expressiveness}${run.scoreNotes ? `\n  notes: ${run.scoreNotes}` : ''}`,
+      `  scores: comp=${s.comprehensiveness} rat=${s.rationality} con=${s.conciseness} exp=${s.expressiveness} omit=${s.omission}${run.scoreNotes ? `\n  notes: ${run.scoreNotes}` : ''}`,
     );
     if (run.errors?.length) {
       for (const e of run.errors) console.log(`  ! ${e}`);
@@ -268,7 +270,7 @@ async function main() {
   await writeFile(outputPath, JSON.stringify(baseline, null, 2) + '\n');
   console.log(`\nBaseline written: ${outputPath}`);
   console.log(
-    `Aggregate: comp=${baseline.aggregate.avgComprehensiveness.toFixed(2)} rat=${baseline.aggregate.avgRationality.toFixed(2)} con=${baseline.aggregate.avgConciseness.toFixed(2)} exp=${baseline.aggregate.avgExpressiveness.toFixed(2)} recall=${baseline.aggregate.avgDefectRecall} hotspots=${baseline.aggregate.avgHotspotPlacement} ttfp=${baseline.aggregate.avgTimeToFirstPartialMs ?? 'n/a'}ms total=${baseline.aggregate.avgTotalMs}ms`,
+    `Aggregate: comp=${baseline.aggregate.avgComprehensiveness.toFixed(2)} rat=${baseline.aggregate.avgRationality.toFixed(2)} con=${baseline.aggregate.avgConciseness.toFixed(2)} exp=${baseline.aggregate.avgExpressiveness.toFixed(2)} omit=${baseline.aggregate.avgOmission.toFixed(2)} recall=${baseline.aggregate.avgDefectRecall} hotspots=${baseline.aggregate.avgHotspotPlacement} ttfp=${baseline.aggregate.avgTimeToFirstPartialMs ?? 'n/a'}ms total=${baseline.aggregate.avgTotalMs}ms`,
   );
 }
 

--- a/packages/cli/src/eval/types.ts
+++ b/packages/cli/src/eval/types.ts
@@ -48,6 +48,8 @@ export type RubricScores = {
   rationality: number;
   conciseness: number;
   expressiveness: number;
+  /** Words spent proportional to importance — penalizes narrating mechanical/low-risk changes at all. */
+  omission: number;
 };
 
 export type DefectDetectionResult = {
@@ -117,6 +119,7 @@ export type Baseline = {
     avgRationality: number;
     avgConciseness: number;
     avgExpressiveness: number;
+    avgOmission: number;
     avgTimeToFirstPartialMs: number | null;
     avgTotalMs: number;
     avgProseWordCount: number;

--- a/packages/cli/src/narrative/engine.ts
+++ b/packages/cli/src/narrative/engine.ts
@@ -4,7 +4,7 @@ import type { RepoContext } from '../repo/snapshot';
 import { buildNarrativePrompt, type PreviousNarrativeContext, type PromptCapStats } from './prompt';
 import { partitionMechanicalFiles } from './diff-filter';
 import { normalizeNarrative, type NarrativeChapter, type NarrativeResponse } from './types';
-import { formatViolation, validateNarrative } from './validator';
+import { formatViolation, repairNarrative, validateNarrative, type ValidationViolation } from './validator';
 import { callAi as _callAi, resolveAiPath, type AiChunkHandler } from './ai-runtime';
 import { extractJson, tryParsePartialJson } from './json-parse';
 import { computeHints } from './hints';
@@ -85,19 +85,32 @@ function logPromptStats(stats: PromptCapStats, mechanicalSkipped: number): void 
   for (const l of lines) console.error(`  ${l}`);
 }
 
-function logNarrativeViolations(narrative: NarrativeResponse, files: DiffFile[]): void {
-  const validation = validateNarrative(narrative, files);
-  if (validation.ok) return;
+function logViolationList(prefix: string, violations: ValidationViolation[]): void {
+  if (violations.length === 0) return;
   const counts = new Map<string, number>();
-  for (const v of validation.violations) counts.set(v.kind, (counts.get(v.kind) ?? 0) + 1);
+  for (const v of violations) counts.set(v.kind, (counts.get(v.kind) ?? 0) + 1);
   const summary = [...counts.entries()].map(([k, n]) => `${n} ${k}`).join(', ');
-  console.error(`${YELLOW}  ⚠ Narrative validation: ${summary}${RESET}`);
-  for (const v of validation.violations.slice(0, 10)) {
+  console.error(`${YELLOW}  ⚠ ${prefix}: ${summary}${RESET}`);
+  for (const v of violations.slice(0, 10)) {
     console.error(`${DIM}      ${formatViolation(v)}${RESET}`);
   }
-  if (validation.violations.length > 10) {
-    console.error(`${DIM}      … and ${validation.violations.length - 10} more${RESET}`);
+  if (violations.length > 10) {
+    console.error(`${DIM}      … and ${violations.length - 10} more${RESET}`);
   }
+}
+
+function logNarrativeViolations(narrative: NarrativeResponse, files: DiffFile[]): void {
+  logViolationList('Narrative validation', validateNarrative(narrative, files).violations);
+}
+
+/**
+ * Blocking repair boundary: strip any diff/reshow ref the UI cannot resolve, log what was dropped,
+ * and return the ship-safe narrative. After this call no chapter references a nonexistent hunk.
+ */
+function repairAndLog(narrative: NarrativeResponse, files: DiffFile[]): NarrativeResponse {
+  const { narrative: repaired, dropped } = repairNarrative(narrative, files);
+  logViolationList('Narrative repair dropped unresolvable refs', dropped);
+  return repaired;
 }
 
 export type NarrativeGenerationOptions = {
@@ -338,10 +351,49 @@ async function generateNarrativeTwoPass(
   });
   await runWithConcurrency(tasks, writerConcurrency);
 
-  const narrative = normalizeNarrative(assembleNarrative(plan, chapters));
   // Validate against the same filtered set the plan was built from — mechanical files (lockfiles,
   // generated) are deliberately unplanned, so checking fullFiles would report them all as orphans.
-  logNarrativeViolations(narrative, narrate);
+  let assembled = normalizeNarrative(assembleNarrative(plan, chapters));
+  const validation = validateNarrative(assembled, narrate);
+  if (!validation.ok) {
+    logNarrativeViolations(assembled, narrate);
+    // Retry ONLY the offending non-suppressed chapters, once, with their own violations as
+    // anchoring feedback. Chapters map 1:1 to plan.themes by index.
+    const perChapter = new Map<number, ValidationViolation[]>();
+    for (const v of validation.violations) {
+      const chapterIdxs = v.kind === 'duplicate-primary' ? v.chapters : 'chapter' in v ? [v.chapter] : [];
+      for (const ci of chapterIdxs) {
+        const arr = perChapter.get(ci);
+        if (arr) arr.push(v);
+        else perChapter.set(ci, [v]);
+      }
+    }
+    const retryTasks = [...perChapter.entries()]
+      .filter(([ci]) => plan.themes[ci] && !plan.themes[ci]!.suppress)
+      .map(([ci, vs]) => async () => {
+        const theme = plan.themes[ci]!;
+        const result = await writeChapter({
+          plan,
+          theme,
+          files: fullFiles,
+          fileTree,
+          config,
+          repoContext: options.repoContext,
+          retryFeedback: vs.map(formatViolation).join('\n'),
+        });
+        if (!writerProvider) writerProvider = result.provider;
+        chapters[ci] = result.chapter;
+        options.onChapter?.({ themeId: theme.id, index: ci, chapter: result.chapter });
+        if (options.onPartial) options.onPartial(assembleNarrative(plan, chapters));
+      });
+    if (retryTasks.length > 0) {
+      console.error(`${DIM}  Retrying ${retryTasks.length} chapter(s) with anchoring feedback${RESET}`);
+      await runWithConcurrency(retryTasks, writerConcurrency);
+      assembled = normalizeNarrative(assembleNarrative(plan, chapters));
+    }
+  }
+  // Final blocking boundary: strip whatever still doesn't resolve so the UI never sees a bad ref.
+  const narrative = repairAndLog(assembled, narrate);
   const provider = writerProvider ? `${plannerProvider} + ${writerProvider}` : plannerProvider;
   return { narrative, provider, capStats };
 }
@@ -374,67 +426,83 @@ async function generateNarrativeSinglePass(
   const debugPerf = Boolean(process.env.DIFFDAD_DEBUG_PERF);
   const startedAt = Date.now();
 
-  const MAX_RETRIES = 2;
-  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    let chars = 0;
-    let buffer = '';
-    let lastEmittedHash = '';
-    let firstChunkAt: number | undefined;
-    let firstPartialAt: number | undefined;
+  // One streamed generation with internal truncation retries. Returns a parsed narrative, or throws.
+  const runAttempt = async (userPrompt: string): Promise<{ narrative: NarrativeResponse; provider: string }> => {
+    const MAX_RETRIES = 2;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      let chars = 0;
+      let buffer = '';
+      let lastEmittedHash = '';
+      let firstChunkAt: number | undefined;
+      let firstPartialAt: number | undefined;
 
-    const emitPartialIfChanged = (onPartial: NarrativePartialHandler) => {
-      const parsed = tryParsePartialJson(buffer);
-      if (!parsed) return;
-      const partial = normalizeNarrative(parsed);
-      const planChars = partial.readingPlan.reduce((s, p) => s + p.step.length + (p.why?.length ?? 0), 0);
-      const concernChars = partial.concerns.reduce((s, c) => s + c.question.length + c.why.length, 0);
-      const chapterChars = partial.chapters.reduce(
-        (s, c) => s + c.title.length + c.summary.length + c.whyMatters.length,
-        0,
-      );
-      const hash = `${partial.title.length}|${partial.tldr.length}|${partial.verdict}|${partial.readingPlan.length}|${partial.concerns.length}|${partial.chapters.length}|${planChars}|${concernChars}|${chapterChars}`;
-      if (hash === lastEmittedHash) return;
-      lastEmittedHash = hash;
-      if (firstPartialAt === undefined) firstPartialAt = Date.now();
-      onPartial(partial);
-    };
+      const emitPartialIfChanged = (onPartial: NarrativePartialHandler) => {
+        const parsed = tryParsePartialJson(buffer);
+        if (!parsed) return;
+        const partial = normalizeNarrative(parsed);
+        const planChars = partial.readingPlan.reduce((s, p) => s + p.step.length + (p.why?.length ?? 0), 0);
+        const concernChars = partial.concerns.reduce((s, c) => s + c.question.length + c.why.length, 0);
+        const chapterChars = partial.chapters.reduce(
+          (s, c) => s + c.title.length + c.summary.length + c.whyMatters.length,
+          0,
+        );
+        const hash = `${partial.title.length}|${partial.tldr.length}|${partial.verdict}|${partial.readingPlan.length}|${partial.concerns.length}|${partial.chapters.length}|${planChars}|${concernChars}|${chapterChars}`;
+        if (hash === lastEmittedHash) return;
+        lastEmittedHash = hash;
+        if (firstPartialAt === undefined) firstPartialAt = Date.now();
+        onPartial(partial);
+      };
 
-    const onChunk: AiChunkHandler | undefined =
-      options.onProgress || options.onPartial || debugPerf
-        ? (delta) => {
-            chars += delta.length;
-            buffer += delta;
-            if (firstChunkAt === undefined) firstChunkAt = Date.now();
-            options.onProgress?.({ delta, chars });
-            if (options.onPartial) emitPartialIfChanged(options.onPartial);
-          }
-        : undefined;
+      const onChunk: AiChunkHandler | undefined =
+        options.onProgress || options.onPartial || debugPerf
+          ? (delta) => {
+              chars += delta.length;
+              buffer += delta;
+              if (firstChunkAt === undefined) firstChunkAt = Date.now();
+              options.onProgress?.({ delta, chars });
+              if (options.onPartial) emitPartialIfChanged(options.onPartial);
+            }
+          : undefined;
 
-    const result = await _callAi(config, system, user, NARRATIVE_MAX_TOKENS, onChunk);
+      const result = await _callAi(config, system, userPrompt, NARRATIVE_MAX_TOKENS, onChunk);
 
-    const json = extractJson(result.text);
-    try {
-      const parsed = JSON.parse(json);
-      const narrative = normalizeNarrative(parsed);
-      if (debugPerf) {
-        const { path } = resolveAiPath(config);
-        const fmt = (t: number | undefined) => (t === undefined ? '-' : `${((t - startedAt) / 1000).toFixed(1)}s`);
-        const total = ((Date.now() - startedAt) / 1000).toFixed(1);
-        console.error(
-          `Narrative perf: path=${path} provider="${result.provider}" firstChunk=${fmt(firstChunkAt)} firstPartial=${fmt(firstPartialAt)} total=${total}s chapters=${narrative.chapters.length} chars=${chars}`,
+      const json = extractJson(result.text);
+      try {
+        const parsed = JSON.parse(json);
+        const narrative = normalizeNarrative(parsed);
+        if (debugPerf) {
+          const { path } = resolveAiPath(config);
+          const fmt = (t: number | undefined) => (t === undefined ? '-' : `${((t - startedAt) / 1000).toFixed(1)}s`);
+          const total = ((Date.now() - startedAt) / 1000).toFixed(1);
+          console.error(
+            `Narrative perf: path=${path} provider="${result.provider}" firstChunk=${fmt(firstChunkAt)} firstPartial=${fmt(firstPartialAt)} total=${total}s chapters=${narrative.chapters.length} chars=${chars}`,
+          );
+        }
+        return { narrative, provider: result.provider };
+      } catch (err) {
+        if (result.truncated && attempt < MAX_RETRIES) {
+          console.log(`Narrative truncated (attempt ${attempt + 1}/${MAX_RETRIES + 1}), retrying...`);
+          continue;
+        }
+        throw new Error(
+          `Failed to parse narrative JSON: ${(err as Error).message}${result.truncated ? " (response was truncated — PR may be too large for the model's output limit)" : ''}`,
         );
       }
-      logNarrativeViolations(narrative, narrate);
-      return { narrative, provider: result.provider, capStats: stats };
-    } catch (err) {
-      if (result.truncated && attempt < MAX_RETRIES) {
-        console.log(`Narrative truncated (attempt ${attempt + 1}/${MAX_RETRIES + 1}), retrying...`);
-        continue;
-      }
-      throw new Error(
-        `Failed to parse narrative JSON: ${(err as Error).message}${result.truncated ? " (response was truncated — PR may be too large for the model's output limit)" : ''}`,
-      );
     }
+    throw new Error('Unreachable');
+  };
+
+  // Validation retry: generate, and if the narrative anchors to nonexistent hunks, retry ONCE with the
+  // violations appended as feedback. Then repair whatever still doesn't resolve before shipping.
+  let attemptResult = await runAttempt(user);
+  const validation = validateNarrative(attemptResult.narrative, narrate);
+  if (!validation.ok) {
+    logNarrativeViolations(attemptResult.narrative, narrate);
+    const feedback = validation.violations.map(formatViolation).join('\n');
+    const retryUser = `${user}\n\n---\n\nYour previous attempt had these anchoring errors. Fix them: every diff section and reshow must reference a real file and a valid hunkIndex from the diff above. Drop any reference you cannot anchor.\n${feedback}`;
+    console.error(`${DIM}  Retrying single-pass narrative with anchoring feedback${RESET}`);
+    attemptResult = await runAttempt(retryUser);
   }
-  throw new Error('Unreachable');
+  const narrative = repairAndLog(attemptResult.narrative, narrate);
+  return { narrative, provider: attemptResult.provider, capStats: stats };
 }

--- a/packages/cli/src/narrative/prompt.ts
+++ b/packages/cli/src/narrative/prompt.ts
@@ -66,8 +66,19 @@ const MAX_THEMES = 7;
 // interpretation legend, and every risk score moved with the rescaled centrality term. Risk hints reach
 // the planner through `buildSharedHeader`, so plans change too — without both bumps, every PR already
 // reviewed at the same head SHA would keep serving its diff-only narrative from cache.
-export const PLANNER_PROMPT_REVISION = 2;
-export const NARRATIVE_PROMPT_REVISION = 3;
+// Bumped again for the reader-contract + omission mandate added to the prose prompts (single-pass,
+// writer, and planner prose guidance). Both keys move so every cached plan and narrative regenerates
+// against the new instructions.
+export const PLANNER_PROMPT_REVISION = 3;
+export const NARRATIVE_PROMPT_REVISION = 4;
+
+// Shared reader-contract + omission mandate injected into every prompt that produces reader-facing
+// prose. (a) forces the model to spend its budget deciding what to leave out; (b) pins the reader's
+// knowledge to the PR text + this narrative, so mid-implementation jargon never leaks through.
+const READER_CONTRACT = `## Reader contract & omission mandate
+
+- **Omit aggressively.** Spend substantial reasoning effort deciding what to OMIT rather than what to include; deep analysis followed by a small amount of clear output is the correct tradeoff. Every word taxes the reader.
+- **Reader model.** The reader sees ONLY the PR title/description and your narrative. Never reference internal abstractions, temporary names, or mid-implementation concepts as if the reader already knows them.`;
 
 const RESPONSE_SCHEMA = `{
   "title": "string — short title for the PR's review story",
@@ -199,6 +210,8 @@ const SYSTEM_PROMPT = `You are Diff Dad, a senior engineer producing a code revi
 
 ${SHARED_PRINCIPLES}
 
+${READER_CONTRACT}
+
 ## What to produce
 
 ### tldr (1 sentence)
@@ -269,6 +282,10 @@ ${RESPONSE_SCHEMA}`;
 const PLANNER_SYSTEM_PROMPT = `You are Diff Dad's planner. You are running the FIRST of two passes: you decide the chapter structure for a PR review, then a second pass writes the prose.
 
 ${SHARED_PRINCIPLES}
+
+${READER_CONTRACT}
+
+The reading plan, concerns, tldr, and theme rationales you emit here are reader-facing prose — the omission mandate and reader model above apply to every one of them.
 
 ## Your job in this pass
 
@@ -396,6 +413,8 @@ ${PLAN_RESPONSE_SCHEMA}`;
 const WRITER_SYSTEM_PROMPT = `You are Diff Dad's writer. You are running the SECOND of two passes: a planner has already decided the chapter structure; you write the prose for ONE theme.
 
 ${SHARED_PRINCIPLES}
+
+${READER_CONTRACT}
 
 ## Your job in this pass
 
@@ -631,6 +650,8 @@ export interface WriterPromptInput {
   fullFileTree: string[];
   /** Base-branch snapshot, when one resolved. See {@link NarrativePromptInput.repoContext}. */
   repoContext?: RepoContext;
+  /** Formatted anchoring-error feedback from a previous failed attempt at this chapter. */
+  retryFeedback?: string;
 }
 
 function normalizePath(p: string): string {
@@ -687,7 +708,7 @@ function formatThemeDiff(files: DiffFile[], theme: PlanTheme): string {
 
 /** Build the writer prompt for one theme — second pass of the two-pass pipeline. */
 export function buildWriterPrompt(input: WriterPromptInput): NarrativePrompt {
-  const { plan, theme, files, fullFileTree, repoContext } = input;
+  const { plan, theme, files, fullFileTree, repoContext, retryFeedback } = input;
   const risks = computeRisk(files, repoContext);
   const diffBlock = formatThemeDiff(files, theme);
 
@@ -721,6 +742,16 @@ export function buildWriterPrompt(input: WriterPromptInput): NarrativePrompt {
   if (fullFileTree.length > 0) {
     const tree = fullFileTree.slice(0, 50).join(', ');
     parts.push(`(Project file tree, first 50: ${tree})`, '');
+  }
+
+  if (retryFeedback) {
+    parts.push(
+      '---',
+      '',
+      'Your previous attempt at this chapter had these anchoring errors. Fix them: reference only the hunks listed above, at valid hunk indices, and drop any section that points at a file or hunk not in this theme.',
+      retryFeedback,
+      '',
+    );
   }
 
   // Suppressed themes never reach the writer — the engine synthesizes them via

--- a/packages/cli/src/narrative/validator.ts
+++ b/packages/cli/src/narrative/validator.ts
@@ -129,6 +129,82 @@ export function validateNarrative(narrative: NarrativeResponse, files: DiffFile[
   return { ok: violations.length === 0, violations };
 }
 
+export type RepairResult = {
+  narrative: NarrativeResponse;
+  dropped: ValidationViolation[];
+};
+
+/**
+ * Pure repair pass: strip any diff section or reshow entry that references a hunk the UI cannot
+ * resolve (unknown file, out-of-range hunkIndex, or a reshow that points at a nonexistent hunk).
+ * Prose (narrative sections, titles, summaries, callouts) is untouched — only broken code refs are
+ * removed. The returned narrative is safe to ship: the UI will never receive a reference to a
+ * hunk that does not exist. `dropped` lists exactly what was removed, for logging.
+ *
+ * Kept intentionally narrow: `orphan-hunk` (a real hunk nobody references) and `duplicate-primary`
+ * / `reshow-forward-ref` (refs that DO resolve to a real hunk, just structurally suboptimal) are
+ * NOT stripped — they don't point at anything nonexistent.
+ */
+export function repairNarrative(narrative: NarrativeResponse, files: DiffFile[]): RepairResult {
+  const dropped: ValidationViolation[] = [];
+  const fileMap = new Map<string, DiffFile>();
+  for (const f of files) fileMap.set(normalizePath(f.file), f);
+
+  // (file:hunkIndex) referenced as a primary diff section by an earlier chapter — mirrors the
+  // frontend fallback used to resolve a reshow entry with no explicit `file`.
+  const primaryRefs = new Map<string, number[]>();
+
+  const chapters = narrative.chapters.map((ch, ci) => {
+    const sections = ch.sections.filter((s) => {
+      if (s.type !== 'diff') return true;
+      const norm = normalizePath(s.file);
+      const file = fileMap.get(norm);
+      if (!file) {
+        dropped.push({ kind: 'unknown-file', file: s.file, chapter: ci });
+        return false;
+      }
+      if (s.hunkIndex < 0 || s.hunkIndex >= file.hunks.length) {
+        dropped.push({ kind: 'invalid-hunk-index', file: s.file, hunkIndex: s.hunkIndex, chapter: ci });
+        return false;
+      }
+      const key = `${norm}:${s.hunkIndex}`;
+      const arr = primaryRefs.get(key);
+      if (arr) arr.push(ci);
+      else primaryRefs.set(key, [ci]);
+      return true;
+    });
+
+    let reshow = ch.reshow;
+    if (reshow && reshow.length > 0) {
+      reshow = reshow.filter((entry) => {
+        let resolvedNorm: string | undefined;
+        if (entry.file) {
+          resolvedNorm = normalizePath(entry.file);
+        } else {
+          for (const [key, owners] of primaryRefs) {
+            const sep = key.lastIndexOf(':');
+            if (Number(key.slice(sep + 1)) === entry.ref && owners.some((c) => c < ci)) {
+              resolvedNorm = key.slice(0, sep);
+              break;
+            }
+          }
+        }
+        const file = resolvedNorm ? fileMap.get(resolvedNorm) : undefined;
+        if (!file || entry.ref < 0 || entry.ref >= file.hunks.length) {
+          dropped.push({ kind: 'reshow-unresolved', chapter: ci, ref: entry.ref, file: entry.file });
+          return false;
+        }
+        return true;
+      });
+      if (reshow.length === 0) reshow = undefined;
+    }
+
+    return { ...ch, sections, reshow };
+  });
+
+  return { narrative: { ...narrative, chapters }, dropped };
+}
+
 /** One-line human-readable summary of a violation, for warning logs. */
 export function formatViolation(v: ValidationViolation): string {
   switch (v.kind) {

--- a/packages/cli/src/narrative/writer.ts
+++ b/packages/cli/src/narrative/writer.ts
@@ -15,6 +15,8 @@ export type WriterInput = {
   config: DiffDadConfig;
   /** Base-branch snapshot, when one resolved — widens inbound-reference counting to repo-wide. */
   repoContext?: RepoContext;
+  /** Formatted anchoring-error feedback from a previous failed attempt at this chapter. */
+  retryFeedback?: string;
 };
 
 export type WriterResult = {
@@ -37,8 +39,8 @@ function normalizePath(p: string): string {
 }
 
 export async function writeChapter(input: WriterInput): Promise<WriterResult> {
-  const { plan, theme, files, fileTree, config, repoContext } = input;
-  const prompt = buildWriterPrompt({ plan, theme, files, fullFileTree: fileTree, repoContext });
+  const { plan, theme, files, fileTree, config, repoContext, retryFeedback } = input;
+  const prompt = buildWriterPrompt({ plan, theme, files, fullFileTree: fileTree, repoContext, retryFeedback });
 
   const result = await callAi(config, prompt.system, prompt.user, WRITER_MAX_TOKENS);
   const parsed = parseChapterResponse(result.text, theme.id);


### PR DESCRIPTION
Narrative validation previously only logged violations — chapters could
ship diff sections pointing at files or hunks that don't exist, and the
UI rendered around the holes. Generation now treats anchoring as a
contract:

- repairNarrative() strips unresolvable diff sections and reshow refs
  as a final blocking boundary before any narrative is returned
- two-pass: chapters with violations get one writer retry with the
  formatted violations as explicit feedback before repair
- single-pass: one full retry with violations appended, then repair
- writer/planner/single-pass prompts gain a reader contract: decide
  what to omit, and never reference mid-implementation concepts the
  reader can't know (reader sees only PR title/description + narrative)
- prompt revisions bumped so cached narratives regenerate

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>