### PR TITLE
feat(recap): surface the prompts that drove an agent-authored PR

### DIFF
--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -23,6 +23,8 @@ import { cacheRecap } from './recap/cache';
 import { generateRecap } from './recap/engine';
 import { gatherRecapSources } from './recap/sources';
 import type { RecapResponse } from './recap/types';
+import { findMatchingSessions } from './trace/local-sessions';
+import type { TraceSessionSummary } from '@diffdad/contracts';
 import { describeRepoContext, resolveRepoContext } from './repo/snapshot';
 
 export type ServerContext = {
@@ -64,6 +66,11 @@ export type ServerContext = {
   narratedSha?: string | null;
   /** Last derived review-round status, cached so the poll only broadcasts `review-round` when it changes. */
   reviewRound?: ReviewRound | null;
+  /**
+   * Local authoring-session intent, mined once per server process from ~/.claude/projects. `undefined`
+   * means not looked yet; an empty array means looked and found nothing (feature stays invisible).
+   */
+  traceIntent?: TraceSessionSummary[];
 };
 
 type PostCommentBody = {
@@ -298,6 +305,24 @@ export function createServer(ctx: ServerContext) {
     }
     if (ctx.recap) return c.json({ status: 'ready', recap: ctx.recap });
     return c.json({ status: 'generating' });
+  });
+
+  // Local-only, read-only intent from the coding session that authored this branch. Filesystem work,
+  // no LLM, no upload: prompts live only in this response. Cached in-memory per server process.
+  app.get('/api/trace/intent', async (c) => {
+    if (ctx.traceIntent === undefined) {
+      try {
+        ctx.traceIntent = await findMatchingSessions({
+          repoDirHints: [ctx.repo],
+          branch: ctx.pr.branch,
+          changedFiles: ctx.files.map((f) => f.file),
+          since: ctx.pr.createdAt ? new Date(ctx.pr.createdAt) : undefined,
+        });
+      } catch {
+        ctx.traceIntent = []; // best-effort: any failure means the feature stays invisible
+      }
+    }
+    return c.json({ sessions: ctx.traceIntent });
   });
 
   app.post('/api/ai', async (c) => {

--- a/packages/cli/src/trace/__tests__/local-sessions.test.ts
+++ b/packages/cli/src/trace/__tests__/local-sessions.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { findMatchingSessions } from '../local-sessions';
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'diffdad-trace-'));
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+type Line = Record<string, unknown>;
+
+async function writeSession(dir: string, name: string, lines: Line[]): Promise<void> {
+  const projectDir = join(root, dir);
+  await mkdir(projectDir, { recursive: true });
+  await writeFile(join(projectDir, name), lines.map((l) => JSON.stringify(l)).join('\n'), 'utf-8');
+}
+
+function userLine(over: Partial<Line> & { content: unknown }): Line {
+  return {
+    type: 'user',
+    sessionId: 'sess',
+    cwd: '/work/repo',
+    timestamp: '2026-01-01T00:00:00.000Z',
+    gitBranch: 'main',
+    message: { role: 'user', content: over.content },
+    ...over,
+  };
+}
+
+function toolLine(filePath: string): Line {
+  return {
+    type: 'assistant',
+    message: { role: 'assistant', content: [{ type: 'tool_use', name: 'Edit', input: { file_path: filePath } }] },
+  };
+}
+
+describe('findMatchingSessions', () => {
+  it('returns [] when the log root is missing', async () => {
+    const out = await findMatchingSessions({
+      repoDirHints: ['repo'],
+      changedFiles: [],
+      logRoot: join(root, 'does-not-exist'),
+    });
+    expect(out).toEqual([]);
+  });
+
+  it('ranks a branch match above a cwd-only match', async () => {
+    await writeSession('branch-proj', 'a.jsonl', [
+      { ...userLine({ content: 'branch session' }), sessionId: 'branch', cwd: '/x/other', gitBranch: 'feature/x' },
+    ]);
+    await writeSession('cwd-proj', 'b.jsonl', [
+      { ...userLine({ content: 'cwd session' }), sessionId: 'cwd', cwd: '/x/repo', gitBranch: 'unrelated' },
+    ]);
+
+    const out = await findMatchingSessions({
+      repoDirHints: ['repo'],
+      branch: 'feature/x',
+      changedFiles: [],
+      logRoot: root,
+    });
+
+    expect(out.map((s) => s.sessionId)).toEqual(['branch', 'cwd']);
+    expect(out[0]!.score).toBeGreaterThan(out[1]!.score);
+  });
+
+  it('scores a session that touches >=2 changed files via tool events', async () => {
+    await writeSession('files-proj', 'c.jsonl', [
+      { ...userLine({ content: 'file session' }), sessionId: 'files', cwd: '/x/other', gitBranch: 'nope' },
+      toolLine('src/api.ts'),
+      toolLine('src/db.ts'),
+    ]);
+    // one-file match should not score the file rung
+    await writeSession('one-file', 'd.jsonl', [
+      { ...userLine({ content: 'one' }), sessionId: 'one', cwd: '/x/other', gitBranch: 'nope' },
+      toolLine('src/api.ts'),
+    ]);
+
+    const out = await findMatchingSessions({
+      repoDirHints: ['nomatch'],
+      changedFiles: ['src/api.ts', 'src/db.ts'],
+      logRoot: root,
+    });
+
+    expect(out.map((s) => s.sessionId)).toEqual(['files']);
+  });
+
+  it('drops slash commands and enforces per-prompt and list caps', async () => {
+    const long = 'x'.repeat(3000);
+    const lines: Line[] = [userLine({ content: '/clear' }), userLine({ content: long })];
+    for (let i = 0; i < 30; i++) lines.push(userLine({ content: `prompt ${i}` }));
+    await writeSession(
+      'cap-proj',
+      'e.jsonl',
+      lines.map((l) => ({ ...l, cwd: '/x/repo' })),
+    );
+
+    const out = await findMatchingSessions({ repoDirHints: ['repo'], changedFiles: [], logRoot: root });
+
+    expect(out).toHaveLength(1);
+    const prompts = out[0]!.userPrompts;
+    expect(prompts).toHaveLength(20); // list cap
+    expect(prompts).not.toContain('/clear'); // slash command dropped
+    expect(prompts[0]!).toHaveLength(2000); // per-prompt cap
+  });
+
+  it('takes at most the top 3 scoring sessions', async () => {
+    for (let i = 0; i < 5; i++) {
+      await writeSession(`p${i}`, `f${i}.jsonl`, [
+        { ...userLine({ content: `s${i}` }), sessionId: `s${i}`, cwd: '/x/repo', gitBranch: 'nope' },
+      ]);
+    }
+    const out = await findMatchingSessions({ repoDirHints: ['repo'], changedFiles: [], logRoot: root });
+    expect(out).toHaveLength(3);
+  });
+});

