### PR TITLE
feat(cache): sealed narrative revisions with last-good fallback

### DIFF
--- a/packages/cli/src/__tests__/narrative-revisions.test.ts
+++ b/packages/cli/src/__tests__/narrative-revisions.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { mkdtemp, readdir, readFile, rm, writeFile, utimes } from 'fs/promises';
+import {
+  appendNarrativeRevision,
+  cacheNarrative,
+  computePromptMetaHash,
+  getLastGoodNarrative,
+} from '../narrative/cache';
+import { withLock } from '../narrative/file-lock';
+import type { NarrativeResponse } from '../narrative/types';
+
+const OWNER = 'acme';
+const REPO = 'widgets';
+const PR = 42;
+const META = computePromptMetaHash({ title: 't', body: 'b', labels: [] });
+const PROVIDER = 'claude-haiku';
+
+let cacheDir: string;
+
+beforeEach(async () => {
+  cacheDir = await mkdtemp(join(tmpdir(), 'diffdad-rev-'));
+});
+
+afterEach(async () => {
+  await rm(cacheDir, { recursive: true, force: true });
+});
+
+function mkResponse(overrides: Partial<NarrativeResponse> = {}): NarrativeResponse {
+  return {
+    title: 'A PR',
+    tldr: 'Adds X.',
+    verdict: 'safe',
+    readingPlan: [],
+    concerns: [],
+    chapters: [{ title: 'Chapter 1', summary: 's', whyMatters: 'w', risk: 'low', sections: [] }],
+    ...overrides,
+  };
+}
+
+function revDir(): string {
+  return join(cacheDir, 'revisions', `${OWNER}-${REPO}-${PR}`);
+}
+
+describe('narrative revisions', () => {
+  it('returns null when no revision exists', async () => {
+    expect(await getLastGoodNarrative(OWNER, REPO, PR, { cacheDir })).toBeNull();
+  });
+
+  it('seals a revision and advances the pointer on write', async () => {
+    await appendNarrativeRevision(OWNER, REPO, PR, 'sha1', META, PROVIDER, mkResponse({ title: 'V1' }), { cacheDir });
+    const got = await getLastGoodNarrative(OWNER, REPO, PR, { cacheDir });
+    expect(got?.narrative.title).toBe('V1');
+    expect(got?.meta.sha).toBe('sha1');
+    expect(got?.meta.providerKey).toBe(PROVIDER);
+    expect(typeof got?.meta.savedAt).toBe('number');
+
+    const pointer = JSON.parse(await readFile(join(revDir(), 'current.json'), 'utf-8'));
+    expect(await readdir(revDir())).toContain(`${pointer.revision}.json`);
+  });
+
+  it('is content-addressed: identical content reuses the same revision file', async () => {
+    await appendNarrativeRevision(OWNER, REPO, PR, 'sha1', META, PROVIDER, mkResponse({ title: 'Same' }), { cacheDir });
+    await appendNarrativeRevision(OWNER, REPO, PR, 'sha1', META, PROVIDER, mkResponse({ title: 'Same' }), { cacheDir });
+    const files = (await readdir(revDir())).filter((f) => f !== 'current.json' && f !== '.lock');
+    expect(files).toHaveLength(1);
+  });
+
+  it('the pointer always resolves to the latest write', async () => {
+    await appendNarrativeRevision(OWNER, REPO, PR, 'sha1', META, PROVIDER, mkResponse({ title: 'V1' }), { cacheDir });
+    await appendNarrativeRevision(OWNER, REPO, PR, 'sha2', META, PROVIDER, mkResponse({ title: 'V2' }), { cacheDir });
+    const got = await getLastGoodNarrative(OWNER, REPO, PR, { cacheDir });
+    expect(got?.narrative.title).toBe('V2');
+    expect(got?.meta.sha).toBe('sha2');
+  });
+
+  it('prunes to at most 5 revisions, dropping the oldest by mtime', async () => {
+    for (let i = 0; i < 7; i++) {
+      await appendNarrativeRevision(OWNER, REPO, PR, `sha-${i}`, META, PROVIDER, mkResponse({ title: `V${i}` }), {
+        cacheDir,
+      });
+      // Force distinct, ascending mtimes so prune order is deterministic.
+      const file = JSON.parse(await readFile(join(revDir(), 'current.json'), 'utf-8')).revision + '.json';
+      const t = new Date(Date.now() + i * 1000);
+      await utimes(join(revDir(), file), t, t);
+    }
+    const files = (await readdir(revDir())).filter((f) => f.endsWith('.json') && f !== 'current.json');
+    expect(files.length).toBeLessThanOrEqual(5);
+    // Newest (V6) survives and is still the pointer target.
+    expect((await getLastGoodNarrative(OWNER, REPO, PR, { cacheDir }))?.narrative.title).toBe('V6');
+  });
+
+  it('cacheNarrative also seals a revision', async () => {
+    await cacheNarrative(OWNER, REPO, PR, 'sha-c', META, PROVIDER, mkResponse({ title: 'Cached' }), { cacheDir });
+    expect((await getLastGoodNarrative(OWNER, REPO, PR, { cacheDir }))?.narrative.title).toBe('Cached');
+  });
+
+  it('tolerates a corrupt pointer (returns null)', async () => {
+    await appendNarrativeRevision(OWNER, REPO, PR, 'sha1', META, PROVIDER, mkResponse(), { cacheDir });
+    await writeFile(join(revDir(), 'current.json'), '{ not json');
+    expect(await getLastGoodNarrative(OWNER, REPO, PR, { cacheDir })).toBeNull();
+  });
+
+  it('tolerates a pointer to a missing revision file (returns null)', async () => {
+    await appendNarrativeRevision(OWNER, REPO, PR, 'sha1', META, PROVIDER, mkResponse(), { cacheDir });
+    await writeFile(join(revDir(), 'current.json'), JSON.stringify({ revision: 'deadbeef', sha: 'x' }));
+    expect(await getLastGoodNarrative(OWNER, REPO, PR, { cacheDir })).toBeNull();
+  });
+
+  it('normalizes older-shaped revision payloads on read', async () => {
+    await appendNarrativeRevision(OWNER, REPO, PR, 'sha1', META, PROVIDER, mkResponse(), { cacheDir });
+    const pointer = JSON.parse(await readFile(join(revDir(), 'current.json'), 'utf-8'));
+    await writeFile(
+      join(revDir(), `${pointer.revision}.json`),
+      JSON.stringify({ narrative: { title: 'Legacy', chapters: [] }, meta: pointer }),
+    );
+    const got = await getLastGoodNarrative(OWNER, REPO, PR, { cacheDir });
+    expect(got?.narrative.title).toBe('Legacy');
+    expect(got?.narrative.verdict).toBe('caution');
+  });
+});
+
+describe('file lock', () => {
+  it('serializes concurrent holders: one waits for the other', async () => {
+    const lockPath = join(cacheDir, 'race.lock');
+    const events: string[] = [];
+    const run = (id: string) =>
+      withLock(lockPath, async () => {
+        events.push(`enter-${id}`);
+        await new Promise((r) => setTimeout(r, 50));
+        events.push(`exit-${id}`);
+      });
+
+    await Promise.all([run('a'), run('b')]);
+
+    // Whoever entered first must fully exit before the other enters — no interleaving.
+    expect(events).toHaveLength(4);
+    expect(events[1]).toBe(events[0]?.replace('enter', 'exit'));
+    expect(events[3]).toBe(events[2]?.replace('enter', 'exit'));
+  });
+
+  it('reclaims a stale lock', async () => {
+    const lockPath = join(cacheDir, 'stale.lock');
+    await writeFile(lockPath, JSON.stringify({ pid: 999999, ts: Date.now() - 60_000 }));
+    let ran = false;
+    await withLock(
+      lockPath,
+      async () => {
+        ran = true;
+      },
+      { staleMs: 30_000 },
+    );
+    expect(ran).toBe(true);
+  });
+
+  it('times out waiting on a held, non-stale lock', async () => {
+    const lockPath = join(cacheDir, 'held.lock');
+    await writeFile(lockPath, JSON.stringify({ pid: process.pid, ts: Date.now() }));
+    await expect(withLock(lockPath, async () => {}, { staleMs: 30_000, timeoutMs: 100 })).rejects.toThrow(/Timed out/);
+  });
+});

