### PR TITLE
feat(narrative): content-derived anchors that re-resolve stale hunk refs

### DIFF
--- a/packages/cli/src/__tests__/anchors.test.ts
+++ b/packages/cli/src/__tests__/anchors.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from 'vitest';
+import { computeHunkAnchor, enrichNarrativeAnchors, resolveAnchor } from '../narrative/anchors';
+import { hashHunkLines } from '../github/diff-parser';
+import { repairNarrative } from '../narrative/validator';
+import type { DiffFile, DiffHunk, DiffLine } from '../github/types';
+import type { NarrativeResponse } from '../narrative/types';
+
+function line(type: DiffLine['type'], content: string): DiffLine {
+  return { type, content, lineNumber: {} };
+}
+
+function hunk(newStart: number, newCount: number, contents: [DiffLine['type'], string][]): DiffHunk {
+  const lines = contents.map(([t, c]) => line(t, c));
+  return {
+    header: `@@ -${newStart},1 +${newStart},${newCount} @@`,
+    oldStart: newStart,
+    oldCount: 1,
+    newStart,
+    newCount,
+    lines,
+    contentHash: hashHunkLines(lines),
+  };
+}
+
+function file(path: string, hunks: DiffHunk[]): DiffFile {
+  return { file: path, isNewFile: false, isDeleted: false, hunks };
+}
+
+function narrative(chapters: NarrativeResponse['chapters']): NarrativeResponse {
+  return { title: 't', tldr: '', verdict: 'caution', readingPlan: [], concerns: [], chapters };
+}
+
+describe('computeHunkAnchor', () => {
+  it('is stable: the same hunk contents produce the same contentHash', () => {
+    const h = hunk(10, 2, [
+      ['context', 'const a = 1;'],
+      ['add', 'const b = 2;'],
+    ]);
+    const f = file('a.ts', [h]);
+    const a1 = computeHunkAnchor(f, 0);
+    const a2 = computeHunkAnchor(
+      file('a.ts', [
+        hunk(10, 2, [
+          ['context', 'const a = 1;'],
+          ['add', 'const b = 2;'],
+        ]),
+      ]),
+      0,
+    );
+    expect(a1.contentHash).toBe(a2.contentHash);
+    expect(a1).toEqual({ file: 'a.ts', newStart: 10, newLines: 2, contentHash: a1.contentHash });
+  });
+
+  it('changes contentHash when any line changes', () => {
+    const base = computeHunkAnchor(
+      file('a.ts', [
+        hunk(10, 2, [
+          ['context', 'const a = 1;'],
+          ['add', 'const b = 2;'],
+        ]),
+      ]),
+      0,
+    );
+    const changed = computeHunkAnchor(
+      file('a.ts', [
+        hunk(10, 2, [
+          ['context', 'const a = 1;'],
+          ['add', 'const b = 3;'],
+        ]),
+      ]),
+      0,
+    );
+    expect(changed.contentHash).not.toBe(base.contentHash);
+  });
+
+  it('op changes (add vs context) change the hash even with identical text', () => {
+    const add = computeHunkAnchor(file('a.ts', [hunk(1, 1, [['add', 'x']])]), 0);
+    const ctx = computeHunkAnchor(file('a.ts', [hunk(1, 1, [['context', 'x']])]), 0);
+    expect(add.contentHash).not.toBe(ctx.contentHash);
+  });
+});
+
+describe('resolveAnchor ladder', () => {
+  const target = hunk(20, 2, [
+    ['context', 'foo'],
+    ['add', 'bar'],
+  ]);
+  const anchor = computeHunkAnchor(file('a.ts', [target]), 0);
+
+  it('1. exact: hash + position match', () => {
+    const files = [file('a.ts', [target])];
+    expect(resolveAnchor(files, anchor)).toEqual({ file: 'a.ts', hunkIndex: 0 });
+  });
+
+  it('2. moved-index: same hash at a shifted index', () => {
+    const files = [file('a.ts', [hunk(1, 1, [['add', 'unrelated']]), target])];
+    expect(resolveAnchor(files, anchor)).toEqual({ file: 'a.ts', hunkIndex: 1 });
+  });
+
+  it('3. line-range: hash gone, overlapping new-side range in the named file', () => {
+    const edited = hunk(21, 2, [
+      ['context', 'foo'],
+      ['add', 'baz'], // changed content -> different hash, but overlaps [20,21]
+    ]);
+    const files = [file('a.ts', [edited])];
+    expect(resolveAnchor(files, anchor)).toEqual({ file: 'a.ts', hunkIndex: 0 });
+  });
+
+  it('4. null: file present but no hash match and no overlapping range', () => {
+    const faraway = hunk(200, 1, [['add', 'nope']]);
+    const files = [file('a.ts', [faraway])];
+    expect(resolveAnchor(files, anchor)).toBeNull();
+  });
+
+  it('4. null: named file absent entirely', () => {
+    const files = [file('other.ts', [target])];
+    expect(resolveAnchor(files, anchor)).toBeNull();
+  });
+
+  it('normalizes a/ b/ path prefixes on both sides', () => {
+    const files = [file('a.ts', [target])];
+    expect(resolveAnchor(files, { ...anchor, file: 'b/a.ts' })).toEqual({ file: 'a.ts', hunkIndex: 0 });
+  });
+});
+
+describe('enrichNarrativeAnchors', () => {
+  it('stamps a fresh anchor onto every resolvable diff section', () => {
+    const h = hunk(5, 1, [['add', 'z']]);
+    const files = [file('a.ts', [h])];
+    const n = narrative([
+      {
+        title: 'A',
+        summary: '',
+        whyMatters: '',
+        risk: 'low',
+        sections: [{ type: 'diff', file: 'a.ts', hunkIndex: 0, startLine: 5, endLine: 5 }],
+      },
+    ]);
+    const out = enrichNarrativeAnchors(n, files);
+    const s = out.chapters[0]!.sections[0]!;
+    expect(s.type === 'diff' && s.anchor).toEqual(computeHunkAnchor(files[0]!, 0));
+  });
+});
+
+describe('repairNarrative re-resolution', () => {
+  it('re-resolves a shifted hunkIndex via the anchor instead of dropping it', () => {
+    const target = hunk(20, 2, [
+      ['context', 'foo'],
+      ['add', 'bar'],
+    ]);
+    const anchor = computeHunkAnchor(file('a.ts', [target]), 0);
+    // Diff re-fetched: a new hunk got prepended, so the target now lives at index 1, but the narrative
+    // still says index 0.
+    const files = [file('a.ts', [hunk(1, 1, [['add', 'new']]), target])];
+    const n = narrative([
+      {
+        title: 'A',
+        summary: '',
+        whyMatters: '',
+        risk: 'low',
+        sections: [{ type: 'diff', file: 'a.ts', hunkIndex: 0, startLine: 20, endLine: 21, anchor }],
+      },
+    ]);
+    const { narrative: out, dropped } = repairNarrative(n, files);
+    expect(dropped).toEqual([]);
+    const s = out.chapters[0]!.sections[0]!;
+    expect(s.type).toBe('diff');
+    if (s.type === 'diff') {
+      expect(s.hunkIndex).toBe(1);
+      expect(s.file).toBe('a.ts');
+      expect(s.anchor).toEqual(computeHunkAnchor(files[0]!, 1));
+    }
+  });
+
+  it('re-resolves an unknown-file section when the anchor still names a present file', () => {
+    const target = hunk(3, 1, [['add', 'kept']]);
+    const anchor = computeHunkAnchor(file('a.ts', [target]), 0);
+    const files = [file('a.ts', [target])];
+    const n = narrative([
+      {
+        title: 'A',
+        summary: '',
+        whyMatters: '',
+        risk: 'low',
+        // Section names a stale/renamed path but the anchor points at the real file.
+        sections: [{ type: 'diff', file: 'stale-name.ts', hunkIndex: 9, startLine: 3, endLine: 3, anchor }],
+      },
+    ]);
+    const { narrative: out, dropped } = repairNarrative(n, files);
+    expect(dropped).toEqual([]);
+    const s = out.chapters[0]!.sections[0]!;
+    expect(s.type === 'diff' && s.file).toBe('a.ts');
+    expect(s.type === 'diff' && s.hunkIndex).toBe(0);
+  });
+
+  it('still drops when the anchor cannot be placed', () => {
+    const anchor = computeHunkAnchor(file('a.ts', [hunk(20, 1, [['add', 'gone']])]), 0);
+    const files = [file('a.ts', [hunk(500, 1, [['add', 'different']])])];
+    const n = narrative([
+      {
+        title: 'A',
+        summary: '',
+        whyMatters: '',
+        risk: 'low',
+        sections: [{ type: 'diff', file: 'a.ts', hunkIndex: 7, startLine: 20, endLine: 20, anchor }],
+      },
+    ]);
+    const { narrative: out, dropped } = repairNarrative(n, files);
+    expect(out.chapters[0]!.sections).toEqual([]);
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0]!.kind).toBe('invalid-hunk-index');
+  });
+
+  it('drops (unchanged behavior) when a broken section carries no anchor', () => {
+    const files = [file('a.ts', [hunk(1, 1, [['add', 'x']])])];
+    const n = narrative([
+      {
+        title: 'A',
+        summary: '',
+        whyMatters: '',
+        risk: 'low',
+        sections: [{ type: 'diff', file: 'a.ts', hunkIndex: 9, startLine: 1, endLine: 1 }],
+      },
+    ]);
+    const { narrative: out, dropped } = repairNarrative(n, files);
+    expect(out.chapters[0]!.sections).toEqual([]);
+    expect(dropped).toHaveLength(1);
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,6 +5,7 @@ import { GitHubClient } from './github/client';
 import { type ParsedPr, parsePrRef } from './github/pr-ref';
 import { cacheNarrative, clearCache, computePromptMetaHash, getCachedNarrative } from './narrative/cache';
 import { generateNarrative, resolveAiPath, resolveProviderKey, setCliOverride } from './narrative/engine';
+import { reanchorNarrative } from './narrative/validator';
 import { migrateLegacyData } from './paths';
 import { getCachedRecap } from './recap/cache';
 import { describeRepoContext, resolveRepoContext } from './repo/snapshot';
@@ -228,7 +229,8 @@ async function reviewCommand(prArg: string | undefined): Promise<number> {
   const cachedRecap = noCache ? null : await getCachedRecap(parsed.owner, parsed.repo, parsed.number, metadata.headSha);
 
   const ctx: ServerContext = {
-    narrative: cached,
+    // Re-resolve any stale hunk refs against the diff just fetched for this SHA before serving.
+    narrative: cached ? reanchorNarrative(cached, files) : null,
     pr: metadata,
     files,
     comments,

--- a/packages/cli/src/daemon/daemon.ts
+++ b/packages/cli/src/daemon/daemon.ts
@@ -8,6 +8,7 @@ import { GitHubClient, type PostCommentOptions } from '../github/client';
 import { parseDiff } from '../github/diff-parser';
 import type { CheckRun, PRComment, PRReview } from '../github/types';
 import { cacheNarrative, computePromptMetaHash, getCachedNarrative } from '../narrative/cache';
+import { reanchorNarrative } from '../narrative/validator';
 import { callAi, generateNarrative, resolveProviderKey } from '../narrative/engine';
 import { describeRepoContext, type RepoContext, resolveRepoContext } from '../repo/snapshot';
 import { UnitStore } from '../units/store';
@@ -349,8 +350,10 @@ function makeHydrate(
       const cached = await getCachedNarrative(owner, name, prNumber, sha, metaHash, providerKey);
       if (cached) {
         // No `capStats`: a cached narrative measured no diff, so the drill-in states nothing about
-        // truncation rather than implying the story covered everything.
-        store.attachReview(unit.unitId, files, cached, cached.concerns?.length ?? 0);
+        // truncation rather than implying the story covered everything. Re-anchor first so a cached
+        // narrative meeting a freshly-parsed diff re-resolves shifted hunk indices.
+        const reanchored = reanchorNarrative(cached, files);
+        store.attachReview(unit.unitId, files, reanchored, reanchored.concerns?.length ?? 0);
         return store.get(unit.unitId)!;
       }
     }

--- a/packages/cli/src/github/diff-parser.ts
+++ b/packages/cli/src/github/diff-parser.ts
@@ -1,4 +1,17 @@
+import { createHash } from 'crypto';
 import type { DiffFile, DiffHunk, DiffLine } from './types';
+
+const LINE_OP: Record<DiffLine['type'], string> = { add: '+', remove: '-', context: ' ' };
+
+/**
+ * Deterministic content hash of a hunk's body: `op + content` per line, joined by newline, hashed to
+ * the first 12 hex of sha256. Stable across re-fetches of an identical hunk and changes when any line
+ * changes. The single source of truth for both the server-side anchor and the wire `contentHash`.
+ */
+export function hashHunkLines(lines: DiffLine[]): string {
+  const body = lines.map((l) => LINE_OP[l.type] + l.content).join('\n');
+  return createHash('sha256').update(body).digest('hex').slice(0, 12);
+}
 
 const HUNK_HEADER_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
 // Accept any git prefix, not just a/ b/ — `diff.mnemonicPrefix` emits c/ w/ i/ o/, and merge
@@ -123,6 +136,7 @@ function parseFileChunk(chunk: string[]): DiffFile {
       newStart,
       newCount,
       lines: hunkLines,
+      contentHash: hashHunkLines(hunkLines),
     });
   }
 

--- a/packages/cli/src/github/types.ts
+++ b/packages/cli/src/github/types.ts
@@ -64,6 +64,12 @@ export type DiffHunk = {
   newStart: number;
   newCount: number;
   lines: DiffLine[];
+  /**
+   * First 12 hex of sha256 over this hunk's line contents (op + content per line). Populated at parse
+   * time so the browser can compare anchors by string equality without hashing. Optional because
+   * DiffFiles that predate this field (or are constructed by tests) may carry no value.
+   */
+  contentHash?: string;
 };
 
 export type DiffFile = {

--- a/packages/cli/src/narrative/anchors.ts
+++ b/packages/cli/src/narrative/anchors.ts
@@ -1,0 +1,84 @@
+import { hashHunkLines } from '../github/diff-parser';
+import type { DiffFile, DiffHunk } from '../github/types';
+import type { HunkAnchor, NarrativeResponse } from './types';
+
+function normalizePath(p: string): string {
+  return p
+    .trim()
+    .replace(/^[ab]\//, '')
+    .replace(/^\/+/, '');
+}
+
+function hunkHash(hunk: DiffHunk): string {
+  return hunk.contentHash ?? hashHunkLines(hunk.lines);
+}
+
+/**
+ * Build the deterministic anchor for one hunk. `contentHash` re-uses the parse-time hash when present
+ * so the anchor and the wire hunk always agree; it falls back to hashing the lines for DiffFiles built
+ * without it (tests, older callers). Throws only on a genuinely absent hunk — callers pass a validated
+ * index.
+ */
+export function computeHunkAnchor(file: DiffFile, hunkIndex: number): HunkAnchor {
+  const hunk = file.hunks[hunkIndex];
+  if (!hunk) throw new Error(`computeHunkAnchor: no hunk at index ${hunkIndex} in ${file.file}`);
+  return {
+    file: file.file,
+    newStart: hunk.newStart,
+    newLines: hunk.newCount,
+    contentHash: hunkHash(hunk),
+  };
+}
+
+/**
+ * Re-resolve a stale anchor against a (possibly reshaped) diff. Fallback ladder, scoped to the named
+ * file:
+ *   1. exact    — same contentHash at the same new-side start (unchanged hunk, unchanged position)
+ *   2. moved    — same contentHash anywhere in that file's hunks (hunk survived, index shifted)
+ *   3. range    — overlapping new-side line range in that file (hunk edited, roughly same location)
+ *   4. null     — nothing plausible; the caller drops the reference
+ */
+export function resolveAnchor(files: DiffFile[], anchor: HunkAnchor): { file: string; hunkIndex: number } | null {
+  const norm = normalizePath(anchor.file);
+  const named = files.find((f) => normalizePath(f.file) === norm);
+  if (!named) return null;
+
+  let idx = named.hunks.findIndex((h) => hunkHash(h) === anchor.contentHash && h.newStart === anchor.newStart);
+  if (idx !== -1) return { file: named.file, hunkIndex: idx };
+
+  idx = named.hunks.findIndex((h) => hunkHash(h) === anchor.contentHash);
+  if (idx !== -1) return { file: named.file, hunkIndex: idx };
+
+  const aStart = anchor.newStart;
+  const aEnd = anchor.newStart + Math.max(anchor.newLines - 1, 0);
+  idx = named.hunks.findIndex((h) => {
+    const hEnd = h.newStart + Math.max(h.newCount - 1, 0);
+    return h.newStart <= aEnd && aStart <= hEnd;
+  });
+  if (idx !== -1) return { file: named.file, hunkIndex: idx };
+
+  return null;
+}
+
+/**
+ * Stamp a fresh anchor onto every diff section that resolves to a real hunk. Runs after repair, so
+ * every surviving diff section already points at a valid `{ file, hunkIndex }`; sections whose file or
+ * index is (unexpectedly) unresolvable are left untouched rather than crashing. Prose sections pass
+ * through unchanged.
+ */
+export function enrichNarrativeAnchors(narrative: NarrativeResponse, files: DiffFile[]): NarrativeResponse {
+  const fileMap = new Map<string, DiffFile>();
+  for (const f of files) fileMap.set(normalizePath(f.file), f);
+
+  const chapters = narrative.chapters.map((ch) => ({
+    ...ch,
+    sections: ch.sections.map((s) => {
+      if (s.type !== 'diff') return s;
+      const file = fileMap.get(normalizePath(s.file));
+      if (!file || s.hunkIndex < 0 || s.hunkIndex >= file.hunks.length) return s;
+      return { ...s, anchor: computeHunkAnchor(file, s.hunkIndex) };
+    }),
+  }));
+
+  return { ...narrative, chapters };
+}

--- a/packages/cli/src/narrative/engine.ts
+++ b/packages/cli/src/narrative/engine.ts
@@ -5,6 +5,7 @@ import { buildNarrativePrompt, type PreviousNarrativeContext, type PromptCapStat
 import { partitionMechanicalFiles } from './diff-filter';
 import { normalizeNarrative, type NarrativeChapter, type NarrativeResponse } from './types';
 import { formatViolation, repairNarrative, validateNarrative, type ValidationViolation } from './validator';
+import { enrichNarrativeAnchors } from './anchors';
 import { callAi as _callAi, resolveAiPath, type AiChunkHandler } from './ai-runtime';
 import { extractJson, tryParsePartialJson } from './json-parse';
 import { computeHints } from './hints';
@@ -110,7 +111,9 @@ function logNarrativeViolations(narrative: NarrativeResponse, files: DiffFile[])
 function repairAndLog(narrative: NarrativeResponse, files: DiffFile[]): NarrativeResponse {
   const { narrative: repaired, dropped } = repairNarrative(narrative, files);
   logViolationList('Narrative repair dropped unresolvable refs', dropped);
-  return repaired;
+  // Stamp a content-derived anchor onto every surviving diff section so a later re-fetch can
+  // re-resolve a shifted hunkIndex instead of dropping the reference. Runs on both generation paths.
+  return enrichNarrativeAnchors(repaired, files);
 }
 
 export type NarrativeGenerationOptions = {

--- a/packages/cli/src/narrative/types.ts
+++ b/packages/cli/src/narrative/types.ts
@@ -71,6 +71,19 @@ export type ReshowEntry = {
   highlight?: { from: number; to: number };
 };
 
+/**
+ * Deterministic, content-derived anchor for a diff section, computed server-side alongside the
+ * fragile `hunkIndex`. `contentHash` is {@link import('../github/diff-parser').hashHunkLines} over the
+ * hunk body: stable across re-fetches, changes when the hunk changes. Used to re-resolve a stale
+ * `hunkIndex` after the diff shifts shape instead of dropping the reference.
+ */
+export type HunkAnchor = {
+  file: string;
+  newStart: number;
+  newLines: number;
+  contentHash: string;
+};
+
 export type NarrativeSection =
   | { type: 'narrative'; content: string }
   | {
@@ -79,6 +92,8 @@ export type NarrativeSection =
       startLine: number;
       endLine: number;
       hunkIndex: number;
+      /** Content-derived re-resolution anchor. Absent on narratives cached before this field existed. */
+      anchor?: HunkAnchor;
     };
 
 const CONCERN_CATEGORIES: ConcernCategory[] = [

--- a/packages/cli/src/narrative/validator.ts
+++ b/packages/cli/src/narrative/validator.ts
@@ -1,5 +1,6 @@
 import type { DiffFile } from '../github/types';
-import type { NarrativeResponse } from './types';
+import { computeHunkAnchor, enrichNarrativeAnchors, resolveAnchor } from './anchors';
+import type { NarrativeResponse, NarrativeSection } from './types';
 
 export type ValidationViolation =
   | { kind: 'duplicate-primary'; file: string; hunkIndex: number; chapters: number[] }
@@ -155,24 +156,66 @@ export function repairNarrative(narrative: NarrativeResponse, files: DiffFile[])
   const primaryRefs = new Map<string, number[]>();
 
   const chapters = narrative.chapters.map((ch, ci) => {
-    const sections = ch.sections.filter((s) => {
-      if (s.type !== 'diff') return true;
+    const sections: NarrativeSection[] = [];
+    for (const s of ch.sections) {
+      if (s.type !== 'diff') {
+        sections.push(s);
+        continue;
+      }
       const norm = normalizePath(s.file);
       const file = fileMap.get(norm);
+      const inRange = file ? s.hunkIndex >= 0 && s.hunkIndex < file.hunks.length : false;
+      const record = (keyNorm: string, idx: number) => {
+        const key = `${keyNorm}:${idx}`;
+        const arr = primaryRefs.get(key);
+        if (arr) arr.push(ci);
+        else primaryRefs.set(key, [ci]);
+      };
+
+      // When the section carries a content anchor it is the authoritative join key: re-resolve it
+      // against the current diff so a shifted (or now-wrong) hunkIndex is fixed in place rather than
+      // trusting a raw index the diff may have moved out from under. During generation sections have
+      // no anchor yet (enrichment runs after repair), so this branch only bites on cache load, which
+      // is exactly where indices have drifted.
+      if (s.anchor) {
+        const resolved = resolveAnchor(files, s.anchor);
+        if (resolved) {
+          const resolvedNorm = normalizePath(resolved.file);
+          const resolvedFile = fileMap.get(resolvedNorm)!;
+          const fixed: NarrativeSection = {
+            ...s,
+            file: resolved.file,
+            hunkIndex: resolved.hunkIndex,
+            anchor: computeHunkAnchor(resolvedFile, resolved.hunkIndex),
+          };
+          record(resolvedNorm, resolved.hunkIndex);
+          sections.push(fixed);
+          continue;
+        }
+        // Anchor couldn't place it. Keep a structurally-valid raw index (a real hunk, just not the one
+        // the anchor described); drop only when the index points at nothing.
+        if (file && inRange) {
+          record(norm, s.hunkIndex);
+          sections.push(s);
+          continue;
+        }
+        if (!file) dropped.push({ kind: 'unknown-file', file: s.file, chapter: ci });
+        else dropped.push({ kind: 'invalid-hunk-index', file: s.file, hunkIndex: s.hunkIndex, chapter: ci });
+        continue;
+      }
+
+      // No anchor (fresh generation, or a narrative cached before anchors existed): raw index only.
       if (!file) {
         dropped.push({ kind: 'unknown-file', file: s.file, chapter: ci });
-        return false;
+        continue;
       }
-      if (s.hunkIndex < 0 || s.hunkIndex >= file.hunks.length) {
+      if (!inRange) {
         dropped.push({ kind: 'invalid-hunk-index', file: s.file, hunkIndex: s.hunkIndex, chapter: ci });
-        return false;
+        continue;
       }
-      const key = `${norm}:${s.hunkIndex}`;
-      const arr = primaryRefs.get(key);
-      if (arr) arr.push(ci);
-      else primaryRefs.set(key, [ci]);
-      return true;
-    });
+      record(norm, s.hunkIndex);
+      sections.push(s);
+    }
 
     let reshow = ch.reshow;
     if (reshow && reshow.length > 0) {
@@ -203,6 +246,17 @@ export function repairNarrative(narrative: NarrativeResponse, files: DiffFile[])
   });
 
   return { narrative: { ...narrative, chapters }, dropped };
+}
+
+/**
+ * Cache-load boundary: a narrative from cache meets a freshly-fetched diff whose hunk indices may have
+ * shifted. Re-resolve stale refs via their anchors (fixing in place), drop only the truly unresolvable,
+ * then refresh anchors so subsequent loads keep re-resolving. Safe on older cached narratives that
+ * carry no anchors — those simply fall through to the existing drop behavior.
+ */
+export function reanchorNarrative(narrative: NarrativeResponse, files: DiffFile[]): NarrativeResponse {
+  const { narrative: repaired } = repairNarrative(narrative, files);
+  return enrichNarrativeAnchors(repaired, files);
 }
 
 /** One-line human-readable summary of a violation, for warning logs. */

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -10,6 +10,7 @@ import type { GitHubClient } from './github/client';
 import { mapCommentsToChapters } from './github/comments';
 import type { CheckRun, DiffFile, PRComment, PRMetadata, PRReview } from './github/types';
 import { cacheNarrative, computePromptMetaHash, getCachedNarrative, getLastGoodNarrative } from './narrative/cache';
+import { reanchorNarrative } from './narrative/validator';
 import { chapterCallers, resolveCollapse } from './narrative/collapse';
 import { callAi, generateNarrative, resolveAiPath, resolveProviderKey } from './narrative/engine';
 import { buildChapterAiPrompt } from './narrative/chapter-ai';
@@ -437,7 +438,10 @@ export function createServer(ctx: ServerContext) {
                   providerKey,
                 );
                 if (cached) {
-                  ctx.narrative = cached;
+                  // The cached narrative was anchored against a prior diff; the SHA just changed and
+                  // `freshFiles` may have shifted hunk indices. Re-resolve via content anchors so refs
+                  // survive the reshape instead of dropping.
+                  ctx.narrative = reanchorNarrative(cached, freshFiles);
                   // A cached narrative carries no budget stats, and inventing them would tell the
                   // reviewer a story built from a truncated diff was complete.
                   ctx.capStats = null;

--- a/packages/contracts/src/drift.ts
+++ b/packages/contracts/src/drift.ts
@@ -10,6 +10,7 @@ import type {
   Callout as CCallout,
   Concern as CConcern,
   ConcernCategory as CConcernCategory,
+  HunkAnchor as CHunkAnchor,
   NarrativeChapter as CNarrativeChapter,
   NarrativeResponse as CNarrativeResponse,
   NarrativeSection as CNarrativeSection,
@@ -43,6 +44,7 @@ import type {
   DiffHunk,
   DiffLine,
   HelpSuggestion,
+  HunkAnchor,
   HunkRef,
   NarrativeChapter,
   NarrativeResponse,
@@ -73,6 +75,7 @@ type _Callout = Expect<Equal<Callout, CCallout>>;
 type _NarrativeChapter = Expect<Equal<NarrativeChapter, CNarrativeChapter>>;
 type _ReshowEntry = Expect<Equal<ReshowEntry, CReshowEntry>>;
 type _NarrativeSection = Expect<Equal<NarrativeSection, CNarrativeSection>>;
+type _HunkAnchor = Expect<Equal<HunkAnchor, CHunkAnchor>>;
 
 // github/types.ts — exact equality
 type _PRMetadata = Expect<Equal<PRMetadata, CPRMetadata>>;

--- a/packages/contracts/src/github.ts
+++ b/packages/contracts/src/github.ts
@@ -68,6 +68,8 @@ export const diffHunkSchema = z.object({
   newStart: z.number(),
   newCount: z.number(),
   lines: z.array(diffLineSchema),
+  /** First 12 hex of sha256 over the hunk body; lets the browser re-resolve anchors by string compare. */
+  contentHash: z.string().optional(),
 });
 export type DiffHunk = z.infer<typeof diffHunkSchema>;
 

--- a/packages/contracts/src/narrative.ts
+++ b/packages/contracts/src/narrative.ts
@@ -50,6 +50,14 @@ export const reshowEntrySchema = z.object({
 });
 export type ReshowEntry = z.infer<typeof reshowEntrySchema>;
 
+export const hunkAnchorSchema = z.object({
+  file: z.string(),
+  newStart: z.number(),
+  newLines: z.number(),
+  contentHash: z.string(),
+});
+export type HunkAnchor = z.infer<typeof hunkAnchorSchema>;
+
 export const narrativeSectionSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('narrative'), content: z.string() }),
   z.object({
@@ -58,6 +66,7 @@ export const narrativeSectionSchema = z.discriminatedUnion('type', [
     startLine: z.number(),
     endLine: z.number(),
     hunkIndex: z.number(),
+    anchor: hunkAnchorSchema.optional(),
   }),
 ]);
 export type NarrativeSection = z.infer<typeof narrativeSectionSchema>;

--- a/packages/web/src/components/Chapter.tsx
+++ b/packages/web/src/components/Chapter.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { resolveAnchor } from '../lib/anchor';
 import { collapseReason, initialCollapsed } from '../lib/collapse';
 import { normalizePath } from '../lib/paths';
 import { useReviewStore } from '../state/review-store';
@@ -10,6 +11,7 @@ import type {
   CollapseDecision,
   DiffFile,
   DiffHunk,
+  HunkAnchor,
 } from '../state/types';
 import { Hunk } from './Hunk';
 import { IconCheck, IconChevron } from './Icons';
@@ -179,15 +181,38 @@ function ReshowBlock({
   );
 }
 
-type FlatHunk = { hunk: DiffHunk; file: string; isNewFile: boolean };
+type FlatHunk = { hunk: DiffHunk; file: string; isNewFile: boolean; hunkIndex: number };
 
-function findHunk(files: DiffFile[], file: string, hunkIndex: number): FlatHunk | null {
+/**
+ * Resolve a diff section to a concrete hunk. Prefers the direct `hunks[hunkIndex]` lookup, but falls
+ * back to the content anchor when the index is missing OR the hunk it lands on no longer matches the
+ * anchor's `contentHash` (the diff shifted shape since the narrative was written). `hunkIndex` in the
+ * result is the resolved index, which may differ from the requested one.
+ */
+function findHunk(files: DiffFile[], file: string, hunkIndex: number, anchor?: HunkAnchor): FlatHunk | null {
   const norm = normalizePath(file);
   const diffFile = files.find((f) => normalizePath(f.file) === norm);
-  if (!diffFile) return null;
-  const hunk = diffFile.hunks[hunkIndex];
-  if (!hunk) return null;
-  return { hunk, file: diffFile.file, isNewFile: diffFile.isNewFile };
+  const direct = diffFile?.hunks[hunkIndex];
+  const directMatchesAnchor =
+    !anchor || direct == null || direct.contentHash == null || direct.contentHash === anchor.contentHash;
+
+  if (diffFile && direct && directMatchesAnchor) {
+    return { hunk: direct, file: diffFile.file, isNewFile: diffFile.isNewFile, hunkIndex };
+  }
+
+  if (anchor) {
+    const resolved = resolveAnchor(files, anchor);
+    if (resolved) {
+      const hunk = resolved.file.hunks[resolved.hunkIndex]!;
+      return { hunk, file: resolved.file.file, isNewFile: resolved.file.isNewFile, hunkIndex: resolved.hunkIndex };
+    }
+  }
+
+  // No anchor (or it failed): fall back to the direct hit if one exists at all.
+  if (diffFile && direct) {
+    return { hunk: direct, file: diffFile.file, isNewFile: diffFile.isNewFile, hunkIndex };
+  }
+  return null;
 }
 
 export function Chapter({ index, chapter, resolve, decision, callers }: Props) {
@@ -258,9 +283,9 @@ export function Chapter({ index, chapter, resolve, decision, callers }: Props) {
     const bucket = (i: number) => (bySection[i] ??= { resolve: [], callouts: [] });
     chapter.sections.forEach((section, i) => {
       if (section.type !== 'diff') return;
-      const flat = findHunk(files, section.file, section.hunkIndex);
+      const flat = findHunk(files, section.file, section.hunkIndex, section.anchor);
       if (!flat) return;
-      const nf = normalizePath(section.file);
+      const nf = normalizePath(flat.file);
       const start = flat.hunk.newStart;
       const end = start + Math.max(flat.hunk.newCount - 1, 0);
       for (const item of items) {
@@ -343,7 +368,7 @@ export function Chapter({ index, chapter, resolve, decision, callers }: Props) {
     let count = 0;
     for (const section of hunkSections) {
       if (section.type !== 'diff') continue;
-      const flat = findHunk(files, section.file, section.hunkIndex);
+      const flat = findHunk(files, section.file, section.hunkIndex, section.anchor);
       if (!flat) continue;
       const start = flat.hunk.newStart;
       const end = start + Math.max(flat.hunk.newCount - 1, 0);
@@ -478,11 +503,11 @@ export function Chapter({ index, chapter, resolve, decision, callers }: Props) {
           if (i !== firstNarrativeIndex) return null;
           return <NarrationBlock key={i} content={section.content} chapterKey={id} />;
         }
-        const flat = findHunk(files, section.file, section.hunkIndex);
+        const flat = findHunk(files, section.file, section.hunkIndex, section.anchor);
         if (!flat) {
           return <MissingHunkBanner key={i} file={section.file} hunkIndex={section.hunkIndex} />;
         }
-        const hunkKey = `${section.file}:${section.hunkIndex}`;
+        const hunkKey = `${flat.file}:${flat.hunkIndex}`;
         const isDuplicate = priorHunks.has(hunkKey);
         const hunkCoversAll =
           section.startLine <= flat.hunk.newStart &&
@@ -498,7 +523,7 @@ export function Chapter({ index, chapter, resolve, decision, callers }: Props) {
                 file={flat.file}
                 hunk={flat.hunk}
                 isNewFile={flat.isNewFile}
-                hunkIndex={section.hunkIndex}
+                hunkIndex={flat.hunkIndex}
                 highlight={highlight}
               />
             </ReshowBlock>
@@ -511,7 +536,7 @@ export function Chapter({ index, chapter, resolve, decision, callers }: Props) {
             file={flat.file}
             hunk={flat.hunk}
             isNewFile={flat.isNewFile}
-            hunkIndex={section.hunkIndex}
+            hunkIndex={flat.hunkIndex}
             highlight={highlight}
             resolve={annotationPlacement.bySection[i]?.resolve}
             callouts={annotationPlacement.bySection[i]?.callouts}

--- a/packages/web/src/lib/__tests__/anchor.test.ts
+++ b/packages/web/src/lib/__tests__/anchor.test.ts
@@ -1,50 +1,62 @@
 import { describe, expect, it } from 'vitest';
-import { anchorByNewLine } from '../anchor';
-import type { DiffLine } from '../../state/types';
+import { resolveAnchor } from '../anchor';
+import type { DiffFile, DiffHunk, HunkAnchor } from '../../state/types';
 
-// A small hunk spanning new-side lines 10..13, with one removed line (no new number).
-//   idx 0  context  new 10
-//   idx 1  remove   old 11   (no new)
-//   idx 2  add      new 11
-//   idx 3  add      new 12
-//   idx 4  context  new 13
-function mkLines(): DiffLine[] {
-  return [
-    { type: 'context', content: 'a', lineNumber: { old: 10, new: 10 } },
-    { type: 'remove', content: 'b', lineNumber: { old: 11 } },
-    { type: 'add', content: 'c', lineNumber: { new: 11 } },
-    { type: 'add', content: 'd', lineNumber: { new: 12 } },
-    { type: 'context', content: 'e', lineNumber: { old: 12, new: 13 } },
-  ];
+function hunk(newStart: number, newCount: number, contentHash?: string): DiffHunk {
+  return {
+    header: `@@ +${newStart},${newCount} @@`,
+    oldStart: newStart,
+    oldCount: 1,
+    newStart,
+    newCount,
+    lines: [],
+    contentHash,
+  };
 }
 
-describe('anchorByNewLine', () => {
-  it('anchors an item to the line index whose NEW-side number equals item.line', () => {
-    const { byLine, trailing } = anchorByNewLine(mkLines(), [{ line: 12 }]);
-    expect(byLine.get(3)).toEqual([0]); // new 12 lives at index 3
-    expect(trailing).toEqual([]);
+function file(path: string, hunks: DiffHunk[]): DiffFile {
+  return { file: path, isNewFile: false, isDeleted: false, hunks };
+}
+
+const anchor: HunkAnchor = { file: 'a.ts', newStart: 20, newLines: 2, contentHash: 'abc123' };
+
+describe('web resolveAnchor', () => {
+  it('exact: hash + position match', () => {
+    const files = [file('a.ts', [hunk(20, 2, 'abc123')])];
+    expect(resolveAnchor(files, anchor)).toEqual({ file: files[0], hunkIndex: 0 });
   });
 
-  it('groups multiple items on one line in items order', () => {
-    const { byLine } = anchorByNewLine(mkLines(), [{ line: 11 }, { line: 13 }, { line: 11 }]);
-    expect(byLine.get(2)).toEqual([0, 2]); // both line-11 items at index 2
-    expect(byLine.get(4)).toEqual([1]); // line-13 item at index 4
+  it('moved hunk found by hash at a shifted index', () => {
+    const files = [file('a.ts', [hunk(1, 1, 'other'), hunk(40, 2, 'abc123')])];
+    const r = resolveAnchor(files, anchor);
+    expect(r?.hunkIndex).toBe(1);
   });
 
-  it('sends items with no matching new-side line to trailing', () => {
-    const { byLine, trailing } = anchorByNewLine(mkLines(), [{ line: 99 }]);
-    expect(byLine.size).toBe(0);
-    expect(trailing).toEqual([0]);
+  it('missing hash falls back to overlapping line range', () => {
+    // Hunk shifted a line and its content changed, so no contentHash match; range [20,21] overlaps [21,22].
+    const files = [file('a.ts', [hunk(21, 2, 'changed')])];
+    expect(resolveAnchor(files, anchor)?.hunkIndex).toBe(0);
   });
 
-  it('never anchors to a removed line (line 11 is an add, not the removed old-11)', () => {
-    const { byLine } = anchorByNewLine(mkLines(), [{ line: 11 }]);
-    expect(byLine.get(2)).toEqual([0]); // the add at index 2, not the remove at index 1
-    expect(byLine.has(1)).toBe(false);
+  it('both hash and range fail -> null', () => {
+    const files = [file('a.ts', [hunk(200, 1, 'changed')])];
+    expect(resolveAnchor(files, anchor)).toBeNull();
   });
 
-  it('treats null/undefined line as trailing', () => {
-    const { trailing } = anchorByNewLine(mkLines(), [{ line: null }, { line: undefined }, {}]);
-    expect(trailing).toEqual([0, 1, 2]);
+  it('named file absent -> null', () => {
+    const files = [file('other.ts', [hunk(20, 2, 'abc123')])];
+    expect(resolveAnchor(files, anchor)).toBeNull();
+  });
+
+  it('does not match on an undefined contentHash even if the anchor hash is also falsy-adjacent', () => {
+    // A wire hunk with no contentHash must not accidentally match; only line-range can save it.
+    const files = [file('a.ts', [hunk(20, 2, undefined)])];
+    // range overlaps, so it resolves via the range rung, not the hash rung.
+    expect(resolveAnchor(files, anchor)?.hunkIndex).toBe(0);
+  });
+
+  it('normalizes path prefixes', () => {
+    const files = [file('a.ts', [hunk(20, 2, 'abc123')])];
+    expect(resolveAnchor(files, { ...anchor, file: 'b/a.ts' })?.hunkIndex).toBe(0);
   });
 });

--- a/packages/web/src/lib/anchor.ts
+++ b/packages/web/src/lib/anchor.ts
@@ -1,4 +1,5 @@
-import type { DiffLine } from '../state/types';
+import type { DiffFile, DiffLine, HunkAnchor } from '../state/types';
+import { normalizePath } from './paths';
 
 /**
  * Anchors line-scoped annotations (resolve items, callouts) to the diff row they
@@ -37,4 +38,36 @@ export function anchorByNewLine(
   });
 
   return { byLine, trailing };
+}
+
+/**
+ * Wire-side mirror of the server's `resolveAnchor`. Re-resolves a diff section's content anchor when
+ * its `hunkIndex` no longer lands on the right hunk (diff re-fetch, truncation, off-by-one). The
+ * browser never hashes: it compares the `contentHash` the server stamped onto each wire hunk. Ladder,
+ * scoped to the named file:
+ *   1. exact  — same contentHash at the same new-side start
+ *   2. moved  — same contentHash anywhere in that file
+ *   3. range  — overlapping new-side line range in that file
+ *   4. null   — nothing plausible
+ */
+export function resolveAnchor(files: DiffFile[], anchor: HunkAnchor): { file: DiffFile; hunkIndex: number } | null {
+  const norm = normalizePath(anchor.file);
+  const named = files.find((f) => normalizePath(f.file) === norm);
+  if (!named) return null;
+
+  let idx = named.hunks.findIndex((h) => h.contentHash === anchor.contentHash && h.newStart === anchor.newStart);
+  if (idx !== -1) return { file: named, hunkIndex: idx };
+
+  idx = named.hunks.findIndex((h) => h.contentHash != null && h.contentHash === anchor.contentHash);
+  if (idx !== -1) return { file: named, hunkIndex: idx };
+
+  const aStart = anchor.newStart;
+  const aEnd = anchor.newStart + Math.max(anchor.newLines - 1, 0);
+  idx = named.hunks.findIndex((h) => {
+    const hEnd = h.newStart + Math.max(h.newCount - 1, 0);
+    return h.newStart <= aEnd && aStart <= hEnd;
+  });
+  if (idx !== -1) return { file: named, hunkIndex: idx };
+
+  return null;
 }

--- a/packages/web/src/state/types.ts
+++ b/packages/web/src/state/types.ts
@@ -21,6 +21,7 @@ export type {
   DiffFile,
   DiffHunk,
   DiffLine,
+  HunkAnchor,
   HunkRef,
   Lane,
   NarrativeChapter as Chapter,


### PR DESCRIPTION
Every narrative diff section keys on { file, hunkIndex } — an index
into the parsed diff that silently mis-anchors when the diff is
re-fetched, truncated, or the model is off by one. Sections now carry
a deterministic anchor computed server-side (no LLM contract change):

- each parsed hunk gets a contentHash (sha256 over op+content lines)
- after repair, every diff section is enriched with
  { file, newStart, newLines, contentHash }
- repair re-resolves broken refs through a ladder — exact hash at same
  index, hash moved elsewhere in the file, overlapping line range —
  and only drops as a last resort
- cache-hit paths re-anchor cached narratives against freshly fetched
  diffs (the exact scenario where indices shift)
- web findHunk verifies contentHash and falls back through the same
  ladder via lib/anchor.ts

hunkIndex stays the internal join key; anchors make it self-healing.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>