--- a/packages/cli/src/trace/__tests__/normalize.test.ts
+++ b/packages/cli/src/trace/__tests__/normalize.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeSession } from '../normalize';
+
+describe('normalizeSession', () => {
+  it('extracts user, assistant, and tool events and skips malformed lines', () => {
+    const jsonl = [
+      JSON.stringify({ type: 'user', message: { role: 'user', content: 'Add rate limiting to the API' } }),
+      '{ this is not json',
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'planning' },
+            { type: 'text', text: 'On it.' },
+            { type: 'tool_use', name: 'Edit', input: { file_path: 'src/api.ts', description: 'add limiter' } },
+          ],
+        },
+      }),
+      '',
+    ].join('\n');
+
+    const events = normalizeSession(jsonl);
+    expect(events).toEqual([
+      { kind: 'user', text: 'Add rate limiting to the API' },
+      { kind: 'assistant', markdown: 'On it.' },
+      { kind: 'tool', tool: 'Edit', title: 'add limiter', filePath: 'src/api.ts' },
+    ]);
+  });
+
+  it('reads text parts from array user content and drops tool_result noise', () => {
+    const jsonl = [
+      JSON.stringify({
+        type: 'user',
+        message: { role: 'user', content: [{ type: 'text', text: 'Fix the failing test' }] },
+      }),
+      JSON.stringify({
+        type: 'user',
+        message: { role: 'user', content: [{ type: 'tool_result', content: 'ok', tool_use_id: 'x' }] },
+      }),
+    ].join('\n');
+
+    const events = normalizeSession(jsonl);
+    expect(events).toEqual([{ kind: 'user', text: 'Fix the failing test' }]);
+  });
+
+  it('returns [] for empty input', () => {
+    expect(normalizeSession('')).toEqual([]);
+  });
+});

