### PR TITLE
feat(server): derive review-round status from GitHub state

### DIFF
--- a/packages/cli/src/__tests__/review-round.test.ts
+++ b/packages/cli/src/__tests__/review-round.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, test } from 'bun:test';
+import type { PRComment, PRReview } from '../github/types';
+import { deriveReviewRound } from '../review-round';
+
+const AUTHOR = 'prauthor';
+const REVIEWER = 'reviewer';
+
+function comment(over: Partial<PRComment> & Pick<PRComment, 'id' | 'author' | 'createdAt'>): PRComment {
+  return {
+    body: 'x',
+    updatedAt: over.createdAt,
+    path: 'src/a.ts',
+    line: 10,
+    ...over,
+  };
+}
+
+function review(over: Partial<PRReview> & Pick<PRReview, 'id' | 'state' | 'submittedAt'>): PRReview {
+  return {
+    user: REVIEWER,
+    avatarUrl: '',
+    ...over,
+  };
+}
+
+describe('deriveReviewRound state', () => {
+  test('awaiting-review when there are no reviews', () => {
+    const round = deriveReviewRound({
+      headSha: 'a',
+      lastNarratedSha: 'a',
+      comments: [],
+      reviews: [],
+      prAuthor: AUTHOR,
+    });
+    expect(round.state).toBe('awaiting-review');
+    expect(round.lastReviewSubmittedAt).toBeUndefined();
+  });
+
+  test('changes-requested when latest CHANGES_REQUESTED is newer than any APPROVED', () => {
+    const round = deriveReviewRound({
+      headSha: 'a',
+      lastNarratedSha: 'a',
+      comments: [],
+      reviews: [
+        review({ id: 1, state: 'APPROVED', submittedAt: '2024-01-01T00:00:00Z' }),
+        review({ id: 2, state: 'CHANGES_REQUESTED', submittedAt: '2024-01-02T00:00:00Z' }),
+      ],
+      prAuthor: AUTHOR,
+    });
+    expect(round.state).toBe('changes-requested');
+    expect(round.lastReviewSubmittedAt).toBe('2024-01-02T00:00:00Z');
+  });
+
+  test('an APPROVED newer than CHANGES_REQUESTED is not changes-requested', () => {
+    const round = deriveReviewRound({
+      headSha: 'a',
+      lastNarratedSha: 'a',
+      comments: [],
+      reviews: [
+        review({ id: 1, state: 'CHANGES_REQUESTED', submittedAt: '2024-01-01T00:00:00Z' }),
+        review({ id: 2, state: 'APPROVED', submittedAt: '2024-01-02T00:00:00Z' }),
+      ],
+      prAuthor: AUTHOR,
+    });
+    expect(round.state).toBe('awaiting-review');
+  });
+
+  test('DISMISSED CHANGES_REQUESTED is ignored', () => {
+    const round = deriveReviewRound({
+      headSha: 'a',
+      lastNarratedSha: 'a',
+      comments: [],
+      reviews: [review({ id: 1, state: 'DISMISSED', submittedAt: '2024-01-02T00:00:00Z' })],
+      prAuthor: AUTHOR,
+    });
+    expect(round.state).toBe('awaiting-review');
+  });
+
+  test('updated-since-review when a commit lands after the newest review', () => {
+    const round = deriveReviewRound({
+      headSha: 'b',
+      lastNarratedSha: 'a',
+      comments: [],
+      reviews: [review({ id: 1, state: 'APPROVED', submittedAt: '2024-01-01T00:00:00Z' })],
+      commits: [{ sha: 'b', committedAt: '2024-01-02T00:00:00Z' }],
+      prAuthor: AUTHOR,
+    });
+    expect(round.state).toBe('updated-since-review');
+  });
+
+  test('updated-since-review takes precedence over changes-requested (D1)', () => {
+    const round = deriveReviewRound({
+      headSha: 'b',
+      lastNarratedSha: 'a',
+      comments: [],
+      reviews: [review({ id: 1, state: 'CHANGES_REQUESTED', submittedAt: '2024-01-01T00:00:00Z' })],
+      commits: [{ sha: 'b', committedAt: '2024-01-03T00:00:00Z' }],
+      prAuthor: AUTHOR,
+    });
+    expect(round.state).toBe('updated-since-review');
+  });
+
+  test('a commit before the review does not trigger updated-since-review', () => {
+    const round = deriveReviewRound({
+      headSha: 'b',
+      lastNarratedSha: 'b',
+      comments: [],
+      reviews: [review({ id: 1, state: 'CHANGES_REQUESTED', submittedAt: '2024-01-05T00:00:00Z' })],
+      commits: [{ sha: 'b', committedAt: '2024-01-01T00:00:00Z' }],
+      prAuthor: AUTHOR,
+    });
+    expect(round.state).toBe('changes-requested');
+  });
+});
+
+describe('answered-thread heuristic', () => {
+  test('a reviewer comment with no reply is unresolved', () => {
+    const round = deriveReviewRound({
+      headSha: 'a',
+      lastNarratedSha: 'a',
+      comments: [comment({ id: 1, author: REVIEWER, createdAt: '2024-01-01T00:00:00Z' })],
+      reviews: [],
+      prAuthor: AUTHOR,
+    });
+    expect(round.unresolvedThreads).toBe(1);
+  });
+
+  test('a thread whose last reply is by the PR author is answered', () => {
+    const round = deriveReviewRound({
+      headSha: 'a',
+      lastNarratedSha: 'a',
+      comments: [
+        comment({ id: 1, author: REVIEWER, createdAt: '2024-01-01T00:00:00Z' }),
+        comment({ id: 2, author: AUTHOR, createdAt: '2024-01-02T00:00:00Z', inReplyToId: 1 }),
+      ],
+      reviews: [],
+      prAuthor: AUTHOR,
+    });
+    expect(round.unresolvedThreads).toBe(0);
+  });
+
+  test('a reviewer getting the last word keeps the thread unresolved', () => {
+    const round = deriveReviewRound({
+      headSha: 'a',
+      lastNarratedSha: 'a',
+      comments: [
+        comment({ id: 1, author: REVIEWER, createdAt: '2024-01-01T00:00:00Z' }),
+        comment({ id: 2, author: AUTHOR, createdAt: '2024-01-02T00:00:00Z', inReplyToId: 1 }),
+        comment({ id: 3, author: REVIEWER, createdAt: '2024-01-03T00:00:00Z', inReplyToId: 1 }),
+      ],
+      reviews: [],
+      prAuthor: AUTHOR,
+    });
+    expect(round.unresolvedThreads).toBe(1);
+  });
+
+  test('PR-level (non-inline) comments are not counted as threads', () => {
+    const round = deriveReviewRound({
+      headSha: 'a',
+      lastNarratedSha: 'a',
+      comments: [
+        comment({ id: 1, author: REVIEWER, createdAt: '2024-01-01T00:00:00Z', path: undefined, line: undefined }),
+      ],
+      reviews: [],
+      prAuthor: AUTHOR,
+    });
+    expect(round.unresolvedThreads).toBe(0);
+  });
+});
+
+describe('carriedOverThreads', () => {
+  test('is zero when head has not moved past the narrated SHA', () => {
+    const round = deriveReviewRound({
+      headSha: 'a',
+      lastNarratedSha: 'a',
+      comments: [comment({ id: 1, author: REVIEWER, createdAt: '2024-01-01T00:00:00Z' })],
+      reviews: [],
+      prAuthor: AUTHOR,
+    });
+    expect(round.carriedOverThreads).toBe(0);
+  });
+
+  test('counts unresolved threads predating the latest push once head advanced', () => {
+    const round = deriveReviewRound({
+      headSha: 'b',
+      lastNarratedSha: 'a',
+      comments: [
+        // Unresolved, created before the push -> carries over.
+        comment({ id: 1, author: REVIEWER, createdAt: '2024-01-01T00:00:00Z' }),
+        // Answered -> not carried over.
+        comment({ id: 2, author: REVIEWER, createdAt: '2024-01-01T00:00:00Z', path: 'src/b.ts' }),
+        comment({ id: 3, author: AUTHOR, createdAt: '2024-01-01T12:00:00Z', inReplyToId: 2 }),
+        // Unresolved, created AFTER the push -> not carried over.
+        comment({ id: 4, author: REVIEWER, createdAt: '2024-01-05T00:00:00Z', path: 'src/c.ts' }),
+      ],
+      reviews: [],
+      commits: [{ sha: 'b', committedAt: '2024-01-03T00:00:00Z' }],
+      prAuthor: AUTHOR,
+    });
+    expect(round.unresolvedThreads).toBe(2);
+    expect(round.carriedOverThreads).toBe(1);
+  });
+
+  test('without commit timestamps every unresolved thread is treated as carried over', () => {
+    const round = deriveReviewRound({
+      headSha: 'b',
+      lastNarratedSha: 'a',
+      comments: [
+        comment({ id: 1, author: REVIEWER, createdAt: '2024-01-01T00:00:00Z' }),
+        comment({ id: 2, author: REVIEWER, createdAt: '2024-01-02T00:00:00Z', path: 'src/b.ts' }),
+      ],
+      reviews: [],
+      prAuthor: AUTHOR,
+    });
+    expect(round.carriedOverThreads).toBe(2);
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -240,6 +240,8 @@ async function reviewCommand(prArg: string | undefined): Promise<number> {
     owner: parsed.owner,
     repo: parsed.repo,
     headSha: metadata.headSha,
+    // A cached narrative was generated against this head; a fresh generation sets it below once done.
+    narratedSha: cached ? metadata.headSha : null,
     recap: cachedRecap,
     recapGenerating: false,
     recapError: null,
@@ -371,6 +373,7 @@ async function reviewCommand(prArg: string | undefined): Promise<number> {
     const generated = result.narrative;
     const usedProvider = result.provider;
     ctx.narrative = generated;
+    ctx.narratedSha = metadata.headSha;
     // Absent when the planner pass came off the plan cache — the banner then says nothing rather than
     // claim a diff nobody measured was complete.
     ctx.capStats = result.capStats ?? null;

--- a/packages/cli/src/review-round.ts
+++ b/packages/cli/src/review-round.ts
@@ -1,0 +1,155 @@
+import type { ReviewRound } from '@diffdad/contracts';
+import type { PRComment, PRReview } from './github/types';
+
+export type { ReviewRound };
+
+export type DeriveReviewRoundInput = {
+  /** Current head SHA of the PR. */
+  headSha: string;
+  /**
+   * SHA the on-screen narrative was last generated against, or null if none has been narrated yet.
+   * When this differs from `headSha`, a regeneration is in flight and threads may carry over.
+   */
+  lastNarratedSha: string | null;
+  comments: PRComment[];
+  reviews: PRReview[];
+  /**
+   * Commits on the PR, newest push time used as the boundary for "updated since review" and
+   * "carried over". Optional: without it those two signals fall back conservatively (see below).
+   */
+  commits?: { sha: string; committedAt?: string }[];
+  /**
+   * Login of the PR author. Required for the answered-thread heuristic: a thread is answered when the
+   * PR author had the last word. Not part of the raw comment/review payloads, so the caller threads it
+   * through from the PR metadata.
+   */
+  prAuthor: string;
+};
+
+/**
+ * Derive where a PR sits in its current review round from GitHub data alone. Pure and side-effect free;
+ * GitHub remains the source of truth and this never blocks anything.
+ *
+ * State precedence (D1): `updated-since-review` > `changes-requested` > `awaiting-review`. New commits
+ * landing after the newest review is the most time-sensitive signal and the whole point of this feature
+ * (telling a fresh push apart from lingering threads), so it wins even when changes were requested — the
+ * requested-changes review still stands on GitHub, but the diff the reviewer saw is now stale. When no
+ * push has happened since the newest review, an unaddressed `changes-requested` is the blocker to surface.
+ * With no reviews at all, the round is `awaiting-review`.
+ */
+export function deriveReviewRound(input: DeriveReviewRoundInput): ReviewRound {
+  const { headSha, lastNarratedSha, comments, reviews, commits = [], prAuthor } = input;
+
+  const threads = groupInlineThreads(comments, prAuthor);
+  const unresolvedThreads = threads.filter((t) => t.unresolved).length;
+
+  // Only submitted reviews carry a decision; PENDING is a draft the author hasn't sent, DISMISSED is a
+  // review GitHub has retired. Both are excluded from the newest-review and changes-requested tests.
+  const submitted = reviews.filter((r) => r.state !== 'PENDING' && r.state !== 'DISMISSED' && r.submittedAt);
+  const newestReviewTime = maxTime(submitted.map((r) => r.submittedAt));
+  const lastReviewSubmittedAt = pickLatest(submitted)?.submittedAt;
+
+  const latestChangesRequested = maxTime(
+    submitted.filter((r) => r.state === 'CHANGES_REQUESTED').map((r) => r.submittedAt),
+  );
+  const latestApproved = maxTime(submitted.filter((r) => r.state === 'APPROVED').map((r) => r.submittedAt));
+  const changesRequested =
+    latestChangesRequested !== null && (latestApproved === null || latestChangesRequested > latestApproved);
+
+  const newestPush = maxTime(commits.map((c) => c.committedAt));
+  const updatedSinceReview = newestReviewTime !== null && newestPush !== null && newestPush > newestReviewTime;
+
+  const state: ReviewRound['state'] = updatedSinceReview
+    ? 'updated-since-review'
+    : changesRequested
+      ? 'changes-requested'
+      : 'awaiting-review';
+
+  // A thread carries over only once head has advanced past the narrated SHA (a regeneration). It carried
+  // over if its root predates the latest push; without commit timestamps we can't place the boundary, so
+  // every unresolved thread is treated as carried over (they all predate a push that just triggered regen).
+  let carriedOverThreads = 0;
+  if (lastNarratedSha && lastNarratedSha !== headSha) {
+    for (const t of threads) {
+      if (!t.unresolved) continue;
+      const rootTime = Date.parse(t.rootCreatedAt);
+      if (newestPush === null || (!Number.isNaN(rootTime) && rootTime < newestPush)) carriedOverThreads++;
+    }
+  }
+
+  return {
+    state,
+    unresolvedThreads,
+    carriedOverThreads,
+    ...(lastReviewSubmittedAt ? { lastReviewSubmittedAt } : {}),
+  };
+}
+
+type InlineThread = { rootId: number; rootCreatedAt: string; unresolved: boolean };
+
+/**
+ * Group inline review comments into threads: a root is an inline comment (has `path`) with no
+ * `inReplyToId`; replies chain to it via `inReplyToId`. Non-inline (PR-level) comments are ignored.
+ *
+ * ponytail: "unresolved" here is a heuristic, not GitHub's real resolution state. GitHub only exposes
+ * thread resolution through the GraphQL `reviewThreads` API (`isResolved`), which diff dad doesn't use.
+ * We approximate: a thread is answered when its LAST comment is by the PR author, otherwise unresolved.
+ * A reviewer marking a thread resolved on GitHub won't clear it here, and an author's reply that doesn't
+ * actually resolve anything will. Swap this for `reviewThreads.isResolved` when GraphQL lands.
+ */
+function groupInlineThreads(comments: PRComment[], prAuthor: string): InlineThread[] {
+  const byId = new Map<number, PRComment>(comments.map((c) => [c.id, c]));
+
+  function rootOf(c: PRComment): PRComment {
+    let cur = c;
+    const seen = new Set<number>();
+    while (cur.inReplyToId != null && byId.has(cur.inReplyToId) && !seen.has(cur.id)) {
+      seen.add(cur.id);
+      cur = byId.get(cur.inReplyToId)!;
+    }
+    return cur;
+  }
+
+  const groups = new Map<number, PRComment[]>();
+  for (const c of comments) {
+    const root = rootOf(c);
+    if (root.path == null) continue; // not an inline thread
+    const arr = groups.get(root.id) ?? [];
+    arr.push(c);
+    groups.set(root.id, arr);
+  }
+
+  const threads: InlineThread[] = [];
+  for (const [rootId, members] of groups) {
+    const sorted = [...members].sort((a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt));
+    const last = sorted[sorted.length - 1]!;
+    const root = byId.get(rootId)!;
+    threads.push({ rootId, rootCreatedAt: root.createdAt, unresolved: last.author !== prAuthor });
+  }
+  return threads;
+}
+
+function maxTime(isos: (string | undefined)[]): number | null {
+  let max: number | null = null;
+  for (const iso of isos) {
+    if (!iso) continue;
+    const t = Date.parse(iso);
+    if (Number.isNaN(t)) continue;
+    if (max === null || t > max) max = t;
+  }
+  return max;
+}
+
+function pickLatest(reviews: PRReview[]): PRReview | undefined {
+  let latest: PRReview | undefined;
+  let latestTime = -Infinity;
+  for (const r of reviews) {
+    const t = Date.parse(r.submittedAt);
+    if (Number.isNaN(t)) continue;
+    if (t >= latestTime) {
+      latestTime = t;
+      latest = r;
+    }
+  }
+  return latest;
+}

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1,4 +1,4 @@
-import { sseDataSchemaFor, type SseDataFor, type SseEventName } from '@diffdad/contracts';
+import { sseDataSchemaFor, type ReviewRound, type SseDataFor, type SseEventName } from '@diffdad/contracts';
 import type { PRComment as WirePRComment } from '@diffdad/contracts';
 import { existsSync } from 'fs';
 import { Hono } from 'hono';
@@ -17,6 +17,7 @@ import { buildChapterAiPrompt } from './narrative/chapter-ai';
 import type { PromptCapStats } from './narrative/prompt';
 import { buildReviewSummaryPrompt } from './narrative/review-summary';
 import type { NarrativeResponse } from './narrative/types';
+import { deriveReviewRound } from './review-round';
 import type { RepoContext } from './repo/snapshot';
 import { cacheRecap } from './recap/cache';
 import { generateRecap } from './recap/engine';
@@ -55,6 +56,14 @@ export type ServerContext = {
   recapGenerating?: boolean;
   /** Set if the last recap generation attempt failed; cleared on retry. */
   recapError?: string | null;
+  /**
+   * The SHA the on-screen narrative was last generated against. Feeds `deriveReviewRound`'s carry-over
+   * count: when `headSha` advances past this, unresolved threads that predate the push carry over. Null
+   * until the first narrative is narrated.
+   */
+  narratedSha?: string | null;
+  /** Last derived review-round status, cached so the poll only broadcasts `review-round` when it changes. */
+  reviewRound?: ReviewRound | null;
 };
 
 type PostCommentBody = {
@@ -94,6 +103,29 @@ export function createServer(ctx: ServerContext) {
   let exitTimer: ReturnType<typeof setTimeout> | null = null;
 
   let narrativeProgressChars = 0;
+
+  /**
+   * Derive the review round from the data currently in `ctx` (plus freshly polled `commits`) and
+   * broadcast `review-round` only when it changes (JSON compare). Purely additive — never blocks.
+   */
+  function recomputeReviewRound(commits?: { sha: string; committedAt?: string }[]): ReviewRound {
+    const round = deriveReviewRound({
+      headSha: ctx.headSha,
+      lastNarratedSha: ctx.narratedSha ?? null,
+      comments: ctx.comments,
+      reviews: ctx.reviews,
+      commits,
+      prAuthor: ctx.pr.author.login,
+    });
+    const changed = JSON.stringify(round) !== JSON.stringify(ctx.reviewRound ?? null);
+    ctx.reviewRound = round;
+    if (changed) broadcast('review-round', { round });
+    return round;
+  }
+
+  // Seed the round from the data already in `ctx` so the bootstrap `GET /api/narrative` can carry it.
+  // No commits yet (the poll fetches those); this establishes review/thread state at once.
+  recomputeReviewRound();
 
   function broadcast<E extends SseEventName>(event: E, data: SseDataFor<E>) {
     if (event === 'narrative-progress') {
@@ -167,6 +199,7 @@ export function createServer(ctx: ServerContext) {
         repoUrl: `https://github.com/${ctx.owner}/${ctx.repo}`,
         mode: 'pr',
         aiPath,
+        round: ctx.reviewRound ?? undefined,
       });
     }
     const commentPaths = [...new Set(ctx.comments.map((cm) => cm.path).filter((p): p is string => Boolean(p)))];
@@ -197,6 +230,7 @@ export function createServer(ctx: ServerContext) {
       repoUrl: `https://github.com/${ctx.owner}/${ctx.repo}`,
       mode: 'pr',
       aiPath,
+      round: ctx.reviewRound ?? undefined,
       _debug: {
         totalComments: ctx.comments.length,
         commentPaths,
@@ -402,6 +436,19 @@ export function createServer(ctx: ServerContext) {
             ctx.reviews = freshReviews;
             send('reviews', freshReviews);
 
+            // Commit timestamps place the "latest push" boundary that `updated-since-review` and the
+            // carry-over count depend on. Mapped from author date (the only date `getPRCommits` returns).
+            // Isolated so a commits fetch failure degrades the round (no push boundary) rather than
+            // aborting the whole poll and its regeneration.
+            let freshCommits: { sha: string; committedAt?: string }[] = [];
+            try {
+              const cs = await gh.getPRCommits(ctx.owner, ctx.repo, ctx.pr.number);
+              freshCommits = cs.map((cm) => ({ sha: cm.sha, committedAt: cm.authoredAt }));
+            } catch {
+              // degrade the round (no push boundary) rather than aborting the poll
+            }
+            const round = recomputeReviewRound(freshCommits);
+
             if ((shaChanged || promptMetaChanged) && !regenerating) {
               regenerating = true;
               const prevSha = ctx.headSha.slice(0, 7);
@@ -412,7 +459,13 @@ export function createServer(ctx: ServerContext) {
                 console.log(`\n  \x1b[38;5;221m↻\x1b[0m PR title/description/labels changed`);
               }
               console.log(`  \x1b[2mRegenerating narrative...\x1b[0m`);
-              broadcast('regenerating', { previousSha: prevSha, newSha });
+              // Carry the surviving unresolved-thread count so the UI can say "regenerating — N threads
+              // carry over" instead of blurring a force-push into the reviewer's open threads.
+              broadcast('regenerating', {
+                previousSha: prevSha,
+                newSha,
+                ...(round.carriedOverThreads > 0 ? { carriedOverThreads: round.carriedOverThreads } : {}),
+              });
 
               try {
                 const prevTldr = ctx.narrative?.tldr;
@@ -538,11 +591,18 @@ export function createServer(ctx: ServerContext) {
                   );
                 }
 
+                // The narrative now describes the new head, so that head is the narrated SHA. Recompute
+                // the round against it (carry-over collapses to 0 once head == narrated) and ship it with
+                // the narrative payload.
+                ctx.narratedSha = ctx.headSha;
+                const postRegenRound = recomputeReviewRound(freshCommits);
+
                 broadcast('narrative', {
                   narrative: ctx.narrative,
                   pr: ctx.pr,
                   files: ctx.files,
                   comments: mapCommentsToChapters(ctx.comments, ctx.narrative),
+                  round: postRegenRound,
                   // Recomputed for the new chapter array: `CollapseDecision.chapterIndex` indexes the
                   // chapters it was computed against, so shipping the narrative without it would leave
                   // the browser holding a boundary that describes the previous plan.

--- a/packages/contracts/src/github.ts
+++ b/packages/contracts/src/github.ts
@@ -91,6 +91,19 @@ export const prReviewSchema = z.object({
 });
 export type PRReview = z.infer<typeof prReviewSchema>;
 
+/**
+ * A derived view of where a PR sits in its current review round. GitHub stays the source of truth; this
+ * is computed from comments/reviews/commits and never blocks anything. See `deriveReviewRound` in the
+ * CLI for the semantics of each state and the answered-thread heuristic.
+ */
+export const reviewRoundSchema = z.object({
+  state: z.enum(['awaiting-review', 'changes-requested', 'updated-since-review']),
+  unresolvedThreads: z.number(),
+  carriedOverThreads: z.number(),
+  lastReviewSubmittedAt: z.string().optional(),
+});
+export type ReviewRound = z.infer<typeof reviewRoundSchema>;
+
 export const checkRunSchema = z.object({
   id: z.number(),
   name: z.string(),

--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -196,10 +196,22 @@ const sseCases: { event: string; data: unknown }[] = [
   { event: 'comments', data: [comment] },
   { event: 'checks', data: [checkRun] },
   { event: 'reviews', data: [review] },
+  {
+    event: 'review-round',
+    data: {
+      round: {
+        state: 'changes-requested',
+        unresolvedThreads: 2,
+        carriedOverThreads: 1,
+        lastReviewSubmittedAt: '2024-01-02T00:00:00Z',
+      },
+    },
+  },
   { event: 'config', data: configResponse },
   { event: 'pr', data: prMetadata },
   { event: 'units', data: { units: [wireUnit], dismissed: [], polledAt: 1 } },
   { event: 'regenerating', data: { previousSha: 'aaa', newSha: 'bbb' } },
+  { event: 'regenerating', data: { previousSha: 'aaa', newSha: 'bbb', carriedOverThreads: 3 } },
   { event: 'narrative-progress', data: { chars: 100 } },
   { event: 'narrative-error', data: { message: 'boom' } },
   { event: 'narrative.partial', data: { narrative, pr: prMetadata, files: [diffFile], comments: [comment] } },

--- a/packages/contracts/src/sse.ts
+++ b/packages/contracts/src/sse.ts
@@ -1,7 +1,14 @@
 import { z } from 'zod';
 import { chapterCallersSchema, capStatsSchema, collapseResultSchema } from './collapse';
 import { configResponseSchema } from './config';
-import { checkRunSchema, diffFileSchema, prCommentSchema, prMetadataSchema, prReviewSchema } from './github';
+import {
+  checkRunSchema,
+  diffFileSchema,
+  prCommentSchema,
+  prMetadataSchema,
+  prReviewSchema,
+  reviewRoundSchema,
+} from './github';
 import { narrativeChapterSchema, narrativeResponseSchema } from './narrative';
 import { planSchema } from './plan';
 import { recapResponseSchema } from './recap';
@@ -20,6 +27,8 @@ const narrativePayloadSchema = z.object({
   comments: z.array(prCommentSchema),
   ...blastRadiusShape,
   capStats: capStatsSchema.optional(),
+  /** Derived review-round status for the PR, when the server has computed one. */
+  round: reviewRoundSchema.optional(),
 });
 
 export const sseEventSchema = z.discriminatedUnion('event', [
@@ -32,6 +41,7 @@ export const sseEventSchema = z.discriminatedUnion('event', [
   z.object({ event: z.literal('comments'), data: z.array(prCommentSchema) }),
   z.object({ event: z.literal('checks'), data: z.array(checkRunSchema) }),
   z.object({ event: z.literal('reviews'), data: z.array(prReviewSchema) }),
+  z.object({ event: z.literal('review-round'), data: z.object({ round: reviewRoundSchema }) }),
   z.object({
     event: z.literal('review'),
     data: z.object({ event: z.enum(['COMMENT', 'APPROVE', 'REQUEST_CHANGES']), body: z.string().optional() }),
@@ -41,7 +51,12 @@ export const sseEventSchema = z.discriminatedUnion('event', [
   z.object({ event: z.literal('units'), data: unitsPayloadSchema }),
   z.object({
     event: z.literal('regenerating'),
-    data: z.object({ previousSha: z.string(), newSha: z.string() }),
+    data: z.object({
+      previousSha: z.string(),
+      newSha: z.string(),
+      /** Unresolved threads carried across the regeneration, so the UI can say "N threads carry over". */
+      carriedOverThreads: z.number().optional(),
+    }),
   }),
   z.object({ event: z.literal('narrative-progress'), data: z.object({ chars: z.number() }) }),
   z.object({ event: z.literal('narrative-error'), data: z.object({ message: z.string() }) }),

--- a/packages/web/src/components/PRHeader.tsx
+++ b/packages/web/src/components/PRHeader.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { copy } from '../lib/microcopy';
 import { pendingReviewComments, useReviewStore } from '../state/review-store';
-import type { CheckRun } from '../state/types';
+import type { CheckRun, ReviewRound } from '../state/types';
 import { IconCheck } from './Icons';
 import { ReviewViewTabs } from './ReviewViewTabs';
 import { SubmitDialog } from './SubmitDialog';
@@ -105,11 +105,55 @@ function timeAgo(iso: string | undefined | null): string {
   return `${yr}y ago`;
 }
 
+/**
+ * Compact, derived review-round status. Colors ride CSS custom properties (Radix scales), so both
+ * themes stay legible. Purely informational — mirrors GitHub, never blocks.
+ */
+function ReviewRoundChip({ round }: { round: ReviewRound }) {
+  const config =
+    round.state === 'changes-requested'
+      ? {
+          label:
+            round.unresolvedThreads > 0
+              ? `Changes requested · ${round.unresolvedThreads} unresolved`
+              : 'Changes requested',
+          bg: 'var(--red-3)',
+          fg: 'var(--red-11)',
+          title:
+            round.unresolvedThreads > 0
+              ? `A reviewer requested changes. ${round.unresolvedThreads} comment thread${round.unresolvedThreads === 1 ? '' : 's'} still awaiting an author reply.`
+              : 'A reviewer requested changes.',
+        }
+      : round.state === 'updated-since-review'
+        ? {
+            label: 'Updated since review',
+            bg: 'var(--blue-3)',
+            fg: 'var(--blue-11)',
+            title: 'New commits landed since the last review — the diff a reviewer saw may be stale.',
+          }
+        : {
+            label: 'Awaiting review',
+            bg: 'var(--gray-3)',
+            fg: 'var(--fg-2)',
+            title: 'No review has been submitted yet.',
+          };
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full px-2 py-[2px] text-[11.5px] font-bold uppercase tracking-[0.04em]"
+      style={{ background: config.bg, color: config.fg }}
+      title={config.title}
+    >
+      {config.label}
+    </span>
+  );
+}
+
 export function PRHeader() {
   const pr = useReviewStore((s) => s.pr);
   const repoUrl = useReviewStore((s) => s.repoUrl);
   const checkRuns = useReviewStore((s) => s.checkRuns);
   const reviews = useReviewStore((s) => s.reviews);
+  const reviewRound = useReviewStore((s) => s.reviewRound);
   const drafts = useReviewStore((s) => s.drafts);
   const clearDrafts = useReviewStore((s) => s.clearDrafts);
   const [open, setOpen] = useState(false);
@@ -224,6 +268,7 @@ export function PRHeader() {
         >
           {pr.state === 'merged' ? 'Merged' : pr.state === 'closed' ? 'Closed' : pr.draft ? 'Draft' : 'Open'}
         </span>
+        {reviewRound ? <ReviewRoundChip round={reviewRound} /> : null}
         <span className="rounded-[4px] bg-[var(--gray-3)] px-[7px] py-[2px] font-mono text-[12.5px] text-[var(--fg-2)]">
           <b className="font-medium text-[var(--fg-1)]">{pr.branch}</b> <span className="text-[var(--fg-3)]">→</span>{' '}
           <b className="font-medium text-[var(--fg-1)]">{pr.base}</b>

--- a/packages/web/src/hooks/useLiveStream.ts
+++ b/packages/web/src/hooks/useLiveStream.ts
@@ -159,6 +159,16 @@ export function useLiveStream() {
       }
     };
 
+    const onReviewRound = (e: MessageEvent) => {
+      try {
+        const data = parseSse('review-round', e);
+        useReviewStore.getState().setReviewRound(data.round);
+        setLastEventAt(Date.now());
+      } catch {
+        // ignore
+      }
+    };
+
     // A config PUT (from another tab, or the same-server saving tab) broadcasts the fresh
     // ConfigResponse. Funnel it through `applyConfigResponse` so open settings tabs and the header
     // theme/accent controls converge — this is also what brings a token-less daemon's UI alive when a
@@ -253,6 +263,7 @@ export function useLiveStream() {
           state.reviews,
           { collapse: data.collapse ?? null, callers: data.callers ?? [], capStats: data.capStats ?? null },
         );
+        if (data.round) useReviewStore.getState().setReviewRound(data.round);
         useReviewStore.getState().setRegenerating(false);
         useReviewStore.getState().setNarrativeProgressChars(0);
         setLastEventAt(Date.now());
@@ -314,6 +325,7 @@ export function useLiveStream() {
     es.addEventListener('comments', onComments as EventListener);
     es.addEventListener('checks', onChecks as EventListener);
     es.addEventListener('reviews', onReviews as EventListener);
+    es.addEventListener('review-round', onReviewRound as EventListener);
     es.addEventListener('config', onConfig as EventListener);
     es.addEventListener('pr', onPr as EventListener);
     es.addEventListener('units', onUnits as EventListener);
@@ -344,6 +356,7 @@ export function useLiveStream() {
       es.removeEventListener('comments', onComments as EventListener);
       es.removeEventListener('checks', onChecks as EventListener);
       es.removeEventListener('reviews', onReviews as EventListener);
+      es.removeEventListener('review-round', onReviewRound as EventListener);
       es.removeEventListener('config', onConfig as EventListener);
       es.removeEventListener('pr', onPr as EventListener);
       es.removeEventListener('units', onUnits as EventListener);

--- a/packages/web/src/hooks/useNarrative.ts
+++ b/packages/web/src/hooks/useNarrative.ts
@@ -10,6 +10,7 @@ import type {
   PRComment,
   PRData,
   PRReview,
+  ReviewRound,
   Unit,
 } from '../state/types';
 
@@ -33,6 +34,8 @@ type NarrativeApiResponse = {
   collapse?: CollapseResult;
   callers?: ChapterCallers[];
   capStats?: CapStats;
+  /** Derived review-round status, when the server has computed one. Purely additive; never blocks. */
+  round?: ReviewRound;
   /** Command-center bootstrap: the daemon seeds the initial queue so the dashboard paints at once. */
   units?: Unit[];
   /** Command-center bootstrap: rows ✕ has hidden until their author pushes. Counted, never rendered inline. */
@@ -113,6 +116,7 @@ export function useNarrative() {
             { collapse: data.collapse ?? null, callers: data.callers ?? [], capStats: data.capStats ?? null },
           );
           useReviewStore.getState().setAiPath(data.aiPath ?? null);
+          if (data.round) useReviewStore.getState().setReviewRound(data.round);
         }
 
         useReviewStore.getState().setMode(data.mode ?? 'pr');

--- a/packages/web/src/state/review-store.ts
+++ b/packages/web/src/state/review-store.ts
@@ -15,6 +15,7 @@ import type {
   PRComment,
   PRData,
   PRReview,
+  ReviewRound,
   Unit,
 } from './types';
 import type { RecapResponse } from './recap-types';
@@ -73,6 +74,8 @@ type ReviewState = {
   route: Route;
   checkRuns: CheckRun[];
   reviews: PRReview[];
+  /** Derived review-round status (server-computed), or null before the first has landed. Never blocks. */
+  reviewRound: ReviewRound | null;
   repoUrl: string | null;
   chapterStates: Record<string, ChapterState>;
   activeChapterId: string | null;
@@ -213,6 +216,7 @@ type ReviewState = {
   setLastEventAt: (ts: number) => void;
   setCheckRuns: (checkRuns: CheckRun[]) => void;
   setReviews: (reviews: PRReview[]) => void;
+  setReviewRound: (round: ReviewRound | null) => void;
   setShortcutsHelpOpen: (open: boolean) => void;
   setSubmitOpen: (open: boolean) => void;
   setSettingsOpen: (open: boolean) => void;
@@ -476,6 +480,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   route: typeof window !== 'undefined' ? parseRoute(window.location.pathname) : { name: 'center' },
   checkRuns: [],
   reviews: [],
+  reviewRound: null,
   repoUrl: null,
   chapterStates: {},
   activeChapterId: null,
@@ -726,6 +731,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
 
   setCheckRuns: (checkRuns) => set({ checkRuns }),
   setReviews: (reviews) => set({ reviews }),
+  setReviewRound: (reviewRound) => set({ reviewRound }),
 
   setShortcutsHelpOpen: (shortcutsHelpOpen) => set({ shortcutsHelpOpen }),
   setSubmitOpen: (submitOpen) => set({ submitOpen }),

--- a/packages/web/src/state/types.ts
+++ b/packages/web/src/state/types.ts
@@ -33,6 +33,7 @@ export type {
   PRMetadata as PRData,
   PRReview,
   ReadingPlanStep,
+  ReviewRound,
   TriagedFile,
   TriageKind,
   TriageSummary,


### PR DESCRIPTION
Narratives regenerate freely on SHA change with no notion of a review
round — unresolved reviewer threads and a fresh force-push blur
together. The server now derives a ReviewRound from data it already
fetches (GitHub stays the source of truth; nothing blocks):

- states: updated-since-review > changes-requested > awaiting-review
- unresolved threads approximated by 'PR author had the last word'
  (real resolution needs the GraphQL reviewThreads API — noted inline)
- carriedOverThreads counts unresolved threads surviving a push, and
  rides the regenerating SSE payload so the UI can say what carried
- new review-round SSE event + round on the narrative payload
- PRHeader renders a status chip (CSS-var colors, dark-mode safe)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>