### PR TITLE
feat(web): find-in-review widget

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -12,6 +12,7 @@ import { PRHeader } from './components/PRHeader';
 import { RecapView } from './components/RecapView';
 import { SettingsView } from './components/SettingsView';
 import { ShortcutsHelp } from './components/ShortcutsHelp';
+import { ReviewFind } from './components/ReviewFind';
 import { StoryView } from './components/StoryView';
 import { SubmitBar } from './components/SubmitBar';
 import { UnitReview } from './components/UnitReview';
@@ -186,6 +187,7 @@ export default function App() {
       <SubmitBar />
       <ActivityDrawer open={activityOpen} onClose={() => setActivityOpen(false)} />
       <ShortcutsHelp open={shortcutsHelpOpen} onClose={() => setShortcutsHelpOpen(false)} />
+      {narrative ? <ReviewFind /> : null}
     </div>
   );
 }

--- a/packages/web/src/components/Chapter.tsx
+++ b/packages/web/src/components/Chapter.tsx
@@ -317,16 +317,15 @@ export function Chapter({ index, chapter, resolve, decision, callers }: Props) {
     if (hasDecision && !prevHadDecision.current && !touched.current) setCollapsed(true);
     prevHadDecision.current = hasDecision;
   }, [decision]);
-  // A TOC jump to a collapsed chapter opens it before the scroll lands, then clears the request so it
-  // fires once. Counts as the reviewer acting (`touched`) so a later decision cannot re-collapse it.
-  const pendingExpandChapterId = useReviewStore((s) => s.pendingExpandChapterId);
-  const requestExpandChapter = useReviewStore((s) => s.requestExpandChapter);
+  // A TOC jump or find-widget navigation targeting this chapter forces it open so the destination is
+  // visible. Keyed on `nonce` so revealing the same chapter twice still expands it after a manual
+  // re-collapse. Counts as the reviewer acting (`touched`) so a later decision cannot re-collapse it.
+  const chapterReveal = useReviewStore((s) => s.chapterReveal);
   useEffect(() => {
-    if (pendingExpandChapterId !== id) return;
+    if (chapterReveal?.chid !== id) return;
     touched.current = true;
     setCollapsed(false);
-    requestExpandChapter(null);
-  }, [pendingExpandChapterId, id, requestExpandChapter]);
+  }, [chapterReveal, id]);
   // `reviewed` wins: both seeds produce the same collapsed row, so precedence only decides which line
   // explains it, and the reviewer's own action outranks the tool's inference.
   const reasonLine = collapseReason(decision, reviewed);