--- a/packages/cli/src/narrative/cache.ts
+++ b/packages/cli/src/narrative/cache.ts
@@ -1,12 +1,16 @@
 import { homedir } from 'os';
 import { join } from 'path';
 import { createHash } from 'crypto';
-import { readdir, readFile, rm, writeFile, mkdir } from 'fs/promises';
+import { readdir, readFile, rename, rm, stat, writeFile, mkdir } from 'fs/promises';
 import { normalizeNarrative, type NarrativeResponse } from './types';
 import { isPlan, type Plan } from './plan-types';
 import { NARRATIVE_PROMPT_REVISION, PLANNER_PROMPT_REVISION } from './prompt';
+import { withLock } from './file-lock';
 
 const CACHE_DIR = join(homedir(), '.cache', 'diffdad');
+
+// At most this many sealed revisions are retained per PR; older ones are pruned by mtime.
+const MAX_REVISIONS_PER_PR = 5;
 
 // Cache schema version tracks serialized compatibility. Prompt revisions are keyed
 // separately so prose-contract changes regenerate without pretending the shape changed.
@@ -42,10 +46,20 @@ export function narrativeCachePath(
   metaHash: string,
   providerKey: string,
 ): string {
-  return join(
-    CACHE_DIR,
-    `${owner}-${repo}-${number}-${sha}-${metaHash}.v${SCHEMA_VERSION}.p${PLANNER_PROMPT_REVISION}-${NARRATIVE_PROMPT_REVISION}.${providerKey}.json`,
-  );
+  return join(CACHE_DIR, narrativeCacheFileName(owner, repo, number, sha, metaHash, providerKey));
+}
+
+// Just the filename portion of {@link narrativeCachePath}, so an injected cache dir (tests) can
+// reuse the exact key scheme without duplicating it.
+function narrativeCacheFileName(
+  owner: string,
+  repo: string,
+  number: number,
+  sha: string,
+  metaHash: string,
+  providerKey: string,
+): string {
+  return `${owner}-${repo}-${number}-${sha}-${metaHash}.v${SCHEMA_VERSION}.p${PLANNER_PROMPT_REVISION}-${NARRATIVE_PROMPT_REVISION}.${providerKey}.json`;
 }
 
 /**
@@ -107,10 +121,130 @@ export async function cacheNarrative(
   metaHash: string,
   providerKey: string,
   narrative: NarrativeResponse,
+  opts: { cacheDir?: string } = {},
 ): Promise<void> {
-  const path = narrativeCachePath(owner, repo, number, sha, metaHash, providerKey);
-  await mkdir(CACHE_DIR, { recursive: true });
+  const cacheDir = opts.cacheDir ?? CACHE_DIR;
+  const path = join(cacheDir, narrativeCacheFileName(owner, repo, number, sha, metaHash, providerKey));
+  await mkdir(cacheDir, { recursive: true });
   await writeFile(path, JSON.stringify(narrative));
+  // The revision log is a best-effort safety net layered on top of the primary cache. A failure to
+  // seal a revision must never fail the narrative write the rest of the app depends on.
+  try {
+    await appendNarrativeRevision(owner, repo, number, sha, metaHash, providerKey, narrative, { cacheDir });
+  } catch {
+    // swallow — the primary cache write already succeeded.
+  }
+}
+
+export type RevisionMeta = {
+  sha: string;
+  metaHash: string;
+  providerKey: string;
+  savedAt: number;
+};
+
+type RevisionRecord = {
+  narrative: NarrativeResponse;
+  meta: RevisionMeta;
+};
+
+type RevisionPointer = {
+  revision: string;
+} & RevisionMeta;
+
+function revisionsDir(cacheDir: string, owner: string, repo: string, number: number): string {
+  return join(cacheDir, 'revisions', `${owner}-${repo}-${number}`);
+}
+
+// Stable-key canonical JSON so identical narrative content seals to the same content hash regardless
+// of key insertion order.
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
+      return Object.fromEntries(Object.entries(val as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b)));
+    }
+    return val;
+  });
+}
+
+async function writeAtomic(path: string, data: string): Promise<void> {
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  await writeFile(tmp, data);
+  await rename(tmp, path);
+}
+
+/**
+ * Seal a successful narrative as an immutable, content-addressed revision and advance the PR's
+ * last-good pointer. The revision file is named by the sha256 of its canonical content (excluding
+ * the savedAt timestamp so re-sealing the same state dedupes). The pointer update and prune run
+ * under a per-PR file lock so the concurrent server/daemon writers never corrupt current.json.
+ */
+export async function appendNarrativeRevision(
+  owner: string,
+  repo: string,
+  number: number,
+  sha: string,
+  metaHash: string,
+  providerKey: string,
+  narrative: NarrativeResponse,
+  opts: { cacheDir?: string } = {},
+): Promise<void> {
+  const cacheDir = opts.cacheDir ?? CACHE_DIR;
+  const dir = revisionsDir(cacheDir, owner, repo, number);
+  await mkdir(dir, { recursive: true });
+
+  const revision = createHash('sha256')
+    .update(canonicalJson({ narrative, sha, metaHash, providerKey }))
+    .digest('hex')
+    .slice(0, 12);
+  const record: RevisionRecord = { narrative, meta: { sha, metaHash, providerKey, savedAt: Date.now() } };
+  await writeAtomic(join(dir, `${revision}.json`), JSON.stringify(record));
+
+  await withLock(join(dir, '.lock'), async () => {
+    const pointer: RevisionPointer = { revision, sha, metaHash, providerKey, savedAt: record.meta.savedAt };
+    await writeAtomic(join(dir, 'current.json'), JSON.stringify(pointer));
+    await pruneRevisions(dir, pointer.revision);
+  });
+}
+
+// Keep at most MAX_REVISIONS_PER_PR sealed revisions, dropping the oldest by mtime. The pointer's
+// current revision is always preserved even if it is the oldest.
+async function pruneRevisions(dir: string, keepRevision: string): Promise<void> {
+  const entries = (await readdir(dir)).filter((e) => e.endsWith('.json') && e !== 'current.json');
+  if (entries.length <= MAX_REVISIONS_PER_PR) return;
+  const keepName = `${keepRevision}.json`;
+  const withMtime = await Promise.all(
+    entries.map(async (name) => ({ name, mtime: (await stat(join(dir, name))).mtimeMs })),
+  );
+  withMtime.sort((a, b) => b.mtime - a.mtime); // newest first
+  // The pointer's revision is always kept, so it reserves one of the MAX slots. Everything else is
+  // trimmed oldest-first until the total (kept + pointer) is within budget.
+  const deletable = withMtime.filter((e) => e.name !== keepName);
+  const budget = entries.includes(keepName) ? MAX_REVISIONS_PER_PR - 1 : MAX_REVISIONS_PER_PR;
+  for (const { name } of deletable.slice(budget)) {
+    await rm(join(dir, name), { force: true }).catch(() => {});
+  }
+}
+
+/**
+ * Read the PR's last successfully sealed narrative via its pointer. Returns null on any
+ * missing/corrupt pointer or revision file so callers can treat "no last-good" uniformly.
+ */
+export async function getLastGoodNarrative(
+  owner: string,
+  repo: string,
+  number: number,
+  opts: { cacheDir?: string } = {},
+): Promise<{ narrative: NarrativeResponse; meta: RevisionMeta } | null> {
+  const dir = revisionsDir(opts.cacheDir ?? CACHE_DIR, owner, repo, number);
+  try {
+    const pointer = JSON.parse(await readFile(join(dir, 'current.json'), 'utf-8')) as RevisionPointer;
+    if (!pointer || typeof pointer.revision !== 'string') return null;
+    const record = JSON.parse(await readFile(join(dir, `${pointer.revision}.json`), 'utf-8')) as RevisionRecord;
+    return { narrative: normalizeNarrative(record.narrative), meta: record.meta };
+  } catch {
+    return null;
+  }
 }
 
 export async function getCachedPlan(

--- a/packages/cli/src/narrative/file-lock.ts
+++ b/packages/cli/src/narrative/file-lock.ts
@@ -1,0 +1,61 @@
+import { mkdir, readFile, stat, unlink, writeFile } from 'fs/promises';
+import { dirname } from 'path';
+
+const DEFAULT_STALE_MS = 30_000;
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Minimal advisory lock: an exclusive-create lock file carrying the holder's pid and timestamp.
+ * A lock older than `staleMs` is treated as abandoned (crashed writer) and reclaimed. Contenders
+ * retry with exponential backoff until `timeoutMs`. This guards concurrent revision pointer updates
+ * and prunes between the server and the daemon; it is deliberately small, not a general lock manager.
+ */
+export async function withLock<T>(
+  lockPath: string,
+  fn: () => Promise<T>,
+  opts: { staleMs?: number; timeoutMs?: number } = {},
+): Promise<T> {
+  const staleMs = opts.staleMs ?? DEFAULT_STALE_MS;
+  const deadline = Date.now() + (opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  await mkdir(dirname(lockPath), { recursive: true });
+
+  let backoff = 10;
+  for (;;) {
+    try {
+      await writeFile(lockPath, JSON.stringify({ pid: process.pid, ts: Date.now() }), { flag: 'wx' });
+      break;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+      if (await isStale(lockPath, staleMs)) {
+        await unlink(lockPath).catch(() => {});
+        continue;
+      }
+      if (Date.now() >= deadline) throw new Error(`Timed out acquiring lock ${lockPath}`);
+      await sleep(Math.min(backoff, Math.max(1, deadline - Date.now())));
+      backoff = Math.min(backoff * 2, 250);
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    await unlink(lockPath).catch(() => {});
+  }
+}
+
+async function isStale(lockPath: string, staleMs: number): Promise<boolean> {
+  try {
+    const held = JSON.parse(await readFile(lockPath, 'utf-8')) as { ts?: number };
+    const ts = typeof held.ts === 'number' ? held.ts : (await stat(lockPath)).mtimeMs;
+    return Date.now() - ts > staleMs;
+  } catch {
+    // Unreadable/corrupt lock: fall back to mtime, and treat a vanished file as free.
+    try {
+      return Date.now() - (await stat(lockPath)).mtimeMs > staleMs;
+    } catch {
+      return true;
+    }
+  }
+}

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -7,7 +7,7 @@ import { readConfig } from './config';
 import type { GitHubClient } from './github/client';
 import { mapCommentsToChapters } from './github/comments';
 import type { CheckRun, DiffFile, PRComment, PRMetadata, PRReview } from './github/types';
-import { cacheNarrative, computePromptMetaHash, getCachedNarrative } from './narrative/cache';
+import { cacheNarrative, computePromptMetaHash, getCachedNarrative, getLastGoodNarrative } from './narrative/cache';
 import { chapterCallers, resolveCollapse } from './narrative/collapse';
 import { callAi, generateNarrative, resolveAiPath, resolveProviderKey } from './narrative/engine';
 import { buildChapterAiPrompt } from './narrative/chapter-ai';
@@ -519,10 +519,19 @@ export function createServer(ctx: ServerContext) {
                 });
               } catch (err) {
                 const msg = err instanceof Error ? err.message : String(err);
-                console.error(`  \x1b[38;5;204m✗\x1b[0m Regeneration failed: ${msg}`);
-                // The terminal log is invisible to the browser tab, which otherwise keeps showing stale
-                // content with no hint that the refresh failed. Push the error so the UI can surface it.
-                broadcast('narrative-error', { message: msg });
+                // generateNarrative threw before assigning ctx.narrative, so ctx still holds the prior
+                // (last successfully served) narrative. If a sealed last-good revision exists for this
+                // PR, keep serving what the reviewer already has instead of surfacing a fatal error to
+                // the UI — a failed regen must not blank the tab.
+                const lastGood = await getLastGoodNarrative(ctx.owner, ctx.repo, ctx.pr.number);
+                if (lastGood) {
+                  console.warn(`  \x1b[38;5;221m⚠\x1b[0m Regeneration failed (${msg}); keeping last-good narrative.`);
+                } else {
+                  console.error(`  \x1b[38;5;204m✗\x1b[0m Regeneration failed: ${msg}`);
+                  // The terminal log is invisible to the browser tab, which otherwise keeps showing stale
+                  // content with no hint that the refresh failed. Push the error so the UI can surface it.
+                  broadcast('narrative-error', { message: msg });
+                }
               } finally {
                 regenerating = false;
               }


### PR DESCRIPTION
Regeneration failures previously surfaced as fatal errors even when a
perfectly good narrative had just been on screen. The cache now seals
every successful narrative as a content-addressed revision:

- ~/.cache/diffdad/revisions/{owner}-{repo}-{number}/ holds up to 5
  immutable revisions plus a current.json pointer
- atomic temp+rename writes; pointer updates and prunes run under a
  per-PR advisory file lock (server and daemon can write concurrently)
- getLastGoodNarrative() tolerates missing/corrupt files
- server regen failures now keep serving the last good narrative
  instead of broadcasting a fatal error when a revision exists

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>