--- a/packages/cli/src/trace/local-sessions.ts
+++ b/packages/cli/src/trace/local-sessions.ts
@@ -1,0 +1,169 @@
+import { readdir, readFile } from 'fs/promises';
+import { homedir } from 'os';
+import { basename, join } from 'path';
+import type { TraceSessionSummary } from '@diffdad/contracts';
+import { normalizeSession } from './normalize';
+
+export type FindMatchingSessionsOptions = {
+  /** Repo-name hints; a session whose cwd basename matches one scores the cwd rung. */
+  repoDirHints: string[];
+  /** PR head branch. A session whose gitBranch equals it scores the top rung. */
+  branch?: string;
+  /** Diff file paths. A session touching >=2 of them via tool events scores the file rung. */
+  changedFiles: string[];
+  /** Start of the PR commit window; sessions active at/after it score the recency rung. */
+  since?: Date;
+  /** Defaults to ~/.claude/projects. Injectable for tests. */
+  logRoot?: string;
+};
+
+const MAX_PROMPT_CHARS = 2000;
+const MAX_PROMPTS = 20;
+const TOP_N = 3;
+
+// Scoring ladder weights, highest signal first.
+const SCORE_BRANCH = 4;
+const SCORE_CWD = 2;
+const SCORE_FILES = 2;
+const SCORE_RECENCY = 1;
+
+type SessionMeta = {
+  sessionId: string;
+  startedAt: string;
+  endedAt: string;
+  branch?: string;
+  cwd?: string;
+};
+
+function parseMeta(jsonlText: string): SessionMeta {
+  let sessionId = '';
+  let branch: string | undefined;
+  let cwd: string | undefined;
+  let minTs = Infinity;
+  let maxTs = -Infinity;
+  for (const line of jsonlText.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let entry: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (!parsed || typeof parsed !== 'object') continue;
+      entry = parsed as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    if (!sessionId && typeof entry.sessionId === 'string') sessionId = entry.sessionId;
+    if (!branch && typeof entry.gitBranch === 'string' && entry.gitBranch.length > 0) branch = entry.gitBranch;
+    if (!cwd && typeof entry.cwd === 'string' && entry.cwd.length > 0) cwd = entry.cwd;
+    if (typeof entry.timestamp === 'string') {
+      const t = Date.parse(entry.timestamp);
+      if (Number.isFinite(t)) {
+        if (t < minTs) minTs = t;
+        if (t > maxTs) maxTs = t;
+      }
+    }
+  }
+  const startedAt = Number.isFinite(minTs) ? new Date(minTs).toISOString() : '';
+  const endedAt = Number.isFinite(maxTs) ? new Date(maxTs).toISOString() : '';
+  return { sessionId, startedAt, endedAt, branch, cwd };
+}
+
+function isNoise(text: string): boolean {
+  if (text.startsWith('/')) return true; // slash command
+  if (/^<(command-|local-command-)/.test(text)) return true; // slash-command scaffolding
+  if (text.includes('<tool_use_error>')) return true;
+  return false;
+}
+
+function extractPrompts(jsonlText: string): string[] {
+  const out: string[] = [];
+  for (const ev of normalizeSession(jsonlText)) {
+    if (ev.kind !== 'user') continue;
+    const text = ev.text.trim();
+    if (!text || isNoise(text)) continue;
+    out.push(text.length > MAX_PROMPT_CHARS ? text.slice(0, MAX_PROMPT_CHARS) : text);
+    if (out.length >= MAX_PROMPTS) break;
+  }
+  return out;
+}
+
+/** Count distinct changed files a session touched via tool events (basename or path-suffix match). */
+function countFileMatches(jsonlText: string, changedFiles: string[]): number {
+  const toolPaths = new Set<string>();
+  for (const ev of normalizeSession(jsonlText)) {
+    if (ev.kind === 'tool' && ev.filePath) toolPaths.add(ev.filePath);
+  }
+  if (toolPaths.size === 0) return 0;
+  const toolBases = new Set([...toolPaths].map((p) => basename(p)));
+  let matched = 0;
+  for (const changed of changedFiles) {
+    const base = basename(changed);
+    const hit = toolBases.has(base) || [...toolPaths].some((p) => p.endsWith(changed) || changed.endsWith(p));
+    if (hit) matched++;
+  }
+  return matched;
+}
+
+async function listJsonlFiles(logRoot: string): Promise<string[]> {
+  let rootEntries;
+  try {
+    rootEntries = await readdir(logRoot, { withFileTypes: true });
+  } catch {
+    return []; // missing root => no feature
+  }
+  const files: string[] = [];
+  for (const entry of rootEntries) {
+    if (entry.isDirectory()) {
+      const dir = join(logRoot, entry.name);
+      try {
+        for (const sub of await readdir(dir)) {
+          if (sub.endsWith('.jsonl')) files.push(join(dir, sub));
+        }
+      } catch {
+        // unreadable project dir: skip
+      }
+    } else if (entry.name.endsWith('.jsonl')) {
+      files.push(join(logRoot, entry.name));
+    }
+  }
+  return files;
+}
+
+export async function findMatchingSessions(opts: FindMatchingSessionsOptions): Promise<TraceSessionSummary[]> {
+  const logRoot = opts.logRoot ?? join(homedir(), '.claude', 'projects');
+  const hints = opts.repoDirHints.map((h) => h.toLowerCase()).filter((h) => h.length > 0);
+  const files = await listJsonlFiles(logRoot);
+
+  const candidates: TraceSessionSummary[] = [];
+  for (const file of files) {
+    let text: string;
+    try {
+      text = await readFile(file, 'utf-8');
+    } catch {
+      continue;
+    }
+    const meta = parseMeta(text);
+
+    let score = 0;
+    if (opts.branch && meta.branch && meta.branch === opts.branch) score += SCORE_BRANCH;
+    if (meta.cwd && hints.includes(basename(meta.cwd).toLowerCase())) score += SCORE_CWD;
+    if (countFileMatches(text, opts.changedFiles) >= 2) score += SCORE_FILES;
+    if (opts.since && meta.endedAt && Date.parse(meta.endedAt) >= opts.since.getTime()) score += SCORE_RECENCY;
+
+    if (score <= 0) continue;
+
+    candidates.push({
+      sessionId: meta.sessionId || basename(file, '.jsonl'),
+      path: file,
+      startedAt: meta.startedAt,
+      endedAt: meta.endedAt,
+      branch: meta.branch,
+      cwd: meta.cwd,
+      score,
+      userPrompts: extractPrompts(text),
+    });
+  }
+
+  candidates.sort((a, b) => b.score - a.score || b.endedAt.localeCompare(a.endedAt));
+  return candidates.slice(0, TOP_N);
+}

