### PR TITLE
feat(web): rail-to-pill chapter TOC with scroll-spy

### DIFF
--- a/packages/web/src/components/Chapter.tsx
+++ b/packages/web/src/components/Chapter.tsx
@@ -317,6 +317,16 @@ export function Chapter({ index, chapter, resolve, decision, callers }: Props) {
     if (hasDecision && !prevHadDecision.current && !touched.current) setCollapsed(true);
     prevHadDecision.current = hasDecision;
   }, [decision]);
+  // A TOC jump to a collapsed chapter opens it before the scroll lands, then clears the request so it
+  // fires once. Counts as the reviewer acting (`touched`) so a later decision cannot re-collapse it.
+  const pendingExpandChapterId = useReviewStore((s) => s.pendingExpandChapterId);
+  const requestExpandChapter = useReviewStore((s) => s.requestExpandChapter);
+  useEffect(() => {
+    if (pendingExpandChapterId !== id) return;
+    touched.current = true;
+    setCollapsed(false);
+    requestExpandChapter(null);
+  }, [pendingExpandChapterId, id, requestExpandChapter]);
   // `reviewed` wins: both seeds produce the same collapsed row, so precedence only decides which line
   // explains it, and the reviewer's own action outranks the tool's inference.
   const reasonLine = collapseReason(decision, reviewed);

--- a/packages/web/src/components/ChapterTOC.tsx
+++ b/packages/web/src/components/ChapterTOC.tsx
@@ -1,7 +1,42 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { normalizePath } from '../lib/paths';
+import { activeTocEntry, buildTocEntries, reviewedProgress, type TocEntry } from '../lib/toc';
 import { useReviewStore } from '../state/review-store';
 import { useInlineComments } from '../hooks/useInlineComments';