--- a/packages/web/src/components/ChapterTOC.tsx
+++ b/packages/web/src/components/ChapterTOC.tsx
@@ -61,7 +61,7 @@ export function ChapterTOC() {
   const railCollapsed = useReviewStore((s) => s.railCollapsed);
   const setRailCollapsed = useReviewStore((s) => s.setRailCollapsed);
   const setActiveChapter = useReviewStore((s) => s.setActiveChapter);
-  const requestExpandChapter = useReviewStore((s) => s.requestExpandChapter);
+  const revealChapter = useReviewStore((s) => s.revealChapter);
 
   const [pillOpen, setPillOpen] = useState(false);
 
@@ -111,7 +111,7 @@ export function ChapterTOC() {
   // Open the chapter first (it may be collapsed), then scroll on the next frame so the target is laid
   // out before the browser measures it.
   function jump(id: string) {
-    requestExpandChapter(id);
+    revealChapter(id);
     setActiveChapter(id);
     setPillOpen(false);
     requestAnimationFrame(() => {

--- a/packages/web/src/components/ReviewFind.tsx
+++ b/packages/web/src/components/ReviewFind.tsx
@@ -1,0 +1,306 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useReviewStore } from '../state/review-store';
+import {
+  compileFindQuery,
+  findInNarrative,
+  regexMatches,
+  wrapIndex,
+  type FindMatch,
+  type FindOptions,
+} from '../lib/find';
+
+const HIGHLIGHT_ALL = 'diffdad-find';
+const HIGHLIGHT_ACTIVE = 'diffdad-find-active';
+const FALLBACK_CLASS = 'diffdad-find-fallback';
+
+type HighlightRegistry = {
+  set(name: string, value: unknown): void;
+  delete(name: string): void;
+};
+
+/** The CSS Custom Highlight API, or null when the browser (or test env) lacks it. */
+function highlightApi(): { registry: HighlightRegistry; Highlight: new (...ranges: Range[]) => unknown } | null {
+  const view = window as Window & {
+    CSS?: { highlights?: HighlightRegistry };
+    Highlight?: new (...ranges: Range[]) => unknown;
+  };
+  const registry = view.CSS?.highlights;
+  return registry && view.Highlight ? { registry, Highlight: view.Highlight } : null;
+}
+
+function clearHighlights() {
+  const api = highlightApi();
+  api?.registry.delete(HIGHLIGHT_ALL);
+  api?.registry.delete(HIGHLIGHT_ACTIVE);
+  document.querySelectorAll(`.${FALLBACK_CLASS}`).forEach((el) => el.classList.remove(FALLBACK_CLASS));
+}
+
+/** Build DOM Ranges for every `expression` hit inside `root`, mapping char offsets back to text nodes. */
+function rangesInElement(root: Element, expression: RegExp): Range[] {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const nodes: { node: Text; start: number; end: number }[] = [];
+  let text = '';
+  for (let n = walker.nextNode(); n; n = walker.nextNode()) {
+    const t = n as Text;
+    const value = t.data;
+    nodes.push({ node: t, start: text.length, end: text.length + value.length });
+    text += value;
+  }
+  const pointAt = (offset: number): { node: Text; offset: number } | null => {
+    for (const seg of nodes) {
+      if (offset >= seg.start && offset <= seg.end) return { node: seg.node, offset: offset - seg.start };
+    }
+    return null;
+  };
+  const ranges: Range[] = [];
+  for (const { start, end } of regexMatches(text, expression)) {
+    const from = pointAt(start);
+    const to = pointAt(end);
+    if (!from || !to) continue;
+    const range = document.createRange();
+    range.setStart(from.node, from.offset);
+    range.setEnd(to.node, to.offset);
+    ranges.push(range);
+  }
+  return ranges;
+}
+
+function ToggleButton({
+  label,
+  active,
+  error,
+  onClick,
+  children,
+}: {
+  label: string;
+  active: boolean;
+  error?: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-pressed={active}
+      title={label}
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onClick}
+      className="flex h-6 w-6 items-center justify-center rounded-[5px] font-mono text-[11px] font-semibold transition-colors"
+      style={
+        active
+          ? {
+              background: error ? 'var(--red-3)' : 'var(--purple-3)',
+              color: error ? 'var(--red-11)' : 'var(--purple-11)',
+              boxShadow: `inset 0 0 0 1px ${error ? 'var(--red-a4)' : 'var(--purple-a4)'}`,
+            }
+          : { color: 'var(--fg-3)' }
+      }
+    >
+      {children}
+    </button>
+  );
+}
+
+function ActionButton({
+  label,
+  disabled,
+  onClick,
+  children,
+}: {
+  label: string;
+  disabled?: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      disabled={disabled}
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onClick}
+      className="flex h-6 w-6 items-center justify-center rounded-[5px] text-[13px] leading-none text-[var(--fg-3)] transition-colors hover:bg-[var(--gray-a3)] hover:text-[var(--fg-1)] disabled:pointer-events-none disabled:opacity-40"
+    >
+      {children}
+    </button>
+  );
+}
+
+export function ReviewFind() {
+  const narrative = useReviewStore((s) => s.narrative);
+  const files = useReviewStore((s) => s.files);
+  const revealChapter = useReviewStore((s) => s.revealChapter);
+
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [matchCase, setMatchCase] = useState(false);
+  const [wholeWord, setWholeWord] = useState(false);
+  const [regex, setRegex] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const opts: FindOptions = useMemo(() => ({ matchCase, wholeWord, regex }), [matchCase, wholeWord, regex]);
+
+  const { matches, error } = useMemo<{ matches: FindMatch[]; error: string | null }>(
+    () => (open ? findInNarrative(narrative, files, query, opts) : { matches: [], error: null }),
+    [open, narrative, files, query, opts],
+  );
+
+  // Compiled expression for the DOM highlighter (only when the query is valid and non-empty).
+  const highlightExpr = useMemo(() => {
+    if (!query) return null;
+    const compiled = compileFindQuery(query, opts);
+    return 'error' in compiled ? null : compiled.expression;
+  }, [query, opts]);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    clearHighlights();
+  }, []);
+
+  // Global Cmd/Ctrl-F opens the widget when a narrative is loaded; preventDefault stops the browser's
+  // own find, which would miss collapsed chapters.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && !e.altKey && (e.key === 'f' || e.key === 'F')) {
+        if (!narrative) return;
+        e.preventDefault();
+        setOpen(true);
+        requestAnimationFrame(() => {
+          inputRef.current?.focus();
+          inputRef.current?.select();
+        });
+      }
+    }
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [narrative]);
+
+  // A fresh result set starts at the first match.
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [query, opts, narrative, files]);
+
+  // Reveal + scroll + highlight the active match. Expanding a collapsed chapter is a store request the
+  // Chapter reacts to; the scroll + highlight run on the next frame so the expanded DOM exists.
+  useEffect(() => {
+    if (!open) return;
+    clearHighlights();
+    const match = matches[activeIndex];
+    if (!match || !highlightExpr) return;
+
+    revealChapter(match.chid);
+    const raf = requestAnimationFrame(() => {
+      const el = document.querySelector(`[data-chid="${match.chid}"]`);
+      if (!el) return;
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+
+      const api = highlightApi();
+      if (!api) {
+        // No Custom Highlight API: fall back to a temporary outline on the chapter element.
+        el.classList.add(FALLBACK_CLASS);
+        return;
+      }
+      // Highlight every match inside the visible active chapter; a second, brighter highlight marks the
+      // single active one when it can be resolved to a specific range.
+      const ranges = rangesInElement(el, highlightExpr);
+      if (ranges.length === 0) return;
+      api.registry.set(HIGHLIGHT_ALL, new api.Highlight(...ranges));
+      // Position of the active match among this chapter's matches → which range to spotlight.
+      const localRank = matches.filter((m, i) => m.chid === match.chid && i < activeIndex).length;
+      const activeRange = ranges[localRank] ?? ranges[0]!;
+      api.registry.set(HIGHLIGHT_ACTIVE, new api.Highlight(activeRange));
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [open, matches, activeIndex, highlightExpr, revealChapter]);
+
+  // Clear highlights whenever the widget is closed or unmounts.
+  useEffect(() => {
+    if (!open) clearHighlights();
+    return () => clearHighlights();
+  }, [open]);
+
+  const navigate = useCallback(
+    (delta: number) => {
+      if (matches.length === 0) return;
+      setActiveIndex((i) => wrapIndex(i + delta, matches.length));
+    },
+    [matches.length],
+  );
+
+  if (!open || !narrative) return null;
+
+  const total = matches.length;
+  const countLabel = error
+    ? 'Invalid regex'
+    : !query
+      ? ''
+      : total === 0
+        ? 'No results'
+        : `${activeIndex + 1} of ${total}`;
+
+  return (
+    <div
+      role="search"
+      aria-label="Find in review"
+      className="fixed right-4 top-[76px] z-50 flex items-center gap-1.5 rounded-[10px] px-2 py-1.5"
+      style={{
+        background: 'var(--bg-panel)',
+        boxShadow: 'var(--shadow-elevated), inset 0 0 0 1px var(--gray-a5)',
+      }}
+    >
+      <input
+        ref={inputRef}
+        aria-label="Find"
+        aria-invalid={error ? 'true' : undefined}
+        title={error ?? undefined}
+        value={query}
+        placeholder="Find in review"
+        onChange={(e) => setQuery(e.currentTarget.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            e.preventDefault();
+            close();
+          } else if (e.key === 'Enter') {
+            e.preventDefault();
+            navigate(e.shiftKey ? -1 : 1);
+          }
+        }}
+        className="h-6 w-[180px] bg-transparent px-1.5 text-[13px] text-[var(--fg-1)] outline-none placeholder:text-[var(--fg-3)]"
+        style={{ boxShadow: `inset 0 0 0 1px ${error ? 'var(--red-a4)' : 'var(--gray-a4)'}`, borderRadius: 6 }}
+      />
+      <div className="flex items-center gap-0.5">
+        <ToggleButton label="Match case" active={matchCase} onClick={() => setMatchCase((v) => !v)}>
+          Aa
+        </ToggleButton>
+        <ToggleButton label="Whole word" active={wholeWord} onClick={() => setWholeWord((v) => !v)}>
+          ab
+        </ToggleButton>
+        <ToggleButton label="Use regular expression" active={regex} error={!!error} onClick={() => setRegex((v) => !v)}>
+          .*
+        </ToggleButton>
+      </div>
+      <span
+        aria-live="polite"
+        className="min-w-[60px] px-1 text-right text-[11.5px] tabular-nums"
+        style={{ color: error ? 'var(--red-11)' : 'var(--fg-3)' }}
+      >
+        {countLabel}
+      </span>
+      <div className="flex items-center gap-0.5">
+        <ActionButton label="Previous match (Shift+Enter)" disabled={total === 0} onClick={() => navigate(-1)}>
+          ↑
+        </ActionButton>
+        <ActionButton label="Next match (Enter)" disabled={total === 0} onClick={() => navigate(1)}>
+          ↓
+        </ActionButton>
+        <ActionButton label="Close (Esc)" onClick={close}>
+          ✕
+        </ActionButton>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -720,3 +720,20 @@ code {
   font-size: 0.75em;
   color: var(--fg-3);
 }
+
+/* Find-in-review: CSS Custom Highlight API paints matches without mutating the DOM. */
+::highlight(diffdad-find) {
+  background: var(--purple-a4);
+  color: inherit;
+}
+::highlight(diffdad-find-active) {
+  background: var(--purple-a8);
+  color: inherit;
+}
+/* Fallback for browsers without the Highlight API: a temporary outline on the target chapter. */
+.diffdad-find-fallback {
+  outline: 2px solid var(--purple-9);
+  outline-offset: 4px;
+  border-radius: 6px;
+  transition: outline-color 0.4s ease;
+}

--- a/packages/web/src/lib/__tests__/find.test.ts
+++ b/packages/web/src/lib/__tests__/find.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from 'vitest';
+import {
+  collectTargets,
+  compileFindQuery,
+  findInNarrative,
+  matchTargets,
+  wrapIndex,
+} from '../find';
+import type { Chapter, DiffFile, DiffLine, NarrativeResponse, Section } from '../../state/types';
+
+// --- fixtures -------------------------------------------------------------
+
+function line(content: string): DiffLine {
+  return { type: 'context', content, lineNumber: {} };
+}
+
+function mkFile(file: string, contents: string[]): DiffFile {
+  return {
+    file,
+    isNewFile: false,
+    isDeleted: false,
+    hunks: [
+      {
+        header: '@@ -1,1 +1,1 @@',
+        oldStart: 1,
+        oldCount: contents.length,
+        newStart: 1,
+        newCount: contents.length,
+        lines: contents.map(line),
+      },
+    ],
+  };
+}
+
+function prose(content: string): Section {
+  return { type: 'narrative', content };
+}
+
+function diff(file: string, hunkIndex = 0): Section {
+  return { type: 'diff', file, startLine: 1, endLine: 10, hunkIndex };
+}
+
+function mkChapter(o: Partial<Chapter> = {}): Chapter {
+  return { title: 'Chapter', summary: '', whyMatters: '', risk: 'low', sections: [], ...o };
+}
+
+function mkNarrative(chapters: Chapter[]): NarrativeResponse {
+  return { title: 't', tldr: 'td', verdict: 'safe', readingPlan: [], concerns: [], chapters };
+}
+
+const OPTS = { matchCase: false, wholeWord: false, regex: false };
+
+// --- compileFindQuery -----------------------------------------------------
+
+describe('compileFindQuery', () => {
+  it('escapes plain-text queries so metacharacters are literal', () => {
+    const compiled = compileFindQuery('a.b', OPTS);
+    expect('expression' in compiled).toBe(true);
+    if ('expression' in compiled) {
+      expect('axb'.match(compiled.expression)).toBeNull();
+      expect('a.b'.match(compiled.expression)).not.toBeNull();
+    }
+  });
+
+  it('is case-insensitive by default and case-sensitive with matchCase', () => {
+    const insensitive = compileFindQuery('foo', OPTS);
+    const sensitive = compileFindQuery('foo', { ...OPTS, matchCase: true });
+    if ('expression' in insensitive) expect('FOO'.match(insensitive.expression)).not.toBeNull();
+    if ('expression' in sensitive) expect('FOO'.match(sensitive.expression)).toBeNull();
+  });
+
+  it('wraps in word boundaries for wholeWord', () => {
+    const compiled = compileFindQuery('cat', { ...OPTS, wholeWord: true });
+    if ('expression' in compiled) {
+      expect('the cat sat'.match(compiled.expression)).not.toBeNull();
+      expect('category'.match(compiled.expression)).toBeNull();
+    }
+  });
+
+  it('treats the query as a pattern under regex', () => {
+    const compiled = compileFindQuery('a.b', { ...OPTS, regex: true });
+    if ('expression' in compiled) expect('axb'.match(compiled.expression)).not.toBeNull();
+  });
+
+  it('returns an error for an invalid regex', () => {
+    const compiled = compileFindQuery('(unclosed', { ...OPTS, regex: true });
+    expect('error' in compiled).toBe(true);
+  });
+});
+
+// --- collectTargets (document order) --------------------------------------
+
+describe('collectTargets', () => {
+  it('collects title, summary, whyMatters, sections and callouts in render order', () => {
+    const narrative = mkNarrative([
+      mkChapter({
+        title: 'Title A',
+        summary: 'Summary A',
+        whyMatters: 'Why A',
+        sections: [prose('Prose A'), diff('src/a.ts')],
+        callouts: [{ file: 'src/a.ts', line: 1, level: 'nit', message: 'Callout A' }],
+      }),
+    ]);
+    const files = [mkFile('src/a.ts', ['line one', 'line two'])];
+    const targets = collectTargets(narrative, files);
+    expect(targets.map((t) => t.field)).toEqual([
+      'title',
+      'summary',
+      'whyMatters',
+      'narrative',
+      'diff',
+      'diff',
+      'callout',
+    ]);
+    expect(targets.map((t) => t.text)).toEqual([
+      'Title A',
+      'Summary A',
+      'Why A',
+      'Prose A',
+      'line one',
+      'line two',
+      'Callout A',
+    ]);
+    // order is a strictly increasing document rank
+    expect(targets.map((t) => t.order)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+  });
+
+  it('spans multiple chapters in order, including a later chapter that is collapsed in the UI', () => {
+    const narrative = mkNarrative([
+      mkChapter({ title: 'First', sections: [diff('src/a.ts')] }),
+      mkChapter({ title: 'Second', sections: [diff('src/b.ts')] }),
+    ]);
+    const files = [mkFile('src/a.ts', ['needle in a']), mkFile('src/b.ts', ['needle in b'])];
+    // The store has no notion of collapse for search — the data drives it, so a match in the second
+    // chapter is found regardless of any UI collapse.
+    const { matches } = findInNarrative(narrative, files, 'needle', OPTS);
+    expect(matches.map((m) => m.chid)).toEqual(['ch-0', 'ch-1']);
+    expect(matches[0]!.order).toBeLessThan(matches[1]!.order);
+  });
+
+  it('skips diff sections whose file/hunk is missing from files', () => {
+    const narrative = mkNarrative([mkChapter({ sections: [diff('src/missing.ts')] })]);
+    const targets = collectTargets(narrative, []);
+    expect(targets.filter((t) => t.field === 'diff')).toHaveLength(0);
+  });
+
+  it('returns nothing for a null narrative', () => {
+    expect(collectTargets(null, [])).toEqual([]);
+  });
+});
+
+// --- matchTargets / findInNarrative ---------------------------------------
+
+describe('findInNarrative', () => {
+  const narrative = mkNarrative([
+    mkChapter({ title: 'Cat chapter', summary: 'a cat and a category', sections: [diff('src/a.ts')] }),
+  ]);
+  const files = [mkFile('src/a.ts', ['CAT scan', 'concatenate'])];
+
+  it('finds matches across prose and diff content in document order', () => {
+    const { matches } = findInNarrative(narrative, files, 'cat', OPTS);
+    // title(1) + summary(2: "cat", "category") + diff line 1 "CAT" + diff line 2 "concat"
+    expect(matches).toHaveLength(5);
+    expect(matches.map((m) => m.field)).toEqual(['title', 'summary', 'summary', 'diff', 'diff']);
+  });
+
+  it('honors matchCase', () => {
+    const { matches } = findInNarrative(narrative, files, 'CAT', { ...OPTS, matchCase: true });
+    // only the diff line "CAT scan"
+    expect(matches).toHaveLength(1);
+    expect(matches[0]!.field).toBe('diff');
+    expect(matches[0]!.text).toBe('CAT');
+  });
+
+  it('honors wholeWord', () => {
+    const { matches } = findInNarrative(narrative, files, 'cat', { ...OPTS, wholeWord: true });
+    // "Cat chapter" title, "a cat" in summary, "CAT scan" diff — not "category"/"concatenate"
+    expect(matches).toHaveLength(3);
+  });
+
+  it('supports regex queries', () => {
+    const { matches } = findInNarrative(narrative, files, 'c.t', { ...OPTS, regex: true });
+    expect(matches.length).toBeGreaterThan(0);
+  });
+
+  it('reports an invalid regex and yields no matches', () => {
+    const { matches, error } = findInNarrative(narrative, files, '(', { ...OPTS, regex: true });
+    expect(matches).toHaveLength(0);
+    expect(error).toBeTruthy();
+  });
+
+  it('returns no matches and no error for an empty query', () => {
+    expect(findInNarrative(narrative, files, '', OPTS)).toEqual({ matches: [], error: null });
+  });
+
+  it('does not spin on a zero-length regex match', () => {
+    const { matches } = findInNarrative(narrative, files, 'x*', { ...OPTS, regex: true });
+    // zero-length matches are skipped, so nothing is collected for an all-optional pattern
+    expect(matches).toHaveLength(0);
+  });
+});
+
+describe('matchTargets records offsets', () => {
+  it('reports start/end within the target text', () => {
+    const targets = collectTargets(mkNarrative([mkChapter({ summary: 'find me here' })]), []);
+    const compiled = compileFindQuery('me', OPTS);
+    if (!('expression' in compiled)) throw new Error('expected valid regex');
+    const matches = matchTargets(targets, compiled.expression);
+    expect(matches).toHaveLength(1);
+    expect(matches[0]!.start).toBe(5);
+    expect(matches[0]!.end).toBe(7);
+  });
+});
+
+// --- wrapIndex (navigation wrap-around) -----------------------------------
+
+describe('wrapIndex', () => {
+  it('wraps forward past the end to the start', () => {
+    expect(wrapIndex(3, 3)).toBe(0);
+    expect(wrapIndex(4, 3)).toBe(1);
+  });
+
+  it('wraps backward before the start to the end', () => {
+    expect(wrapIndex(-1, 3)).toBe(2);
+    expect(wrapIndex(-2, 3)).toBe(1);
+  });
+
+  it('returns -1 for an empty match set', () => {
+    expect(wrapIndex(0, 0)).toBe(-1);
+  });
+});

--- a/packages/web/src/lib/__tests__/find.test.ts
+++ b/packages/web/src/lib/__tests__/find.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  collectTargets,
-  compileFindQuery,
-  findInNarrative,
-  matchTargets,
-  wrapIndex,
-} from '../find';
+import { collectTargets, compileFindQuery, findInNarrative, matchTargets, wrapIndex } from '../find';
 import type { Chapter, DiffFile, DiffLine, NarrativeResponse, Section } from '../../state/types';
 
 // --- fixtures -------------------------------------------------------------

--- a/packages/web/src/lib/find.ts
+++ b/packages/web/src/lib/find.ts
@@ -1,0 +1,160 @@
+/**
+ * Pure search logic for the find-in-review widget.
+ *
+ * The widget searches the narrative DATA, not the rendered DOM, so a match inside a collapsed chapter
+ * is found (and can then trigger an expand) rather than missed the way browser Ctrl-F misses it. Every
+ * function here is a plain data transform with no DOM access, so the matching rules — case, whole word,
+ * regex, document order across chapters — are testable as functions.
+ */
+import { normalizePath } from './paths';
+import type { DiffFile, NarrativeResponse } from '../state/types';
+
+export type FindOptions = {
+  matchCase: boolean;
+  wholeWord: boolean;
+  regex: boolean;
+};
+
+/** Which slice of a chapter a target's text came from — kept for debugging/tests, not shown to users. */
+export type FindField = 'title' | 'summary' | 'whyMatters' | 'narrative' | 'diff' | 'callout';
+
+/**
+ * A single searchable string plus where it lives. `chapterIndex` / `chid` are what navigation needs to
+ * expand the right chapter and scroll to it; `order` is the document-order rank assigned as targets are
+ * collected top-to-bottom, so matches come out already ordered.
+ */
+export type FindTarget = {
+  chapterIndex: number;
+  chid: string;
+  field: FindField;
+  text: string;
+  order: number;
+};
+
+export type FindMatch = {
+  chapterIndex: number;
+  chid: string;
+  field: FindField;
+  /** The matched text (what the DOM highlighter looks for inside the chapter element). */
+  text: string;
+  /** Char offset of the match within `target.text`. */
+  start: number;
+  end: number;
+  order: number;
+};
+
+/** A compiled query, or a message describing why the regex is invalid (widget shows an inert error). */
+export type CompiledQuery = { expression: RegExp } | { error: string };
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Build the global regex for a query. Non-regex queries are escaped; `wholeWord` wraps the source in
+ * `\b...\b`. An invalid regex returns `{ error }` so the caller can render a subtle error state and run
+ * no search rather than throw.
+ */
+export function compileFindQuery(query: string, opts: FindOptions): CompiledQuery {
+  const source = opts.regex ? query : escapeRegExp(query);
+  const bounded = opts.wholeWord ? `\\b(?:${source})\\b` : source;
+  try {
+    return { expression: new RegExp(bounded, opts.matchCase ? 'gu' : 'giu') };
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+/** All non-overlapping matches of `expression` in `text`, guarding against zero-length-match spins. */
+export function regexMatches(text: string, expression: RegExp): { start: number; end: number }[] {
+  const out: { start: number; end: number }[] = [];
+  expression.lastIndex = 0;
+  for (;;) {
+    const m = expression.exec(text);
+    if (!m) break;
+    if (m[0].length === 0) {
+      expression.lastIndex += 1;
+      continue;
+    }
+    out.push({ start: m.index, end: m.index + m[0].length });
+  }
+  return out;
+}
+
+/**
+ * Every searchable string in the narrative, in the order it renders: per chapter — title, summary,
+ * whyMatters, then each section (narrative prose, or every diff line's content) in section order, then
+ * callouts. Diff line text is pulled from `files` by matching the section's file + hunk index, which is
+ * what lets a match land inside a chapter whose diff is currently collapsed.
+ */
+export function collectTargets(narrative: NarrativeResponse | null, files: DiffFile[]): FindTarget[] {
+  const targets: FindTarget[] = [];
+  if (!narrative) return targets;
+  let order = 0;
+  const push = (chapterIndex: number, chid: string, field: FindField, text: string) => {
+    if (text && text.length > 0) targets.push({ chapterIndex, chid, field, text, order: order++ });
+  };
+
+  narrative.chapters.forEach((ch, idx) => {
+    const chid = `ch-${idx}`;
+    push(idx, chid, 'title', ch.title ?? '');
+    push(idx, chid, 'summary', ch.summary ?? '');
+    push(idx, chid, 'whyMatters', ch.whyMatters ?? '');
+    for (const section of ch.sections) {
+      if (section.type === 'narrative') {
+        push(idx, chid, 'narrative', section.content ?? '');
+      } else {
+        const norm = normalizePath(section.file);
+        const diffFile = files.find((f) => normalizePath(f.file) === norm);
+        const hunk = diffFile?.hunks[section.hunkIndex];
+        if (!hunk) continue;
+        for (const line of hunk.lines) push(idx, chid, 'diff', line.content ?? '');
+      }
+    }
+    for (const callout of ch.callouts ?? []) push(idx, chid, 'callout', callout.message ?? '');
+  });
+
+  return targets;
+}
+
+/** Run a compiled regex over every target, yielding matches in document order. */
+export function matchTargets(targets: FindTarget[], expression: RegExp): FindMatch[] {
+  const matches: FindMatch[] = [];
+  for (const target of targets) {
+    for (const { start, end } of regexMatches(target.text, expression)) {
+      matches.push({
+        chapterIndex: target.chapterIndex,
+        chid: target.chid,
+        field: target.field,
+        text: target.text.slice(start, end),
+        start,
+        end,
+        order: target.order,
+      });
+    }
+  }
+  return matches;
+}
+
+/**
+ * One-shot search: compile the query, collect targets, return ordered matches. An empty query yields no
+ * matches with no error; an invalid regex yields no matches with the error message.
+ */
+export function findInNarrative(
+  narrative: NarrativeResponse | null,
+  files: DiffFile[],
+  query: string,
+  opts: FindOptions,
+): { matches: FindMatch[]; error: string | null } {
+  if (!query) return { matches: [], error: null };
+  const compiled = compileFindQuery(query, opts);
+  if ('error' in compiled) return { matches: [], error: compiled.error };
+  const targets = collectTargets(narrative, files);
+  return { matches: matchTargets(targets, compiled.expression), error: null };
+}
+
+/** Wrap an index into `[0, length)`, so next-from-last lands on 0 and prev-from-0 lands on last. */
+export function wrapIndex(index: number, length: number): number {
+  if (length <= 0) return -1;
+  return ((index % length) + length) % length;
+}

--- a/packages/web/src/state/review-store.ts
+++ b/packages/web/src/state/review-store.ts
@@ -144,6 +144,14 @@ type ReviewState = {
   recapStatus: RecapStatus;
   recapError: string | null;
 
+  /**
+   * A one-shot request from the find widget to expand a specific chapter so a match inside it becomes
+   * visible. Chapter collapse state is local to the `Chapter` component, so this is the channel the
+   * widget uses to reach it: the target `chid` plus a `nonce` that changes on every request, so asking
+   * to reveal the same chapter twice still fires the effect.
+   */
+  chapterReveal: { chid: string; nonce: number } | null;
+
   setData: (
     pr: PRData,
     narrative: NarrativeResponse,
@@ -161,13 +169,6 @@ type ReviewState = {
    */
   setBlastRadius: (data: BlastRadius) => void;
   setActiveChapter: (id: string) => void;
-  /**
-   * A TOC jump to a chapter that may be collapsed. Chapters own their collapsed state locally, so the
-   * TOC cannot open one directly: it names the target here and the matching `Chapter` opens itself, then
-   * clears the request. `null` is the resting state.
-   */
-  pendingExpandChapterId: string | null;
-  requestExpandChapter: (id: string | null) => void;
   toggleReviewed: (idx: number) => void;
   setOpenLine: (key: string | null) => void;
   /** Open a comment thread on `key`. When `extend` is true and `openLine` is
@@ -245,6 +246,8 @@ type ReviewState = {
   setRecap: (recap: RecapResponse | null) => void;
   setRecapStatus: (status: RecapStatus) => void;
   setRecapError: (error: string | null) => void;
+  /** Ask the chapter with this `chid` to expand (find-widget navigation into a collapsed chapter). */
+  revealChapter: (chid: string) => void;
 };
 
 /**
@@ -476,7 +479,6 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   repoUrl: null,
   chapterStates: {},
   activeChapterId: null,
-  pendingExpandChapterId: null,
   reviewKey: null,
   drafts: [],
   openLine: null,
@@ -515,6 +517,8 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   recap: null,
   recapStatus: 'idle',
   recapError: null,
+
+  chapterReveal: null,
 
   plan: null,
   pendingChapterThemeIds: new Set<string>(),
@@ -561,8 +565,6 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   },
 
   setActiveChapter: (id) => set({ activeChapterId: id }),
-
-  requestExpandChapter: (id) => set({ pendingExpandChapterId: id }),
 
   toggleReviewed: (idx) =>
     set((state) => {
@@ -884,6 +886,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   setRecap: (recap) => set({ recap, recapStatus: recap ? 'ready' : 'idle', recapError: null }),
   setRecapStatus: (recapStatus) => set({ recapStatus }),
   setRecapError: (recapError) => set({ recapError, recapStatus: recapError ? 'error' : 'idle' }),
+  revealChapter: (chid) => set((s) => ({ chapterReveal: { chid, nonce: (s.chapterReveal?.nonce ?? 0) + 1 } })),
 }));
 
 export function useResolvedTheme(): 'light' | 'dark' {


### PR DESCRIPTION
Browser Ctrl-F misses matches inside collapsed chapters. Cmd/Ctrl-F
now opens an in-app find widget when a narrative is loaded:

- searches store data, not the DOM: chapter titles, summaries, prose,
  callouts, and diff line content — collapsed chapters included
- match case / whole word / regex toggles (invalid regex is inert)
- Enter/Shift-Enter cycle with N-of-M counter; navigating to a match
  expands its chapter via the shared revealChapter channel, scrolls,
  and highlights via the CSS Custom Highlight API (outline fallback)

The TOC's expand-before-scroll now rides the same revealChapter
channel (nonce-based) instead of a separate one-shot request field.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>