--- a/packages/cli/src/trace/normalize.ts
+++ b/packages/cli/src/trace/normalize.ts
@@ -1,0 +1,93 @@
+/**
+ * Minimal normalization of Claude Code JSONL session logs into the few event kinds the intent UI and
+ * the matching ladder need. Strictly read-only and defensive: unparseable lines are skipped and every
+ * field is treated as possibly absent, because the log format drifts across Claude Code versions.
+ */
+
+export type TraceEvent =
+  | { kind: 'user'; text: string }
+  | { kind: 'assistant'; markdown: string }
+  | { kind: 'tool'; tool: string; title?: string; filePath?: string };
+
+function asString(v: unknown): string {
+  return typeof v === 'string' ? v : '';
+}
+
+/** Pull the human-authored text out of a `type:'user'` message, or '' when the entry is tool noise. */
+function userText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue;
+    const b = block as Record<string, unknown>;
+    // tool_result blocks are the agent feeding tool output back to itself, never a human prompt.
+    if (b.type === 'text' && typeof b.text === 'string') parts.push(b.text);
+  }
+  return parts.join('\n').trim();
+}
+
+function firstString(obj: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const k of keys) {
+    const v = obj[k];
+    if (typeof v === 'string' && v.length > 0) return v;
+  }
+  return undefined;
+}
+
+/** Extract the assistant text and tool_use events from a `type:'assistant'` message. */
+function assistantEvents(content: unknown): TraceEvent[] {
+  if (typeof content === 'string') {
+    const text = content.trim();
+    return text ? [{ kind: 'assistant', markdown: text }] : [];
+  }
+  if (!Array.isArray(content)) return [];
+  const out: TraceEvent[] = [];
+  const textParts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue;
+    const b = block as Record<string, unknown>;
+    if (b.type === 'text' && typeof b.text === 'string') {
+      textParts.push(b.text);
+    } else if (b.type === 'tool_use') {
+      const input = (b.input ?? {}) as Record<string, unknown>;
+      out.push({
+        kind: 'tool',
+        tool: asString(b.name) || 'tool',
+        title: firstString(input, ['description', 'command', 'pattern', 'prompt']),
+        filePath: firstString(input, ['file_path', 'path', 'notebook_path']),
+      });
+    }
+  }
+  const markdown = textParts.join('\n').trim();
+  if (markdown) out.unshift({ kind: 'assistant', markdown });
+  return out;
+}
+
+/**
+ * Parse a JSONL session log body into {@link TraceEvent}s. One JSON object per line; malformed lines
+ * and entries without a usable shape are silently dropped.
+ */
+export function normalizeSession(jsonlText: string): TraceEvent[] {
+  const events: TraceEvent[] = [];
+  for (const line of jsonlText.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let entry: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (!parsed || typeof parsed !== 'object') continue;
+      entry = parsed as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    const message = (entry.message ?? {}) as Record<string, unknown>;
+    if (entry.type === 'user') {
+      const text = userText(message.content).trim();
+      if (text) events.push({ kind: 'user', text });
+    } else if (entry.type === 'assistant') {
+      events.push(...assistantEvents(message.content));
+    }
+  }
+  return events;
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2,6 +2,7 @@ export * from './narrative';
 export * from './github';
 export * from './plan';
 export * from './recap';
+export * from './trace';
 export * from './collapse';
 export * from './units';
 export * from './config';

--- a/packages/contracts/src/trace.ts
+++ b/packages/contracts/src/trace.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+/**
+ * One coding-agent authoring session matched to the PR under review, mined from local Claude Code
+ * logs on the reviewer's machine. Read-only and best-effort: `userPrompts` are the human prompts that
+ * drove the change, never uploaded or persisted — they exist only in this HTTP response.
+ */
+export const traceSessionSummarySchema = z.object({
+  sessionId: z.string(),
+  path: z.string(),
+  startedAt: z.string(),
+  endedAt: z.string(),
+  branch: z.string().optional(),
+  cwd: z.string().optional(),
+  score: z.number(),
+  userPrompts: z.array(z.string()),
+});
+export type TraceSessionSummary = z.infer<typeof traceSessionSummarySchema>;
+
+export const traceIntentResponseSchema = z.object({
+  sessions: z.array(traceSessionSummarySchema),
+});
+export type TraceIntentResponse = z.infer<typeof traceIntentResponseSchema>;

--- a/packages/web/src/components/RecapView.tsx
+++ b/packages/web/src/components/RecapView.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useState } from 'react';
+import type { TraceSessionSummary } from '@diffdad/contracts';
 import { useReviewStore } from '../state/review-store';
 import { useRecapLazy } from '../hooks/useRecapLazy';
