### PR TITLE
feat(narrative): callstack section type for call-flow changes

### DIFF
--- a/packages/cli/src/__tests__/normalize-narrative.test.ts
+++ b/packages/cli/src/__tests__/normalize-narrative.test.ts
@@ -43,6 +43,66 @@ describe('normalizeNarrative', () => {
     expect(out.verdict).toBe('caution');
   });
 
+  it('accepts a callstack section and preserves valid frames', () => {
+    const out = normalizeNarrative({
+      chapters: [
+        {
+          title: 'C',
+          summary: 's',
+          whyMatters: 'w',
+          risk: 'low',
+          sections: [
+            {
+              type: 'callstack',
+              title: 'flow',
+              frames: [
+                { label: 'a — f.ts', change: 'added', depth: 0 },
+                { label: 'b — f.ts', change: 'modified', depth: 1, file: 'f.ts', hunkIndex: 2 },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const section = out.chapters[0]?.sections[0];
+    expect(section?.type).toBe('callstack');
+    if (section?.type === 'callstack') {
+      expect(section.title).toBe('flow');
+      expect(section.frames).toHaveLength(2);
+      expect(section.frames[1]).toEqual({
+        label: 'b — f.ts',
+        change: 'modified',
+        depth: 1,
+        file: 'f.ts',
+        hunkIndex: 2,
+      });
+    }
+  });
+
+  it('clamps frame depth, coerces bad change, drops malformed frames, and caps frame count', () => {
+    const frames = [
+      { label: 'ok', change: 'weird', depth: 99 }, // change -> unchanged, depth -> 8
+      { label: 'deep', change: 'removed', depth: -3 }, // depth -> 0
+      { change: 'added', depth: 1 }, // no label -> dropped
+      { label: '', change: 'added', depth: 1 }, // empty label -> dropped
+      ...Array.from({ length: 40 }, (_, i) => ({ label: `f${i}`, change: 'unchanged', depth: 0 })),
+    ];
+    const out = normalizeNarrative({
+      chapters: [
+        { title: 'C', summary: '', whyMatters: '', risk: 'low', sections: [{ type: 'callstack', title: 't', frames }] },
+      ],
+    });
+    const section = out.chapters[0]?.sections[0];
+    expect(section?.type).toBe('callstack');
+    if (section?.type === 'callstack') {
+      expect(section.frames).toHaveLength(30); // capped
+      expect(section.frames[0]).toMatchObject({ change: 'unchanged', depth: 8 });
+      expect(section.frames[1]).toMatchObject({ change: 'removed', depth: 0 });
+      // the two malformed frames were dropped, so index 2 is the first synthesized filler
+      expect(section.frames[2]?.label).toBe('f0');
+    }
+  });
+
   it('upgrades old narratives missing the new fields', () => {
     const oldShape = {
       title: 'Old',

--- a/packages/cli/src/__tests__/repair.test.ts
+++ b/packages/cli/src/__tests__/repair.test.ts
@@ -130,6 +130,54 @@ describe('repairNarrative', () => {
     expect(out.chapters[0]!.reshow).toEqual([{ ref: 1, file: 'a.ts' }]);
   });
 
+  it('nulls out a callstack frame dead link but keeps the frame and its prose', () => {
+    const files = [file('a.ts', 1)];
+    const n = narrative([
+      {
+        title: 'A',
+        summary: '',
+        whyMatters: '',
+        risk: 'low',
+        sections: [
+          diffSection('a.ts', 0),
+          {
+            type: 'callstack',
+            title: 'flow',
+            frames: [
+              { label: 'root', change: 'unchanged', depth: 0 },
+              { label: 'gone', change: 'added', depth: 1, file: 'ghost.ts', hunkIndex: 0 },
+              { label: 'oob', change: 'modified', depth: 1, file: 'a.ts', hunkIndex: 9 },
+              { label: 'good', change: 'added', depth: 1, file: 'a.ts', hunkIndex: 0 },
+            ],
+          },
+        ],
+      },
+    ]);
+    const { narrative: out, dropped } = repairNarrative(n, files);
+    const section = out.chapters[0]!.sections[1]!;
+    expect(section.type).toBe('callstack');
+    if (section.type === 'callstack') {
+      expect(section.frames).toHaveLength(4); // no frame dropped
+      expect(section.frames[1]).toEqual({
+        label: 'gone',
+        change: 'added',
+        depth: 1,
+        file: undefined,
+        hunkIndex: undefined,
+      });
+      expect(section.frames[2]).toEqual({
+        label: 'oob',
+        change: 'modified',
+        depth: 1,
+        file: undefined,
+        hunkIndex: undefined,
+      });
+      expect(section.frames[3]).toEqual({ label: 'good', change: 'added', depth: 1, file: 'a.ts', hunkIndex: 0 });
+    }
+    expect(dropped).toHaveLength(2);
+    expect(dropped.map((d) => d.kind).sort()).toEqual(['invalid-hunk-index', 'unknown-file']);
+  });
+
   it('produces a narrative with no unresolvable refs left (validator agrees)', () => {
     const files = [file('a.ts', 2)];
     const n = narrative([

--- a/packages/cli/src/__tests__/validator.test.ts
+++ b/packages/cli/src/__tests__/validator.test.ts
@@ -210,6 +210,34 @@ describe('validateNarrative', () => {
     expect(findKind(r.violations, 'orphan-hunk')).toEqual([]);
   });
 
+  it('flags a callstack frame linking an unknown file or out-of-range hunkIndex', () => {
+    const files = [file('a.ts', 1)];
+    const n = narrative([
+      {
+        title: '1',
+        summary: '',
+        whyMatters: '',
+        risk: 'low',
+        sections: [
+          diffSection('a.ts', 0),
+          {
+            type: 'callstack',
+            title: 'flow',
+            frames: [
+              { label: 'root', change: 'unchanged', depth: 0 }, // no link — ignored
+              { label: 'gone', change: 'added', depth: 1, file: 'ghost.ts', hunkIndex: 0 }, // unknown-file
+              { label: 'oob', change: 'modified', depth: 1, file: 'a.ts', hunkIndex: 9 }, // invalid-hunk-index
+              { label: 'good', change: 'added', depth: 1, file: 'a.ts', hunkIndex: 0 }, // valid
+            ],
+          },
+        ],
+      },
+    ]);
+    const r = validateNarrative(n, files);
+    expect(findKind(r.violations, 'unknown-file')).toMatchObject([{ file: 'ghost.ts', chapter: 0 }]);
+    expect(findKind(r.violations, 'invalid-hunk-index')).toMatchObject([{ file: 'a.ts', hunkIndex: 9, chapter: 0 }]);
+  });
+
   it('formatViolation produces a non-empty string for every kind', () => {
     const samples: ValidationViolation[] = [
       { kind: 'duplicate-primary', file: 'a', hunkIndex: 0, chapters: [0, 1] },

--- a/packages/cli/src/eval/judge.ts
+++ b/packages/cli/src/eval/judge.ts
@@ -73,6 +73,8 @@ function summarizeNarrative(narrative: NarrativeResponse): string {
     for (const s of ch.sections) {
       if (s.type === 'narrative') {
         parts.push(`    narrative: ${s.content}`);
+      } else if (s.type === 'callstack') {
+        parts.push(`    callstack[${s.frames.length}]: ${s.title}`);
       } else {
         parts.push(`    diff-ref: ${s.file}:${s.startLine}-${s.endLine}`);
       }

--- a/packages/cli/src/narrative/prompt.ts
+++ b/packages/cli/src/narrative/prompt.ts
@@ -69,8 +69,11 @@ const MAX_THEMES = 7;
 // Bumped again for the reader-contract + omission mandate added to the prose prompts (single-pass,
 // writer, and planner prose guidance). Both keys move so every cached plan and narrative regenerates
 // against the new instructions.
+// Bumped again for the new `callstack` section type in the writer/single-pass JSON contract: cached
+// narratives predate it and would never carry call-tree sections, so they regenerate against the new
+// instructions. Plans are untouched (the section type never appears in a plan), so PLANNER stays put.
 export const PLANNER_PROMPT_REVISION = 3;
-export const NARRATIVE_PROMPT_REVISION = 4;
+export const NARRATIVE_PROMPT_REVISION = 5;
 
 // Shared reader-contract + omission mandate injected into every prompt that produces reader-facing
 // prose. (a) forces the model to spend its budget deciding what to leave out; (b) pins the reader's
@@ -114,6 +117,19 @@ const RESPONSE_SCHEMA = `{
           "startLine": "number — first line in the new file (1-based)",
           "endLine": "number — last line in the new file (1-based)",
           "hunkIndex": "number — 0-based index into DiffFile.hunks for the file"
+        },
+        {
+          "type": "callstack",
+          "title": "string — short label for the call-flow delta, e.g. 'Submit path now revalidates'",
+          "frames": [
+            {
+              "label": "string — 'funcName — path/to/file.ts', caller above callee",
+              "change": "added | removed | unchanged | modified",
+              "depth": "number — 0-based indent; caller is shallower than callee",
+              "file": "string? — only when this frame's change is visible in the diff",
+              "hunkIndex": "number? — 0-based hunk index; only alongside file"
+            }
+          ]
         }
       ],
       "callouts": [
@@ -188,12 +204,36 @@ const CHAPTER_RESPONSE_SCHEMA = `{
       "startLine": "number — 1-based new side",
       "endLine": "number — 1-based new side",
       "hunkIndex": "number — must be one of this theme's hunkIndex values for the given file"
+    },
+    {
+      "type": "callstack",
+      "title": "string — short label for the call-flow delta",
+      "frames": [
+        {
+          "label": "string — 'funcName — path/to/file.ts', caller above callee",
+          "change": "added | removed | unchanged | modified",
+          "depth": "number — 0-based indent; caller shallower than callee",
+          "file": "string? — only when this frame's change is visible in this theme's diff",
+          "hunkIndex": "number? — 0-based hunk index for this theme; only alongside file"
+        }
+      ]
     }
   ],
   "callouts": [
     { "file": "string", "line": "number", "level": "nit | concern | warning", "message": "string" }
   ]
 }`;
+
+// Strict guidance for the optional `callstack` section, injected into both prose prompts. Prose+hunks
+// explain a changed call chain worst; this section renders a base-vs-head call tree with +/- gutters.
+const CALLSTACK_GUIDANCE = `## Call-stack sections (use rarely)
+
+A \`callstack\` section renders a base-vs-head call tree with +/- gutter markers. Use it ONLY when the chapter's central change IS a call-flow change: a function newly called, a call removed, or a call-order change (A→B→C became A→D→C). If the chapter is about anything else, do NOT emit one — a diff section is almost always the right tool.
+
+- **Label frames caller→callee, top-down.** The caller is shallower (\`depth\` smaller); the callee it invokes is one deeper. \`label\` is 'functionName — path/to/file.ts'.
+- **Mark only frames that actually changed.** \`change\` is 'added' (newly in the chain), 'removed' (no longer called), 'modified' (still called but its body changed), or 'unchanged' (context frame shown for orientation). Most frames in a typical tree are 'unchanged'.
+- **3-12 frames is typical.** Fewer than 3 is not a tree; more than ~12 is noise.
+- **Link frames only when the change is visible in the diff.** Set \`file\`+\`hunkIndex\` (both, or neither) so the reviewer can jump to the hunk. Omit them for orientation-only frames.`;
 
 const SHARED_PRINCIPLES = `Your job is to help a reviewer find the things they would otherwise miss. Empirical research on code review (Mantyla & Lassenius 2009) shows that human reviewers reliably catch style and structure issues but miss bugs in **logic, state, timing, and input validation**. Your value is on the slip set — not the obvious stuff.
 
@@ -211,6 +251,8 @@ const SYSTEM_PROMPT = `You are Diff Dad, a senior engineer producing a code revi
 ${SHARED_PRINCIPLES}
 
 ${READER_CONTRACT}
+
+${CALLSTACK_GUIDANCE}
 
 ## What to produce
 
@@ -441,6 +483,10 @@ Skip nits. Use \`concern\` (worth discussing) or \`warning\` (likely bug) sparin
 ## Diff conventions
 
 Same as the planner pass: \`hunkIndex\` is per-file 0-based; \`startLine\`/\`endLine\` are 1-based on the new side and FOCUS the viewer on a slice; truncation markers are real.
+
+${CALLSTACK_GUIDANCE}
+
+When a callstack frame links into the diff, its \`file\`+\`hunkIndex\` must come from this theme's hunks, exactly like a diff section.
 
 ## Output
 

--- a/packages/cli/src/narrative/types.ts
+++ b/packages/cli/src/narrative/types.ts
@@ -84,6 +84,23 @@ export type HunkAnchor = {
   contentHash: string;
 };
 
+/**
+ * One frame in a base-vs-head call-tree diff. `depth` is the 0-based indent (root frames at 0).
+ * `file`+`hunkIndex` optionally link the frame into a diff section the same way a `diff` section does;
+ * both must be present for the link to be live. Unlike diff sections, frames carry no re-resolution
+ * anchor — the validate/repair path nulls a dead link in place rather than re-resolving it.
+ */
+export type CallStackFrame = {
+  /** e.g. 'handleSubmit — src/form.ts'. */
+  label: string;
+  change: 'added' | 'removed' | 'unchanged' | 'modified';
+  /** 0-based indentation level. Clamped to 0-8 by normalizeNarrative. */
+  depth: number;
+  file?: string;
+  /** 0-based index into DiffFile.hunks — same semantics as a diff section. */
+  hunkIndex?: number;
+};
+
 export type NarrativeSection =
   | { type: 'narrative'; content: string }
   | {
@@ -94,7 +111,8 @@ export type NarrativeSection =
       hunkIndex: number;
       /** Content-derived re-resolution anchor. Absent on narratives cached before this field existed. */
       anchor?: HunkAnchor;
-    };
+    }
+  | { type: 'callstack'; title: string; frames: CallStackFrame[] };
 
 const CONCERN_CATEGORIES: ConcernCategory[] = [
   'logic',
@@ -116,6 +134,48 @@ function normalizeReadingPlanStep(input: unknown): ReadingPlanStep | null {
     chapterIndex: typeof obj.chapterIndex === 'number' ? obj.chapterIndex : undefined,
     why: typeof obj.why === 'string' ? obj.why : undefined,
   };
+}
+
+const CALLSTACK_CHANGES: CallStackFrame['change'][] = ['added', 'removed', 'unchanged', 'modified'];
+const MAX_FRAME_DEPTH = 8;
+const MAX_FRAMES = 30;
+
+function normalizeCallStackFrame(input: unknown): CallStackFrame | null {
+  if (!input || typeof input !== 'object') return null;
+  const obj = input as Record<string, unknown>;
+  if (typeof obj.label !== 'string' || obj.label.length === 0) return null;
+  const change = CALLSTACK_CHANGES.includes(obj.change as CallStackFrame['change'])
+    ? (obj.change as CallStackFrame['change'])
+    : 'unchanged';
+  const rawDepth = typeof obj.depth === 'number' && Number.isFinite(obj.depth) ? Math.floor(obj.depth) : 0;
+  const depth = Math.min(Math.max(rawDepth, 0), MAX_FRAME_DEPTH);
+  return {
+    label: obj.label,
+    change,
+    depth,
+    file: typeof obj.file === 'string' ? obj.file : undefined,
+    hunkIndex: typeof obj.hunkIndex === 'number' ? obj.hunkIndex : undefined,
+  };
+}
+
+/**
+ * Normalize one section. Prose and diff sections pass through untouched (they are validated elsewhere);
+ * callstack sections get defensive frame handling: malformed frames dropped, depth clamped, frame count
+ * capped, missing/unknown change coerced to 'unchanged'. Unknown section types pass through so the UI's
+ * safe default can drop them.
+ */
+function normalizeSection(input: unknown): NarrativeSection {
+  if (input && typeof input === 'object' && (input as Record<string, unknown>).type === 'callstack') {
+    const obj = input as Record<string, unknown>;
+    const frames = Array.isArray(obj.frames)
+      ? obj.frames
+          .map(normalizeCallStackFrame)
+          .filter((f): f is CallStackFrame => f !== null)
+          .slice(0, MAX_FRAMES)
+      : [];
+    return { type: 'callstack', title: typeof obj.title === 'string' ? obj.title : '', frames };
+  }
+  return input as NarrativeSection;
 }
 
 function normalizeConcern(input: unknown): Concern | null {
@@ -162,7 +222,7 @@ export function normalizeNarrative(input: unknown): NarrativeResponse {
       risk: (c.risk === 'low' || c.risk === 'medium' || c.risk === 'high'
         ? c.risk
         : 'medium') as NarrativeChapter['risk'],
-      sections: Array.isArray(c.sections) ? (c.sections as NarrativeSection[]) : [],
+      sections: Array.isArray(c.sections) ? c.sections.map(normalizeSection) : [],
       callouts: Array.isArray(c.callouts) ? (c.callouts as Callout[]) : undefined,
       reshow: Array.isArray(c.reshow) ? (c.reshow as ReshowEntry[]) : undefined,
       themeId: typeof c.themeId === 'string' ? c.themeId : undefined,

--- a/packages/cli/src/narrative/validator.ts
+++ b/packages/cli/src/narrative/validator.ts
@@ -41,6 +41,23 @@ export function validateNarrative(narrative: NarrativeResponse, files: DiffFile[
 
   narrative.chapters.forEach((ch, ci) => {
     for (const s of ch.sections) {
+      if (s.type === 'callstack') {
+        // A frame links into the diff only when it carries BOTH file and hunkIndex; validate those refs
+        // the same way diff sections are validated, reported per frame via the shared violation kinds.
+        for (const frame of s.frames) {
+          if (frame.file === undefined || frame.hunkIndex === undefined) continue;
+          const norm = normalizePath(frame.file);
+          const file = fileMap.get(norm);
+          if (!file) {
+            violations.push({ kind: 'unknown-file', file: frame.file, chapter: ci });
+            continue;
+          }
+          if (frame.hunkIndex < 0 || frame.hunkIndex >= file.hunks.length) {
+            violations.push({ kind: 'invalid-hunk-index', file: frame.file, hunkIndex: frame.hunkIndex, chapter: ci });
+          }
+        }
+        continue;
+      }
       if (s.type !== 'diff') continue;
       const norm = normalizePath(s.file);
       const file = fileMap.get(norm);
@@ -158,6 +175,23 @@ export function repairNarrative(narrative: NarrativeResponse, files: DiffFile[])
   const chapters = narrative.chapters.map((ch, ci) => {
     const sections: NarrativeSection[] = [];
     for (const s of ch.sections) {
+      if (s.type === 'callstack') {
+        // Null out (never drop) a frame's dead file/hunkIndex pair: the frame's prose stays, only the
+        // broken link is removed. Frames carry no anchor, so there is nothing to re-resolve — an
+        // unresolvable pair is simply cleared.
+        const frames = s.frames.map((frame) => {
+          if (frame.file === undefined || frame.hunkIndex === undefined) return frame;
+          const norm = normalizePath(frame.file);
+          const file = fileMap.get(norm);
+          const inRange = file ? frame.hunkIndex >= 0 && frame.hunkIndex < file.hunks.length : false;
+          if (file && inRange) return frame;
+          if (!file) dropped.push({ kind: 'unknown-file', file: frame.file, chapter: ci });
+          else dropped.push({ kind: 'invalid-hunk-index', file: frame.file, hunkIndex: frame.hunkIndex, chapter: ci });
+          return { ...frame, file: undefined, hunkIndex: undefined };
+        });
+        sections.push({ ...s, frames });
+        continue;
+      }
       if (s.type !== 'diff') {
         sections.push(s);
         continue;

--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -165,6 +165,47 @@ describe('narrative payload', () => {
     };
     expect(() => narrativeResponseSchema.parse(bad)).toThrow();
   });
+
+  test('round-trips a callstack section', () => {
+    const withCallstack = {
+      ...narrative,
+      chapters: [
+        {
+          ...chapter,
+          sections: [
+            {
+              type: 'callstack' as const,
+              title: 'Submit path revalidates',
+              frames: [
+                { label: 'handleSubmit — src/form.ts', change: 'unchanged' as const, depth: 0 },
+                {
+                  label: 'validate — src/form.ts',
+                  change: 'added' as const,
+                  depth: 1,
+                  file: 'src/form.ts',
+                  hunkIndex: 0,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(narrativeResponseSchema.parse(withCallstack)).toEqual(withCallstack);
+  });
+
+  test('rejects a callstack frame with a bad change enum', () => {
+    const bad = {
+      ...narrative,
+      chapters: [
+        {
+          ...chapter,
+          sections: [{ type: 'callstack', title: 't', frames: [{ label: 'f', change: 'nuked', depth: 0 }] }],
+        },
+      ],
+    };
+    expect(() => narrativeResponseSchema.parse(bad)).toThrow();
+  });
 });
 
 describe('comments', () => {

--- a/packages/contracts/src/narrative.ts
+++ b/packages/contracts/src/narrative.ts
@@ -58,6 +58,15 @@ export const hunkAnchorSchema = z.object({
 });
 export type HunkAnchor = z.infer<typeof hunkAnchorSchema>;
 
+export const callStackFrameSchema = z.object({
+  label: z.string(),
+  change: z.enum(['added', 'removed', 'unchanged', 'modified']),
+  depth: z.number(),
+  file: z.string().optional(),
+  hunkIndex: z.number().optional(),
+});
+export type CallStackFrame = z.infer<typeof callStackFrameSchema>;
+
 export const narrativeSectionSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('narrative'), content: z.string() }),
   z.object({
@@ -67,6 +76,11 @@ export const narrativeSectionSchema = z.discriminatedUnion('type', [
     endLine: z.number(),
     hunkIndex: z.number(),
     anchor: hunkAnchorSchema.optional(),
+  }),
+  z.object({
+    type: z.literal('callstack'),
+    title: z.string(),
+    frames: z.array(callStackFrameSchema),
   }),
 ]);
 export type NarrativeSection = z.infer<typeof narrativeSectionSchema>;

--- a/packages/web/src/components/CallStackSection.tsx
+++ b/packages/web/src/components/CallStackSection.tsx
@@ -1,0 +1,120 @@
+import type { CallStackFrame } from '../state/types';
+
+type Props = {
+  title: string;
+  frames: CallStackFrame[];
+  /**
+   * Resolve a frame's `file`+`hunkIndex` to the DOM id of the hunk rendered in THIS chapter, or null
+   * when that hunk is not shown here. When null, the frame renders its file as a non-interactive dim
+   * suffix instead of a scroll link.
+   */
+  resolveHunkId?: (file: string, hunkIndex: number) => string | null;
+};
+
+type ChangeKind = CallStackFrame['change'];
+
+// Marker + colors per change kind. Row tints mirror Hunk/CodeLine's add/remove rgba tints so the tree
+// reads like the diff it summarizes; modified uses amber, unchanged is dim with no tint.
+const CHANGE_STYLES: Record<ChangeKind, { marker: string; color: string; rowBg: string }> = {
+  added: { marker: '+', color: 'var(--green-11)', rowBg: 'rgba(41, 163, 131, 0.08)' },
+  removed: { marker: '-', color: 'var(--red-11)', rowBg: 'rgba(229, 70, 102, 0.08)' },
+  modified: { marker: '~', color: 'var(--amber-11)', rowBg: 'rgba(232, 179, 57, 0.12)' },
+  unchanged: { marker: ' ', color: 'var(--fg-3)', rowBg: 'transparent' },
+};
+
+/** True when no later frame is a sibling of `frames[i]` (same depth before the depth drops below it). */
+function isLastSibling(frames: CallStackFrame[], i: number): boolean {
+  const d = frames[i]!.depth;
+  for (let j = i + 1; j < frames.length; j++) {
+    const dj = frames[j]!.depth;
+    if (dj < d) return true;
+    if (dj === d) return false;
+  }
+  return true;
+}
+
+export type TreeRow = { frame: CallStackFrame; prefix: string; index: number };
+
+/**
+ * Build the tree connector prefix for each frame: vertical guides (│) for ancestor levels that still
+ * have siblings below, and a ├─/└─ elbow at the frame's own depth. Pure and exported for testing.
+ */
+export function buildTreeRows(frames: CallStackFrame[]): TreeRow[] {
+  const lastAtDepth: boolean[] = [];
+  return frames.map((frame, i) => {
+    const d = Math.max(0, frame.depth);
+    const last = isLastSibling(frames, i);
+    lastAtDepth[d] = last;
+    let prefix = '';
+    for (let level = 1; level < d; level++) {
+      prefix += lastAtDepth[level] ? '   ' : '\u2502  ';
+    }
+    if (d > 0) prefix += last ? '\u2514\u2500 ' : '\u251c\u2500 ';
+    return { frame, prefix, index: i };
+  });
+}
+
+function scrollToHunk(id: string) {
+  const el = document.getElementById(id);
+  if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+}
+
+export function CallStackSection({ title, frames, resolveHunkId }: Props) {
+  const rows = buildTreeRows(frames);
+
+  return (
+    <div
+      className="ml-[34px] mb-[14px] overflow-hidden rounded-[8px] bg-[var(--bg-panel)]"
+      style={{ boxShadow: 'inset 0 0 0 1px var(--gray-a5)' }}
+    >
+      <div
+        className="flex items-center gap-2 bg-[var(--gray-2)] px-3 py-2 font-mono text-[12.5px] text-[var(--fg-2)]"
+        style={{ boxShadow: 'inset 0 -1px 0 var(--gray-a4)' }}
+      >
+        <span aria-hidden className="text-[var(--fg-3)]">
+          ⌇
+        </span>
+        <span className="font-semibold text-[var(--fg-1)]">{title || 'Call flow'}</span>
+        <span className="text-[var(--fg-3)]">call-stack diff</span>
+      </div>
+      <div className="overflow-x-auto py-1" style={{ minWidth: 'max-content' }}>
+        {rows.map(({ frame, prefix, index }) => {
+          const style = CHANGE_STYLES[frame.change];
+          const targetId =
+            frame.file != null && frame.hunkIndex != null
+              ? (resolveHunkId?.(frame.file, frame.hunkIndex) ?? null)
+              : null;
+          return (
+            <div
+              key={index}
+              className="grid items-center font-mono text-[12.75px] leading-[20px]"
+              style={{ gridTemplateColumns: '16px 1fr', background: style.rowBg }}
+            >
+              <span className="select-none text-center font-bold" style={{ color: style.color }}>
+                {style.marker}
+              </span>
+              <span className="whitespace-pre pr-3" style={{ color: 'var(--gray-12)' }}>
+                <span className="select-none text-[var(--fg-3)]">{prefix}</span>
+                {targetId ? (
+                  <button
+                    type="button"
+                    onClick={() => scrollToHunk(targetId)}
+                    className="cursor-pointer underline decoration-dotted underline-offset-2 hover:text-[var(--brand)]"
+                    style={{ color: 'inherit', background: 'transparent' }}
+                  >
+                    {frame.label}
+                  </button>
+                ) : (
+                  <span>{frame.label}</span>
+                )}
+                {!targetId && frame.file ? (
+                  <span className="ml-2 text-[11.5px] text-[var(--fg-3)]">{frame.file}</span>
+                ) : null}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/Chapter.tsx
+++ b/packages/web/src/components/Chapter.tsx
@@ -13,6 +13,7 @@ import type {
   DiffHunk,
   HunkAnchor,
 } from '../state/types';
+import { CallStackSection } from './CallStackSection';
 import { Hunk } from './Hunk';
 import { IconCheck, IconChevron } from './Icons';
 import { NarrationAnchor } from './NarrationAnchor';
@@ -259,6 +260,29 @@ export function Chapter({ index, chapter, resolve, decision, callers }: Props) {
     return map;
   }, [narrative]);
 
+  // DOM id for a hunk rendered in this chapter, so a callstack frame can scroll to it.
+  const hunkDomId = (file: string, hunkIndex: number) => `${id}-hunk-${normalizePath(file)}-${hunkIndex}`;
+
+  // `${normFile}:${hunkIndex}` -> DOM id for every diff-section hunk this chapter renders. A callstack
+  // frame link resolves through this: only hunks actually shown here are scroll targets.
+  const renderedHunkIds = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const section of chapter.sections) {
+      if (section.type !== 'diff') continue;
+      const flat = findHunk(files, section.file, section.hunkIndex, section.anchor);
+      if (!flat) continue;
+      map.set(`${normalizePath(flat.file)}:${flat.hunkIndex}`, hunkDomId(flat.file, flat.hunkIndex));
+    }
+    return map;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chapter.sections, files, id]);
+
+  const resolveHunkId = (file: string, hunkIndex: number): string | null => {
+    const flat = findHunk(files, file, hunkIndex);
+    if (!flat) return null;
+    return renderedHunkIds.get(`${normalizePath(flat.file)}:${flat.hunkIndex}`) ?? null;
+  };
+
   // Hunks already rendered as diff sections by earlier chapters — duplicates render as reshow.
   const priorHunks = useMemo(() => {
     const set = new Set<string>();
@@ -503,6 +527,13 @@ export function Chapter({ index, chapter, resolve, decision, callers }: Props) {
           if (i !== firstNarrativeIndex) return null;
           return <NarrationBlock key={i} content={section.content} chapterKey={id} />;
         }
+        if (section.type === 'callstack') {
+          return (
+            <CallStackSection key={i} title={section.title} frames={section.frames} resolveHunkId={resolveHunkId} />
+          );
+        }
+        // Unknown section types (stale cache) render nothing.
+        if (section.type !== 'diff') return null;
         const flat = findHunk(files, section.file, section.hunkIndex, section.anchor);
         if (!flat) {
           return <MissingHunkBanner key={i} file={section.file} hunkIndex={section.hunkIndex} />;
@@ -524,6 +555,7 @@ export function Chapter({ index, chapter, resolve, decision, callers }: Props) {
                 hunk={flat.hunk}
                 isNewFile={flat.isNewFile}
                 hunkIndex={flat.hunkIndex}
+                anchorId={hunkDomId(flat.file, flat.hunkIndex)}
                 highlight={highlight}
               />
             </ReshowBlock>
@@ -537,6 +569,7 @@ export function Chapter({ index, chapter, resolve, decision, callers }: Props) {
             hunk={flat.hunk}
             isNewFile={flat.isNewFile}
             hunkIndex={flat.hunkIndex}
+            anchorId={hunkDomId(flat.file, flat.hunkIndex)}
             highlight={highlight}
             resolve={annotationPlacement.bySection[i]?.resolve}
             callouts={annotationPlacement.bySection[i]?.callouts}

--- a/packages/web/src/components/Hunk.tsx
+++ b/packages/web/src/components/Hunk.tsx
@@ -20,6 +20,8 @@ type Props = {
   isNewFile?: boolean;
   hunkIndex: number;
   highlight?: { from: number; to: number };
+  /** DOM id for the hunk's outer element, so a callstack frame can scroll to it. */
+  anchorId?: string;
   /** Open questions anchored in this hunk — render inline under the line they're about. */
   resolve?: ResolveItem[];
   /** Passive narrative callouts anchored in this hunk — render inline under their line. */
@@ -535,7 +537,7 @@ function HunkLines({
   );
 }
 
-export function Hunk({ file, hunk, isNewFile, hunkIndex, highlight, resolve, callouts }: Props) {
+export function Hunk({ file, hunk, isNewFile, hunkIndex, highlight, anchorId, resolve, callouts }: Props) {
   const openLine = useReviewStore((s) => s.openLine);
   const commentRangeStart = useReviewStore((s) => s.commentRangeStart);
   const commentDrag = useReviewStore((s) => s.commentDrag);
@@ -680,7 +682,8 @@ export function Hunk({ file, hunk, isNewFile, hunkIndex, highlight, resolve, cal
 
   return (
     <div
-      className="ml-[34px] mb-[14px] overflow-hidden rounded-[8px] bg-[var(--bg-panel)]"
+      id={anchorId}
+      className="ml-[34px] mb-[14px] overflow-hidden rounded-[8px] bg-[var(--bg-panel)] scroll-mt-[180px]"
       style={{ boxShadow: 'inset 0 0 0 1px var(--gray-a5)' }}
     >
       <div

--- a/packages/web/src/components/__tests__/callstack-render.test.tsx
+++ b/packages/web/src/components/__tests__/callstack-render.test.tsx
@@ -1,0 +1,58 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import type { CallStackFrame } from '../../state/types';
+import { buildTreeRows, CallStackSection } from '../CallStackSection';
+
+/**
+ * Pure `buildTreeRows` connector logic plus a server-rendered markup smoke test. Rendered through
+ * `react-dom/server` (no store, props-only component) to match the suite's node environment.
+ */
+
+function frame(label: string, depth: number, change: CallStackFrame['change'] = 'unchanged'): CallStackFrame {
+  return { label, depth, change };
+}
+
+describe('buildTreeRows', () => {
+  it('emits no connector at depth 0 and elbows at deeper levels', () => {
+    const rows = buildTreeRows([frame('root', 0), frame('a', 1), frame('b', 1)]);
+    expect(rows[0]!.prefix).toBe('');
+    expect(rows[1]!.prefix).toBe('├─ '); // a has a sibling below
+    expect(rows[2]!.prefix).toBe('└─ '); // b is last
+  });
+
+  it('draws vertical guides for ancestor levels that still have siblings', () => {
+    // root, child(has sibling), grandchild, sibling-of-child
+    const rows = buildTreeRows([frame('root', 0), frame('c1', 1), frame('gc', 2), frame('c2', 1)]);
+    expect(rows[1]!.prefix).toBe('├─ '); // c1 not last (c2 follows)
+    expect(rows[2]!.prefix).toBe('│  └─ '); // guide for c1's level, gc is last child
+    expect(rows[3]!.prefix).toBe('└─ '); // c2 last
+  });
+});
+
+describe('CallStackSection markup', () => {
+  const frames: CallStackFrame[] = [
+    frame('handleSubmit — src/form.ts', 0),
+    { label: 'validate — src/form.ts', depth: 1, change: 'added', file: 'src/form.ts', hunkIndex: 0 },
+    { label: 'legacyCheck — src/old.ts', depth: 1, change: 'removed', file: 'src/old.ts', hunkIndex: 3 },
+  ];
+
+  it('renders a linked frame as a button when resolveHunkId hits', () => {
+    const html = renderToStaticMarkup(
+      <CallStackSection
+        title="Submit path"
+        frames={frames}
+        resolveHunkId={(file, idx) => (file === 'src/form.ts' && idx === 0 ? 'ch-0-hunk-src/form.ts-0' : null)}
+      />,
+    );
+    expect(html).toContain('Submit path');
+    expect(html).toContain('<button');
+    expect(html).toContain('handleSubmit');
+    // The unresolved removed frame shows its file as a dim suffix, not a button link.
+    expect(html).toContain('src/old.ts');
+  });
+
+  it('renders no buttons when nothing resolves', () => {
+    const html = renderToStaticMarkup(<CallStackSection title="Flow" frames={frames} />);
+    expect(html).not.toContain('<button');
+  });
+});

--- a/packages/web/src/lib/find.ts
+++ b/packages/web/src/lib/find.ts
@@ -16,7 +16,7 @@ export type FindOptions = {
 };
 
 /** Which slice of a chapter a target's text came from — kept for debugging/tests, not shown to users. */
-export type FindField = 'title' | 'summary' | 'whyMatters' | 'narrative' | 'diff' | 'callout';
+export type FindField = 'title' | 'summary' | 'whyMatters' | 'narrative' | 'diff' | 'callstack' | 'callout';
 
 /**
  * A single searchable string plus where it lives. `chapterIndex` / `chid` are what navigation needs to
@@ -103,7 +103,10 @@ export function collectTargets(narrative: NarrativeResponse | null, files: DiffF
     for (const section of ch.sections) {
       if (section.type === 'narrative') {
         push(idx, chid, 'narrative', section.content ?? '');
-      } else {
+      } else if (section.type === 'callstack') {
+        push(idx, chid, 'callstack', section.title ?? '');
+        for (const frame of section.frames) push(idx, chid, 'callstack', frame.label ?? '');
+      } else if (section.type === 'diff') {
         const norm = normalizePath(section.file);
         const diffFile = files.find((f) => normalizePath(f.file) === norm);
         const hunk = diffFile?.hunks[section.hunkIndex];

--- a/packages/web/src/lib/walkthrough.ts
+++ b/packages/web/src/lib/walkthrough.ts
@@ -160,7 +160,7 @@ export function buildWalkthrough(narrative: NarrativeResponse, files: DiffFile[]
     const sections: BeatSection[] = [];
     for (const s of ch.sections ?? []) {
       if (s.type === 'narrative') sections.push({ kind: 'prose', text: s.content });
-      else if (hunkResolves(files, s.file, s.hunkIndex)) {
+      else if (s.type === 'diff' && hunkResolves(files, s.file, s.hunkIndex)) {
         sections.push({ kind: 'diff', file: s.file, hunkIndex: s.hunkIndex });
       }
     }

--- a/packages/web/src/state/types.ts
+++ b/packages/web/src/state/types.ts
@@ -8,6 +8,7 @@ import type { WireUnit } from '@diffdad/contracts';
  */
 export type {
   Callout,
+  CallStackFrame,
   CapStats,
   ChapterCallers,
   CheckRun,


### PR DESCRIPTION
Chapters could only interleave prose and diff hunks — the worst
possible way to explain 'this call chain changed from A→B→C to
A→D→C'. Sections gain a third variant:

  { type: 'callstack', title, frames: [{ label, change, depth,
    file?, hunkIndex? }] }

- writer prompt documents it with strict guidance: only for call-flow
  changes, caller→callee top-down, 3-12 frames, links only when the
  frame's change is visible in the diff; prompt revision bumped
- normalize clamps depth, caps frames, drops malformed ones
- validator checks frame links like diff sections; repair nulls dead
  links but keeps the frame prose
- web renders a monospace tree with connectors and +/-/~ gutter tints;
  frames whose hunk renders in the same chapter scroll to it on click
- unknown section types from stale caches render nothing

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>