+import { IconChat } from './Icons';
+
+const CheckIcon = () => (
+  <svg viewBox="0 0 12 12" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M2.5 6.5l2 2 4.5-5" />
+  </svg>
+);
+
+function Badge({ entry }: { entry: TocEntry }) {
+  const active = useReviewStore((s) => s.activeChapterId) === entry.id;
+  const style = entry.reviewed
+    ? { background: 'var(--green-9)', color: '#fff' }
+    : active
+      ? { background: 'var(--purple-9)', color: '#fff' }
+      : { background: 'var(--gray-3)', color: 'var(--fg-2)' };
+  return (
+    <span
+      className="mt-[1px] inline-flex h-[18px] w-[18px] flex-shrink-0 items-center justify-center rounded-full font-mono text-[10.5px] font-bold"
+      style={style}
+    >
+      {entry.reviewed ? <CheckIcon /> : entry.kind === 'discussion' ? <IconChat className="h-[10px] w-[10px]" /> : entry.number}
+    </span>
+  );
+}
+
+function subtitle(entry: TocEntry): string {
+  if (entry.kind === 'discussion') {
+    return `${entry.commentCount} ${entry.commentCount === 1 ? 'comment' : 'comments'}`;
+  }
+  let s = `${entry.hunkCount} ${entry.hunkCount === 1 ? 'hunk' : 'hunks'}`;
+  if (entry.risk) s += ` · risk ${entry.risk}`;
+  if (entry.commentCount > 0) s += ` · ${entry.commentCount} ${entry.commentCount === 1 ? 'comment' : 'comments'}`;
+  return s;
+}
 
 export function ChapterTOC() {
   const narrative = useReviewStore((s) => s.narrative);
@@ -9,7 +44,12 @@ export function ChapterTOC() {
   const files = useReviewStore((s) => s.files);
   const activeChapterId = useReviewStore((s) => s.activeChapterId);
   const chapterStates = useReviewStore((s) => s.chapterStates);
+  const railCollapsed = useReviewStore((s) => s.railCollapsed);
+  const setRailCollapsed = useReviewStore((s) => s.setRailCollapsed);
   const setActiveChapter = useReviewStore((s) => s.setActiveChapter);
+  const requestExpandChapter = useReviewStore((s) => s.requestExpandChapter);
+
+  const [pillOpen, setPillOpen] = useState(false);
 
   const chapterCommentCounts = useMemo(() => {
     if (!narrative) return {};
@@ -36,158 +76,163 @@ export function ChapterTOC() {
     return counts;
   }, [narrative, comments, files]);
 
-  const discussionCount = useMemo(() => {
-    return comments.filter((c) => !c.path).length;
-  }, [comments]);
+  const discussionCount = useMemo(() => comments.filter((c) => !c.path).length, [comments]);
 
-  const totalCount = narrative?.chapters.length ?? 0;
-  const reviewedCount = useMemo(() => {
-    if (!narrative) return 0;
-    return narrative.chapters.filter((_, idx) => chapterStates[`ch-${idx}`] === 'reviewed').length;
-  }, [narrative, chapterStates]);
+  const entries = useMemo(
+    () =>
+      buildTocEntries({
+        chapters: narrative?.chapters ?? [],
+        chapterStates,
+        commentCounts: chapterCommentCounts,
+        discussionCount,
+      }),
+    [narrative, chapterStates, chapterCommentCounts, discussionCount],
+  );
+
+  const { reviewed: reviewedCount, total: totalCount } = reviewedProgress(entries);
+  const current = activeTocEntry(entries, activeChapterId);
 
   if (!narrative) return null;
 
+  // Open the chapter first (it may be collapsed), then scroll on the next frame so the target is laid
+  // out before the browser measures it.
   function jump(id: string) {
+    requestExpandChapter(id);
     setActiveChapter(id);
-    const el = document.querySelector(`[data-chid="${id}"]`);
-    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    setPillOpen(false);
+    requestAnimationFrame(() => {
+      const el = document.querySelector(`[data-chid="${id}"]`);
+      if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  }
+
+  function Row({ entry }: { entry: TocEntry }) {
+    const active = activeChapterId === entry.id;
+    return (
+      <button
+        type="button"
+        onClick={() => jump(entry.id)}
+        className={`relative flex w-full cursor-pointer items-start gap-2.5 rounded-md px-2.5 py-[9px] text-left transition-colors ${
+          active ? 'text-[var(--purple-11)]' : 'text-[var(--fg-2)]'
+        }`}
+        style={active ? { background: 'var(--purple-a3)' } : undefined}
+        onMouseEnter={(e) => {
+          if (!active) {
+            e.currentTarget.style.background = 'var(--gray-a3)';
+            e.currentTarget.style.color = 'var(--fg-1)';
+          }
+        }}
+        onMouseLeave={(e) => {
+          if (!active) {
+            e.currentTarget.style.background = '';
+            e.currentTarget.style.color = '';
+          }
+        }}
+      >
+        <Badge entry={entry} />
+        <div className="min-w-0 flex-1">
+          <div className="text-[13px] font-medium leading-[17px]">{entry.title}</div>
+          <div className="mt-[2px] text-[11.5px] font-normal leading-[14px] text-[var(--fg-3)]">{subtitle(entry)}</div>
+        </div>
+        {active && (
+          <span
+            aria-hidden
+            className="absolute right-2.5 top-[14px] h-1.5 w-1.5 flex-shrink-0 rounded-full"
+            style={{ background: 'var(--purple-9)' }}
+          />
+        )}
+      </button>
+    );
   }
 
   return (
-    <aside className="sticky top-[160px] self-start text-[13px] text-[var(--fg-2)]">
-      <div className="px-2.5 pb-2 text-[11px] font-bold uppercase tracking-[0.06em] text-[var(--fg-3)]">Story</div>
-      <ul className="m-0 list-none p-0">
-        {narrative.chapters.map((ch, idx) => {
-          const id = `ch-${idx}`;
-          const reviewed = chapterStates[id] === 'reviewed';
-          const active = activeChapterId === id;
-          const hunkCount = ch.sections.filter((s) => s.type === 'diff').length;
-          const commentCount = chapterCommentCounts[id] ?? 0;
-          return (
-            <li key={id}>
+    <>
+      {/* Wide viewport: the left rail. Hidden below `lg`, where the pill takes over. */}
+      <aside className="hidden self-start text-[13px] text-[var(--fg-2)] lg:sticky lg:top-[160px] lg:block">
+        {railCollapsed ? (
+          <button
+            type="button"
+            onClick={() => setRailCollapsed(false)}
+            title="Show story"
+            aria-label="Show story"
+            className="flex h-7 w-7 items-center justify-center rounded-md text-[14px] leading-none text-[var(--fg-3)] transition-colors hover:bg-[var(--gray-a3)] hover:text-[var(--fg-1)]"
+            style={{ boxShadow: 'inset 0 0 0 1px var(--gray-a4)' }}
+          >
+            »
+          </button>
+        ) : (
+          <>
+            <div className="flex items-center justify-between gap-2 px-2.5 pb-2">
+              <span className="text-[11px] font-bold uppercase tracking-[0.06em] text-[var(--fg-3)]">Story</span>
               <button
                 type="button"
-                onClick={() => jump(id)}
-                className={`relative flex w-full cursor-pointer items-start gap-2.5 rounded-md px-2.5 py-[9px] text-left transition-colors ${
-                  active ? 'text-[var(--purple-11)]' : 'text-[var(--fg-2)]'
-                }`}
-                style={active ? { background: 'var(--purple-a3)' } : undefined}
-                onMouseEnter={(e) => {
-                  if (!active) {
-                    e.currentTarget.style.background = 'var(--gray-a3)';
-                    e.currentTarget.style.color = 'var(--fg-1)';
-                  }
-                }}
-                onMouseLeave={(e) => {
-                  if (!active) {
-                    e.currentTarget.style.background = '';
-                    e.currentTarget.style.color = '';
-                  }
-                }}
+                onClick={() => setRailCollapsed(true)}
+                title="Collapse story"
+                aria-label="Collapse story"
+                className="-mr-1 flex h-6 w-6 items-center justify-center rounded-md text-[13px] leading-none text-[var(--fg-3)] transition-colors hover:bg-[var(--gray-a3)] hover:text-[var(--fg-1)]"
               >
-                <span
-                  className="mt-[1px] inline-flex h-[18px] w-[18px] flex-shrink-0 items-center justify-center rounded-full font-mono text-[10.5px] font-bold"
-                  style={
-                    reviewed
-                      ? { background: 'var(--green-9)', color: '#fff' }
-                      : active
-                        ? { background: 'var(--purple-9)', color: '#fff' }
-                        : { background: 'var(--gray-3)', color: 'var(--fg-2)' }
-                  }
-                >
-                  {reviewed ? (
-                    <svg
-                      viewBox="0 0 12 12"
-                      className="h-3 w-3"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    >
-                      <path d="M2.5 6.5l2 2 4.5-5" />
-                    </svg>
-                  ) : (
-                    idx + 1
-                  )}
-                </span>
-                <div className="min-w-0 flex-1">
-                  <div className="text-[13px] font-medium leading-[17px]">{ch.title}</div>
-                  <div className="mt-[2px] text-[11.5px] leading-[14px] text-[var(--fg-3)]" style={{ fontWeight: 400 }}>
-                    {hunkCount} {hunkCount === 1 ? 'hunk' : 'hunks'} · risk {ch.risk}
-                    {commentCount > 0 && (
-                      <>
-                        {' '}
-                        · {commentCount} {commentCount === 1 ? 'comment' : 'comments'}
-                      </>
-                    )}
-                  </div>
-                </div>
-                {active && (
-                  <span
-                    aria-hidden
-                    className="absolute right-2.5 top-[14px] h-1.5 w-1.5 flex-shrink-0 rounded-full"
-                    style={{ background: 'var(--purple-9)' }}
-                  />
-                )}
+                «
               </button>
-            </li>
-          );
-        })}
-        {discussionCount > 0 && (
-          <li>
-            <button
-              type="button"
-              onClick={() => jump('discussion')}
-              className={`relative flex w-full cursor-pointer items-start gap-2.5 rounded-md px-2.5 py-[9px] text-left transition-colors ${
-                activeChapterId === 'discussion' ? 'text-[var(--purple-11)]' : 'text-[var(--fg-2)]'
-              }`}
-              style={activeChapterId === 'discussion' ? { background: 'var(--purple-a3)' } : undefined}
-              onMouseEnter={(e) => {
-                if (activeChapterId !== 'discussion') {
-                  e.currentTarget.style.background = 'var(--gray-a3)';
-                  e.currentTarget.style.color = 'var(--fg-1)';
-                }
-              }}
-              onMouseLeave={(e) => {
-                if (activeChapterId !== 'discussion') {
-                  e.currentTarget.style.background = '';
-                  e.currentTarget.style.color = '';
-                }
-              }}
-            >
-              <span
-                className="mt-[1px] inline-flex h-[18px] w-[18px] flex-shrink-0 items-center justify-center rounded-full font-mono text-[10.5px] font-bold"
-                style={{ background: 'var(--gray-3)', color: 'var(--fg-2)' }}
-              >
-                <svg
-                  viewBox="0 0 15 15"
-                  className="h-[10px] w-[10px]"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                >
-                  <path d="M2 2h11v8H5l-3 3V2z" />
-                </svg>
-              </span>
-              <div className="min-w-0 flex-1">
-                <div className="text-[13px] font-medium leading-[17px]">PR Discussion</div>
-                <div className="mt-[2px] text-[11.5px] leading-[14px] text-[var(--fg-3)]" style={{ fontWeight: 400 }}>
-                  {discussionCount} {discussionCount === 1 ? 'comment' : 'comments'}
+            </div>
+            <ul className="m-0 list-none p-0">
+              {entries.map((entry) => (
+                <li key={entry.id}>
+                  <Row entry={entry} />
+                </li>
+              ))}
+            </ul>
+            {reviewedCount > 0 && reviewedCount < totalCount && (
+              <div className="mt-3 border-t px-2.5 pt-3" style={{ borderColor: 'var(--gray-a4)' }}>
+                <div className="text-[11px] text-[var(--fg-3)]">
+                  {reviewedCount}/{totalCount} chapters reviewed
                 </div>
               </div>
-            </button>
-          </li>
+            )}
+          </>
         )}
-      </ul>
-      {reviewedCount > 0 && reviewedCount < totalCount && (
-        <div className="mt-3 border-t px-2.5 pt-3" style={{ borderColor: 'var(--gray-a4)' }}>
-          <div className="text-[11px] text-[var(--fg-3)]">
-            {reviewedCount}/{totalCount} chapters reviewed
-          </div>
+      </aside>
+
+      {/* Narrow viewport: a fixed breadcrumb pill naming the current section; tap to jump. */}
+      {current && (
+        <div className="lg:hidden">
+          {pillOpen && (
+            <button
+              type="button"
+              aria-label="Close story navigation"
+              onClick={() => setPillOpen(false)}
+              className="fixed inset-0 z-40 cursor-default"
+              style={{ background: 'var(--gray-a8)' }}
+            />
+          )}
+          <button
+            type="button"
+            onClick={() => setPillOpen((v) => !v)}
+            aria-expanded={pillOpen}
+            className="fixed bottom-4 left-4 z-50 flex max-w-[calc(100vw-2rem)] items-center gap-2 rounded-full px-3.5 py-2 text-left text-[13px] shadow-lg"
+            style={{ background: 'var(--bg-panel)', color: 'var(--fg-1)', boxShadow: '0 6px 20px var(--gray-a7), inset 0 0 0 1px var(--gray-a5)' }}
+          >
+            <Badge entry={current} />
+            <span className="min-w-0 flex-1 truncate font-medium">{current.title}</span>
+            <span aria-hidden className="text-[var(--fg-3)]" style={{ transform: pillOpen ? 'rotate(180deg)' : undefined }}>
+              ▾
+            </span>
+          </button>
+          {pillOpen && (
+            <div
+              className="fixed bottom-16 left-4 z-50 max-h-[60vh] w-[calc(100vw-2rem)] max-w-[320px] overflow-auto rounded-xl p-1.5"
+              style={{ background: 'var(--bg-panel)', boxShadow: '0 10px 30px var(--gray-a8), inset 0 0 0 1px var(--gray-a5)' }}
+            >
+              <ul className="m-0 list-none p-0">
+                {entries.map((entry) => (
+                  <li key={entry.id}>
+                    <Row entry={entry} />
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
       )}
-    </aside>
+    </>
   );
 }

--- a/packages/web/src/components/ChapterTOC.tsx
+++ b/packages/web/src/components/ChapterTOC.tsx
@@ -6,7 +6,15 @@ import { useInlineComments } from '../hooks/useInlineComments';
 import { IconChat } from './Icons';
 
 const CheckIcon = () => (
-  <svg viewBox="0 0 12 12" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+  <svg
+    viewBox="0 0 12 12"
+    className="h-3 w-3"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
     <path d="M2.5 6.5l2 2 4.5-5" />
   </svg>
 );
@@ -23,7 +31,13 @@ function Badge({ entry }: { entry: TocEntry }) {
       className="mt-[1px] inline-flex h-[18px] w-[18px] flex-shrink-0 items-center justify-center rounded-full font-mono text-[10.5px] font-bold"
       style={style}
     >
-      {entry.reviewed ? <CheckIcon /> : entry.kind === 'discussion' ? <IconChat className="h-[10px] w-[10px]" /> : entry.number}
+      {entry.reviewed ? (
+        <CheckIcon />
+      ) : entry.kind === 'discussion' ? (
+        <IconChat className="h-[10px] w-[10px]" />
+      ) : (
+        entry.number
+      )}
     </span>
   );
 }
@@ -209,18 +223,29 @@ export function ChapterTOC() {
             onClick={() => setPillOpen((v) => !v)}
             aria-expanded={pillOpen}
             className="fixed bottom-4 left-4 z-50 flex max-w-[calc(100vw-2rem)] items-center gap-2 rounded-full px-3.5 py-2 text-left text-[13px] shadow-lg"
-            style={{ background: 'var(--bg-panel)', color: 'var(--fg-1)', boxShadow: '0 6px 20px var(--gray-a7), inset 0 0 0 1px var(--gray-a5)' }}
+            style={{
+              background: 'var(--bg-panel)',
+              color: 'var(--fg-1)',
+              boxShadow: '0 6px 20px var(--gray-a7), inset 0 0 0 1px var(--gray-a5)',
+            }}
           >
             <Badge entry={current} />
             <span className="min-w-0 flex-1 truncate font-medium">{current.title}</span>
-            <span aria-hidden className="text-[var(--fg-3)]" style={{ transform: pillOpen ? 'rotate(180deg)' : undefined }}>
+            <span
+              aria-hidden
+              className="text-[var(--fg-3)]"
+              style={{ transform: pillOpen ? 'rotate(180deg)' : undefined }}
+            >
               ▾
             </span>
           </button>
           {pillOpen && (
             <div
               className="fixed bottom-16 left-4 z-50 max-h-[60vh] w-[calc(100vw-2rem)] max-w-[320px] overflow-auto rounded-xl p-1.5"
-              style={{ background: 'var(--bg-panel)', boxShadow: '0 10px 30px var(--gray-a8), inset 0 0 0 1px var(--gray-a5)' }}
+              style={{
+                background: 'var(--bg-panel)',
+                boxShadow: '0 10px 30px var(--gray-a8), inset 0 0 0 1px var(--gray-a5)',
+              }}
             >
               <ul className="m-0 list-none p-0">
                 {entries.map((entry) => (

--- a/packages/web/src/components/StoryView.tsx
+++ b/packages/web/src/components/StoryView.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo, useState } from 'react';
+import { type CSSProperties, Fragment, useEffect, useMemo, useState } from 'react';
 import { useScrollTracker } from '../hooks/useScrollTracker';
 import {
   callersByChapter,
@@ -15,7 +15,7 @@ import { useReviewStore } from '../state/review-store';
 import { useInlineComments } from '../hooks/useInlineComments';
 import { useWalkthrough } from '../hooks/useWalkthrough';
 import type { CapStats, CollapseResult, CommentId, DiffFile } from '../state/types';
-import { BeatRail } from './BeatRail';
+import { ChapterTOC } from './ChapterTOC';
 import type { ResolveItem } from '../lib/walkthrough';
 import { Chapter } from './Chapter';
 import { Comment } from './Comment';
@@ -340,7 +340,6 @@ export function StoryView() {
   const layoutMode = useReviewStore((s) => s.layoutMode);
   const displayDensity = useReviewStore((s) => s.displayDensity);
   const railCollapsed = useReviewStore((s) => s.railCollapsed);
-  const setRailCollapsed = useReviewStore((s) => s.setRailCollapsed);
   const storyStructure = useReviewStore((s) => s.storyStructure);
   const collapse = useReviewStore((s) => s.collapse);
   const callers = useReviewStore((s) => s.callers);
@@ -400,25 +399,15 @@ export function StoryView() {
     return <div className={`mx-auto max-w-[880px] px-6 ${padY}`}>{body}</div>;
   }
 
-  const gridCols = railCollapsed ? 'grid-cols-[28px_minmax(0,1fr)]' : 'grid-cols-[220px_minmax(0,1fr)]';
+  // Below `lg` the rail column collapses to zero and ChapterTOC renders its fixed breadcrumb pill
+  // instead; at `lg`+ it is the left rail, narrowed to a strip when the reader collapses it.
+  const railWidth = railCollapsed ? '28px' : '220px';
   return (
-    <div className={`mx-auto grid max-w-[1100px] ${gridCols} gap-7 px-6 ${padY}`}>
-      {railCollapsed ? (
-        <div className="sticky top-[160px] self-start">
-          <button
-            type="button"
-            onClick={() => setRailCollapsed(false)}
-            title="Show walkthrough"
-            aria-label="Show walkthrough"
-            className="flex h-7 w-7 items-center justify-center rounded-md text-[14px] leading-none text-[var(--fg-3)] transition-colors hover:bg-[var(--gray-a3)] hover:text-[var(--fg-1)]"
-            style={{ boxShadow: 'inset 0 0 0 1px var(--gray-a4)' }}
-          >
-            »
-          </button>
-        </div>
-      ) : (
-        <BeatRail />
-      )}
+    <div
+      className={`mx-auto grid max-w-[1100px] grid-cols-[minmax(0,1fr)] gap-7 px-6 lg:grid-cols-[var(--rail-w)_minmax(0,1fr)] ${padY}`}
+      style={{ '--rail-w': railWidth } as CSSProperties}
+    >
+      <ChapterTOC />
       {body}
     </div>
   );

--- a/packages/web/src/components/__tests__/toc.test.ts
+++ b/packages/web/src/components/__tests__/toc.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest';
 import type { Chapter } from '../../state/types';
 import { activeTocEntry, buildTocEntries, reviewedProgress } from '../../lib/toc';
 
-function chapter(title: string, hunks: number, risk: Chapter['risk'] = 'low'): Pick<Chapter, 'title' | 'risk' | 'sections'> {
+function chapter(
+  title: string,
+  hunks: number,
+  risk: Chapter['risk'] = 'low',
+): Pick<Chapter, 'title' | 'risk' | 'sections'> {
   return {
     title,
     risk,

--- a/packages/web/src/components/__tests__/toc.test.ts
+++ b/packages/web/src/components/__tests__/toc.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import type { Chapter } from '../../state/types';
+import { activeTocEntry, buildTocEntries, reviewedProgress } from '../../lib/toc';
+
+function chapter(title: string, hunks: number, risk: Chapter['risk'] = 'low'): Pick<Chapter, 'title' | 'risk' | 'sections'> {
+  return {
+    title,
+    risk,
+    sections: Array.from({ length: hunks }, (_, i) => ({
+      type: 'diff' as const,
+      file: `src/${title}.ts`,
+      startLine: 1,
+      endLine: 10,
+      hunkIndex: i,
+    })),
+  };
+}
+
+const chapters = [chapter('alpha', 2), chapter('beta', 0, 'high'), chapter('gamma', 1)];
+
+describe('buildTocEntries', () => {
+  it('numbers chapters from 1 in source order', () => {
+    const entries = buildTocEntries({ chapters, chapterStates: {}, commentCounts: {}, discussionCount: 0 });
+    expect(entries.map((e) => [e.id, e.number, e.title])).toEqual([
+      ['ch-0', 1, 'alpha'],
+      ['ch-1', 2, 'beta'],
+      ['ch-2', 3, 'gamma'],
+    ]);
+  });
+
+  it('counts diff hunks and carries reviewed state and risk', () => {
+    const entries = buildTocEntries({
+      chapters,
+      chapterStates: { 'ch-0': 'reviewed', 'ch-1': 'reading' },
+      commentCounts: { 'ch-2': 4 },
+      discussionCount: 0,
+    });
+    expect(entries[0]).toMatchObject({ hunkCount: 2, reviewed: true, commentCount: 0 });
+    expect(entries[1]).toMatchObject({ hunkCount: 0, reviewed: false, risk: 'high' });
+    expect(entries[2]).toMatchObject({ hunkCount: 1, commentCount: 4 });
+  });
+
+  it('appends a discussion row only when there is discussion', () => {
+    const none = buildTocEntries({ chapters, chapterStates: {}, commentCounts: {}, discussionCount: 0 });
+    expect(none.some((e) => e.kind === 'discussion')).toBe(false);
+
+    const some = buildTocEntries({ chapters, chapterStates: {}, commentCounts: {}, discussionCount: 3 });
+    const disc = some.at(-1)!;
+    expect(disc).toMatchObject({ id: 'discussion', kind: 'discussion', number: null, commentCount: 3 });
+  });
+});
+
+describe('activeTocEntry', () => {
+  const entries = buildTocEntries({ chapters, chapterStates: {}, commentCounts: {}, discussionCount: 2 });
+
+  it('returns the entry matching the active id', () => {
+    expect(activeTocEntry(entries, 'ch-1')?.id).toBe('ch-1');
+    expect(activeTocEntry(entries, 'discussion')?.id).toBe('discussion');
+  });
+
+  it('falls back to the first entry when nothing is active or the id is unknown', () => {
+    expect(activeTocEntry(entries, null)?.id).toBe('ch-0');
+    expect(activeTocEntry(entries, 'ch-999')?.id).toBe('ch-0');
+  });
+
+  it('returns null for an empty toc', () => {
+    expect(activeTocEntry([], 'ch-0')).toBeNull();
+  });
+});
+
+describe('reviewedProgress', () => {
+  it('counts reviewed chapters and ignores the discussion row', () => {
+    const entries = buildTocEntries({
+      chapters,
+      chapterStates: { 'ch-0': 'reviewed', 'ch-2': 'reviewed' },
+      commentCounts: {},
+      discussionCount: 5,
+    });
+    expect(reviewedProgress(entries)).toEqual({ reviewed: 2, total: 3 });
+  });
+});

--- a/packages/web/src/lib/toc.ts
+++ b/packages/web/src/lib/toc.ts
@@ -1,0 +1,71 @@
+import type { Chapter } from '../state/types';
+
+/**
+ * A single row of the chapter table of contents. `chapter` rows carry a 1-based `number`; the
+ * `discussion` row is unnumbered because it is not part of the narrated sequence.
+ */
+export interface TocEntry {
+  id: string;
+  kind: 'chapter' | 'discussion';
+  number: number | null;
+  title: string;
+  reviewed: boolean;
+  hunkCount: number;
+  commentCount: number;
+  risk: string | null;
+}
+
+/**
+ * The TOC's data, derived once from the raw narrative rather than the DOM: chapters number from 1 in
+ * source order, and the discussion row only appears when there is discussion to link to. Kept pure so
+ * the numbering and the active-row lookup can be tested without a renderer.
+ */
+export function buildTocEntries(params: {
+  chapters: Pick<Chapter, 'title' | 'risk' | 'sections'>[];
+  chapterStates: Record<string, string>;
+  commentCounts: Record<string, number>;
+  discussionCount: number;
+}): TocEntry[] {
+  const { chapters, chapterStates, commentCounts, discussionCount } = params;
+  const entries: TocEntry[] = chapters.map((ch, idx) => {
+    const id = `ch-${idx}`;
+    return {
+      id,
+      kind: 'chapter',
+      number: idx + 1,
+      title: ch.title,
+      reviewed: chapterStates[id] === 'reviewed',
+      hunkCount: ch.sections.filter((s) => s.type === 'diff').length,
+      commentCount: commentCounts[id] ?? 0,
+      risk: ch.risk ?? null,
+    };
+  });
+  if (discussionCount > 0) {
+    entries.push({
+      id: 'discussion',
+      kind: 'discussion',
+      number: null,
+      title: 'PR Discussion',
+      reviewed: false,
+      hunkCount: 0,
+      commentCount: discussionCount,
+      risk: null,
+    });
+  }
+  return entries;
+}
+
+/**
+ * The row the scroll-spy is pointing at, i.e. what the narrow-viewport pill names. Falls back to the
+ * first entry so the pill always has a section to show once there is any content, even before the first
+ * scroll event fires.
+ */
+export function activeTocEntry(entries: TocEntry[], activeChapterId: string | null): TocEntry | null {
+  return entries.find((e) => e.id === activeChapterId) ?? entries[0] ?? null;
+}
+
+/** Reviewed / total across chapter rows only (the discussion row is never "reviewed"). */
+export function reviewedProgress(entries: TocEntry[]): { reviewed: number; total: number } {
+  const chapters = entries.filter((e) => e.kind === 'chapter');
+  return { reviewed: chapters.filter((e) => e.reviewed).length, total: chapters.length };
+}

--- a/packages/web/src/state/review-store.ts
+++ b/packages/web/src/state/review-store.ts
@@ -161,6 +161,13 @@ type ReviewState = {
    */
   setBlastRadius: (data: BlastRadius) => void;
   setActiveChapter: (id: string) => void;
+  /**
+   * A TOC jump to a chapter that may be collapsed. Chapters own their collapsed state locally, so the
+   * TOC cannot open one directly: it names the target here and the matching `Chapter` opens itself, then
+   * clears the request. `null` is the resting state.
+   */
+  pendingExpandChapterId: string | null;
+  requestExpandChapter: (id: string | null) => void;
   toggleReviewed: (idx: number) => void;
   setOpenLine: (key: string | null) => void;
   /** Open a comment thread on `key`. When `extend` is true and `openLine` is
@@ -469,6 +476,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   repoUrl: null,
   chapterStates: {},
   activeChapterId: null,
+  pendingExpandChapterId: null,
   reviewKey: null,
   drafts: [],
   openLine: null,
@@ -553,6 +561,8 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   },
 
   setActiveChapter: (id) => set({ activeChapterId: id }),
+
+  requestExpandChapter: (id) => set({ pendingExpandChapterId: id }),
 
   toggleReviewed: (idx) =>
     set((state) => {


### PR DESCRIPTION
ChapterTOC existed but was unmounted; the live rail was BeatRail.
ChapterTOC is now the single TOC:

- auto-numbered chapters with active-chapter scroll-spy (reuses the
  existing useScrollTracker data-chid contract)
- wide viewports: left rail (collapsible via existing pref); narrow:
  a fixed breadcrumb pill naming the current chapter that opens a
  jump overlay
- jumping to a collapsed chapter expands it before scrolling
  (requestExpandChapter store channel)
- colors via CSS custom properties; BeatRail left in place for now

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>