+import { useTraceIntent } from '../hooks/useTraceIntent';
 import type { Blocker, BlockerType, Decision, DecisionSourceType } from '../state/recap-types';
+import { Markdown } from './markdown/Markdown';
 import { DadMark } from './DadMark';
 import { getAccentMeta } from '../lib/accents';
 
@@ -69,6 +72,54 @@ const PHASES: Phase[] = [
     minMs: 99999, // sticks until the response arrives
   },
 ];
+
+function formatSessionDate(iso: string): string {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return '';
+  return new Date(t).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function TraceSessionCard({ session }: { session: TraceSessionSummary }) {
+  const started = formatSessionDate(session.startedAt);
+  return (
+    <li
+      className="rounded-lg p-4"
+      style={{ background: 'var(--bg-panel)', boxShadow: 'inset 0 0 0 1px var(--gray-a4)' }}
+    >
+      <div className="flex flex-wrap items-center gap-2 text-[12.5px] text-[var(--fg-3)]">
+        {session.branch && (
+          <span className="rounded-md bg-[var(--gray-3)] px-2 py-0.5 font-mono text-[11.5px] text-[var(--fg-2)]">
+            {session.branch}
+          </span>
+        )}
+        {started && <span>{started}</span>}
+        <span className="ml-auto tabular-nums">score {session.score}</span>
+      </div>
+      <div className="mt-3 space-y-2">
+        {session.userPrompts.map((prompt, i) => (
+          <blockquote key={i} className="border-l-[3px] pl-3" style={{ borderColor: 'var(--purple-a5)' }}>
+            <Markdown source={prompt} />
+          </blockquote>
+        ))}
+      </div>
+    </li>
+  );
+}
+
+function TraceIntentSection() {
+  const { sessions } = useTraceIntent();
+  if (sessions.length === 0) return null; // invisible when nothing matched
+  return (
+    <section>
+      <SectionHeader>What drove this change</SectionHeader>
+      <ul className="space-y-3">
+        {sessions.map((s) => (
+          <TraceSessionCard key={s.sessionId} session={s} />
+        ))}
+      </ul>
+    </section>
+  );
+}
 
 function SectionHeader({ children }: { children: React.ReactNode }) {
   return (
@@ -399,6 +450,8 @@ export function RecapView() {
           </pre>
         )}
       </section>
+
+      <TraceIntentSection />
 
       <section>
         <SectionHeader>How to help</SectionHeader>

--- a/packages/web/src/hooks/useTraceIntent.ts
+++ b/packages/web/src/hooks/useTraceIntent.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import type { TraceSessionSummary } from '@diffdad/contracts';
+
+/**
+ * Fetch local authoring-session intent once on mount, mirroring {@link useRecapLazy}'s fetch-once
+ * pattern. Best-effort and invisible on empty: any error or empty response yields `[]`, so the
+ * consuming section renders nothing rather than empty-state chrome.
+ */
+export function useTraceIntent(): { sessions: TraceSessionSummary[] } {
+  const [sessions, setSessions] = useState<TraceSessionSummary[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/trace/intent');
+        if (!res.ok) return;
+        const data = (await res.json()) as { sessions?: TraceSessionSummary[] };
+        if (!cancelled && Array.isArray(data.sessions)) setSessions(data.sessions);
+      } catch {
+        // best-effort: leave sessions empty so the feature stays invisible
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { sessions };
+}


### PR DESCRIPTION
When the reviewer's machine holds the authoring session logs (Claude
Code JSONL under ~/.claude/projects), the Recap tab gains a 'What
drove this change' section quoting the user prompts behind the PR.
Strictly local and read-only: no upload, no persistence, no LLM call —
filesystem matching only, and the section is invisible when nothing
matches.

- session matching ladder: branch name > repo dir name > touches 2+
  changed files > commit-window recency; top 3 by score
- defensive JSONL normalization (user/assistant/tool events)
- GET /api/trace/intent with in-memory per-process cache
- prompts render through the hardened Markdown path

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>