### PR TITLE
fix(server): snapshot regen state, back off failed regens, bind loopback

### DIFF
--- a/packages/cli/src/__tests__/server-sse.test.ts
+++ b/packages/cli/src/__tests__/server-sse.test.ts
@@ -666,11 +666,11 @@ describe('GET /api/events — polling cycle', () => {
     const newSha = `sha-reentrant-${Date.now()}`;
     const initialPr = mkPR({ headSha: newSha });
     const editedPr = mkPR({ headSha: newSha, title: 'Edited mid-regen' });
-    // Pre-seed the cache under the edited title's hash. The standalone 'pr'
-    // branch in poll 2 mutates ctx.pr before poll 1's getDiff resolves, so the
-    // post-await metaHash computation picks up the edited title.
-    const editedMeta = computePromptMetaHash(editedPr);
-    await cacheNarrative('o', 'r', 1, newSha, editedMeta, providerKey, baseNarrative);
+    // Pre-seed the cache under the INITIAL title's hash. Regen snapshots the PR at poll start
+    // (fresh state lives in locals until success), so a mid-flight title edit does not leak into
+    // poll 1's cache key — it triggers its own promptMetaChanged regen on a later poll instead.
+    const initialMeta = computePromptMetaHash(initialPr);
+    await cacheNarrative('o', 'r', 1, newSha, initialMeta, providerKey, baseNarrative);
 
     let releaseDiff!: () => void;
     const diffGate = new Promise<void>((res) => {
@@ -706,12 +706,13 @@ describe('GET /api/events — polling cycle', () => {
     // Mid-flight: someone edits the PR title.
     state.pr = editedPr;
 
-    // Second poll: should hit the regen guard and skip — but still emit 'pr'
-    // for the title change so the UI doesn't go stale.
+    // Second poll: should hit the regen guard and skip. The standalone 'pr' event is suppressed
+    // while a regen is in flight (mutating ctx.pr mid-regen would race the snapshot committed on
+    // success); the title edit converges via its own promptMetaChanged regen on a later poll.
     await capturedIntervalCb!();
     let events = (await reader.drain(50)) as SseEvent[];
     expect(events.filter((e) => e.event === 'regenerating')).toHaveLength(1);
-    expect(events.find((e) => e.event === 'pr')).toBeDefined();
+    expect(events.find((e) => e.event === 'pr')).toBeUndefined();
 
     // Let the first regen finish.
     releaseDiff();

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -254,7 +254,8 @@ async function reviewCommand(prArg: string | undefined): Promise<number> {
   const { app, broadcast, refreshRepoContext, blastRadius } = createServer(ctx);
   const portFlag = Bun.argv.find((f) => f.startsWith('--port='));
   const port = portFlag ? parseInt(portFlag.split('=')[1] ?? '0') : 0;
-  const server = Bun.serve({ fetch: app.fetch, port, idleTimeout: 255 });
+  // Loopback only: the server has no auth and serves private data (session prompts, billable AI routes).
+  const server = Bun.serve({ fetch: app.fetch, port, hostname: '127.0.0.1', idleTimeout: 255 });
   const url = `http://localhost:${server.port}`;
 
   if (cached) {

--- a/packages/cli/src/daemon/app.ts
+++ b/packages/cli/src/daemon/app.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono';
 import { serveStatic } from 'hono/bun';
 import { dirname, resolve } from 'path';
 import { type OnConfigChange, registerConfigRoutes } from '../config-api';
+import { localOnly } from '../local-only';
 import type { PostCommentOptions } from '../github/client';
 import { mapCommentsToChapters } from '../github/comments';
 import { parsePrRef } from '../github/pr-ref';
@@ -169,6 +170,7 @@ function resolveWebDist(override?: string): string {
 export function createDaemonApp(deps: DaemonAppDeps): { app: Hono } {
   const { store, hub, ai, wiring } = deps;
   const app = new Hono();
+  app.use('*', localOnly);
   const broadcast = hub.broadcast;
   // Single-flight state for POST /api/poll: concurrent manual refreshes share one in-flight poll.
   let inflight: Promise<{ minted: number; resurfaced: number; removed: number }> | null = null;

--- a/packages/cli/src/daemon/daemon.ts
+++ b/packages/cli/src/daemon/daemon.ts
@@ -545,7 +545,8 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<number> {
 
   let server: ReturnType<typeof Bun.serve>;
   try {
-    server = Bun.serve({ fetch: app.fetch, port, idleTimeout: 255 });
+    // Loopback only — same posture as the per-PR server: no auth, private data.
+    server = Bun.serve({ fetch: app.fetch, port, hostname: '127.0.0.1', idleTimeout: 255 });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`\n  ${a.red}${a.bold}error:${a.reset} could not bind port ${port}: ${msg}`);

--- a/packages/cli/src/local-only.ts
+++ b/packages/cli/src/local-only.ts
@@ -1,0 +1,20 @@
+import type { Context, Next } from 'hono';
+
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
+
+/**
+ * Reject requests whose Host header isn't a loopback name. The servers bind 127.0.0.1, but a DNS
+ * rebinding page (attacker domain re-pointed at 127.0.0.1) is same-origin to the browser and could
+ * otherwise read responses — including /api/trace/intent, which serves local session prompts. A Host
+ * check breaks that: the rebound request carries the attacker's hostname.
+ */
+export async function localOnly(c: Context, next: Next): Promise<Response | void> {
+  const host = c.req.header('host');
+  // No Host header means a non-browser client (curl, in-process tests). The rebinding attack needs a
+  // browser, and browsers always send Host — so only a present-but-foreign Host is rejected.
+  if (host !== undefined) {
+    const name = host.replace(/:\d+$/, '').toLowerCase();
+    if (!LOCAL_HOSTNAMES.has(name)) return c.text('Forbidden', 403);
+  }
+  await next();
+}

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -5,6 +5,7 @@ import { Hono } from 'hono';
 import { serveStatic } from 'hono/bun';
 import { dirname, resolve } from 'path';
 import { registerConfigRoutes } from './config-api';
+import { localOnly } from './local-only';
 import { readConfig } from './config';
 import type { GitHubClient } from './github/client';
 import { mapCommentsToChapters } from './github/comments';
@@ -104,6 +105,7 @@ function validateSseData(event: SseEventName, data: unknown): void {
 
 export function createServer(ctx: ServerContext) {
   const app = new Hono();
+  app.use('*', localOnly);
   type SseClient = <E extends SseEventName>(event: E, data: SseDataFor<E>) => void;
   const sseClients = new Set<SseClient>();
   let hadClients = false;
@@ -421,6 +423,12 @@ export function createServer(ctx: ServerContext) {
         }
 
         let regenerating = false;
+        // Failure backoff: a regen that threw must not retry every poll tick (each retry is an LLM
+        // call), but it must not pin the PR forever either. Retry when the head moves again or the
+        // cool-down passes. ponytail: fixed 5-minute cool-down; make it configurable if it ever matters.
+        let regenFailedSha: string | null = null;
+        let regenFailedAt = 0;
+        const REGEN_RETRY_MS = 5 * 60_000;
         const interval = setInterval(async () => {
           try {
             const gh = ctx.github;
@@ -437,8 +445,10 @@ export function createServer(ctx: ServerContext) {
             const otherMetaChanged = freshPr.draft !== ctx.pr.draft || freshPr.state !== ctx.pr.state;
             // If the regen branch below will fire, it'll broadcast the fresh PR
             // alongside the new narrative — skip the standalone 'pr' event then.
+            // Also skip while a regen is in flight: mutating ctx.pr mid-regen would race the
+            // snapshot the regen commits on success; the edit converges via its own regen next poll.
             const willRegenerate = (shaChanged || promptMetaChanged) && !regenerating;
-            if ((promptMetaChanged || otherMetaChanged) && !shaChanged && !willRegenerate) {
+            if ((promptMetaChanged || otherMetaChanged) && !shaChanged && !willRegenerate && !regenerating) {
               ctx.pr = freshPr;
               send('pr', ctx.pr);
             }
@@ -474,7 +484,8 @@ export function createServer(ctx: ServerContext) {
             }
             const round = recomputeReviewRound(freshCommits);
 
-            if ((shaChanged || promptMetaChanged) && !regenerating) {
+            const regenCoolingDown = regenFailedSha === freshPr.headSha && Date.now() - regenFailedAt < REGEN_RETRY_MS;
+            if ((shaChanged || promptMetaChanged) && !regenerating && !regenCoolingDown) {
               regenerating = true;
               const prevSha = ctx.headSha.slice(0, 7);
               const newSha = freshPr.headSha.slice(0, 7);
@@ -496,33 +507,37 @@ export function createServer(ctx: ServerContext) {
                 const prevTldr = ctx.narrative?.tldr;
                 const prevChapterTitles = ctx.narrative?.chapters.map((ch) => ch.title) ?? [];
 
-                ctx.pr = freshPr;
+                // Everything fresh stays in locals until generation succeeds. A throw below must leave
+                // ctx on the previously served (mutually consistent) state — advancing ctx.headSha early
+                // would make the next poll see "no change" and never retry, and pairing the old
+                // narrative with fresh files would mis-anchor every diff section.
+                const freshHeadSha = shaChanged ? freshPr.headSha : ctx.headSha;
                 let freshFiles = ctx.files;
                 if (shaChanged) {
-                  ctx.headSha = freshPr.headSha;
-                  freshFiles = await gh.getDiff(ctx.owner, ctx.repo, ctx.pr.number);
-                  ctx.files = freshFiles;
+                  freshFiles = await gh.getDiff(ctx.owner, ctx.repo, freshPr.number);
                 }
 
                 const config = await readConfig();
-                const metaHash = computePromptMetaHash(ctx.pr);
+                const metaHash = computePromptMetaHash(freshPr);
                 const providerKey = await resolveProviderKey(config);
                 const cached = await getCachedNarrative(
                   ctx.owner,
                   ctx.repo,
-                  ctx.pr.number,
-                  ctx.headSha,
+                  freshPr.number,
+                  freshHeadSha,
                   metaHash,
                   providerKey,
                 );
+                let freshNarrative: NarrativeResponse;
+                let freshCapStats: PromptCapStats | null;
                 if (cached) {
                   // The cached narrative was anchored against a prior diff; the SHA just changed and
                   // `freshFiles` may have shifted hunk indices. Re-resolve via content anchors so refs
                   // survive the reshape instead of dropping.
-                  ctx.narrative = reanchorNarrative(cached, freshFiles);
+                  freshNarrative = reanchorNarrative(cached, freshFiles);
                   // A cached narrative carries no budget stats, and inventing them would tell the
                   // reviewer a story built from a truncated diff was complete.
-                  ctx.capStats = null;
+                  freshCapStats = null;
                   console.log(`  \x1b[38;5;78m✓\x1b[0m Using cached narrative \x1b[2m(${newSha})\x1b[0m`);
                 } else {
                   const regenStartedAt = Date.now();
@@ -544,7 +559,7 @@ export function createServer(ctx: ServerContext) {
                   // Same resolution the CLI does before its first generation: the prompt builders call
                   // `computeRisk` synchronously, so the snapshot has to be in hand first. Warm on the
                   // regenerate path (the CLI fetched it at startup), so this is normally a cache read.
-                  const repoContext = await resolveRepoContext(gh, ctx.owner, ctx.repo, ctx.pr.base);
+                  const repoContext = await resolveRepoContext(gh, ctx.owner, ctx.repo, freshPr.base);
                   // Same snapshot the prompt was built from now backs collapse selection, so the
                   // boundary the reviewer sees describes the narrative they are reading.
                   ctx.repoContext = repoContext;
@@ -555,7 +570,7 @@ export function createServer(ctx: ServerContext) {
                   let provider: string;
                   try {
                     const result = await generateNarrative(
-                      ctx.pr,
+                      freshPr,
                       freshFiles,
                       [],
                       config,
@@ -568,8 +583,8 @@ export function createServer(ctx: ServerContext) {
                         cacheKey: {
                           owner: ctx.owner,
                           repo: ctx.repo,
-                          number: ctx.pr.number,
-                          sha: ctx.headSha,
+                          number: freshPr.number,
+                          sha: freshHeadSha,
                           metaHash,
                           providerKey,
                         },
@@ -581,7 +596,7 @@ export function createServer(ctx: ServerContext) {
                         onPartial: (partial) => {
                           broadcast('narrative.partial', {
                             narrative: partial,
-                            pr: ctx.pr,
+                            pr: freshPr,
                             files: freshFiles,
                             comments: ctx.comments,
                           });
@@ -596,17 +611,17 @@ export function createServer(ctx: ServerContext) {
                     );
                     generated = result.narrative;
                     provider = result.provider;
-                    ctx.capStats = result.capStats ?? null;
+                    freshCapStats = result.capStats ?? null;
                   } finally {
                     clearInterval(heartbeat);
                     if (isTty) process.stdout.write('\r\x1b[2K');
                   }
-                  ctx.narrative = generated;
+                  freshNarrative = generated;
                   await cacheNarrative(
                     ctx.owner,
                     ctx.repo,
-                    ctx.pr.number,
-                    ctx.headSha,
+                    freshPr.number,
+                    freshHeadSha,
                     metaHash,
                     providerKey,
                     generated,
@@ -615,6 +630,15 @@ export function createServer(ctx: ServerContext) {
                     `  \x1b[38;5;78m✓\x1b[0m ${generated.chapters.length} chapters regenerated \x1b[2mvia ${provider} in ${fmtRegenElapsed()}\x1b[0m`,
                   );
                 }
+
+                // Success: commit the fresh state atomically — narrative, files, and PR always describe
+                // the same head.
+                ctx.pr = freshPr;
+                ctx.headSha = freshHeadSha;
+                ctx.files = freshFiles;
+                ctx.narrative = freshNarrative;
+                ctx.capStats = freshCapStats;
+                regenFailedSha = null;
 
                 // The narrative now describes the new head, so that head is the narrated SHA. Recompute
                 // the round against it (carry-over collapses to 0 once head == narrated) and ship it with
@@ -636,18 +660,35 @@ export function createServer(ctx: ServerContext) {
                 });
               } catch (err) {
                 const msg = err instanceof Error ? err.message : String(err);
-                // generateNarrative threw before assigning ctx.narrative, so ctx still holds the prior
-                // (last successfully served) narrative. If a sealed last-good revision exists for this
-                // PR, keep serving what the reviewer already has instead of surfacing a fatal error to
-                // the UI — a failed regen must not blank the tab.
-                const lastGood = await getLastGoodNarrative(ctx.owner, ctx.repo, ctx.pr.number);
-                if (lastGood) {
-                  console.warn(`  \x1b[38;5;221m⚠\x1b[0m Regeneration failed (${msg}); keeping last-good narrative.`);
+                // ctx was never advanced (locals above), so it still holds the prior mutually
+                // consistent narrative+files. Record the failed head so the poll backs off instead of
+                // burning an LLM call every tick, then keep serving what the reviewer already has —
+                // a failed regen must not blank the tab.
+                regenFailedSha = freshPr.headSha;
+                regenFailedAt = Date.now();
+                if (ctx.narrative) {
+                  console.warn(`  \x1b[38;5;221m⚠\x1b[0m Regeneration failed (${msg}); keeping current narrative.`);
                 } else {
-                  console.error(`  \x1b[38;5;204m✗\x1b[0m Regeneration failed: ${msg}`);
-                  // The terminal log is invisible to the browser tab, which otherwise keeps showing stale
-                  // content with no hint that the refresh failed. Push the error so the UI can surface it.
-                  broadcast('narrative-error', { message: msg });
+                  // Nothing in memory to keep serving — fall back to the sealed revision log before
+                  // surfacing a fatal error.
+                  const lastGood = await getLastGoodNarrative(ctx.owner, ctx.repo, ctx.pr.number);
+                  if (lastGood) {
+                    ctx.narrative = reanchorNarrative(lastGood.narrative, ctx.files);
+                    console.warn(`  \x1b[38;5;221m⚠\x1b[0m Regeneration failed (${msg}); serving last-good narrative.`);
+                    broadcast('narrative', {
+                      narrative: ctx.narrative,
+                      pr: ctx.pr,
+                      files: ctx.files,
+                      comments: mapCommentsToChapters(ctx.comments, ctx.narrative),
+                      ...blastRadius(),
+                    });
+                  } else {
+                    console.error(`  \x1b[38;5;204m✗\x1b[0m Regeneration failed: ${msg}`);
+                    // The terminal log is invisible to the browser tab, which otherwise keeps showing
+                    // stale content with no hint that the refresh failed. Push the error so the UI can
+                    // surface it.
+                    broadcast('narrative-error', { message: msg });
+                  }
                 }
               } finally {
                 regenerating = false;

--- a/packages/cli/src/trace/local-sessions.ts
+++ b/packages/cli/src/trace/local-sessions.ts
@@ -148,9 +148,13 @@ export async function findMatchingSessions(opts: FindMatchingSessionsOptions): P
     if (opts.branch && meta.branch && meta.branch === opts.branch) score += SCORE_BRANCH;
     if (meta.cwd && hints.includes(basename(meta.cwd).toLowerCase())) score += SCORE_CWD;
     if (countFileMatches(text, opts.changedFiles) >= 2) score += SCORE_FILES;
+    // Recency is a tiebreaker, never an identity: without at least one identity rung (branch, cwd,
+    // or file overlap), a session from an unrelated project would qualify purely by being recent —
+    // and its private prompts would surface on the wrong PR.
+    const hasIdentity = score > 0;
     if (opts.since && meta.endedAt && Date.parse(meta.endedAt) >= opts.since.getTime()) score += SCORE_RECENCY;
 
-    if (score <= 0) continue;
+    if (!hasIdentity) continue;
 
     candidates.push({
       sessionId: meta.sessionId || basename(file, '.jsonl'),

--- a/packages/web/src/hooks/__tests__/useLiveStream.test.ts
+++ b/packages/web/src/hooks/__tests__/useLiveStream.test.ts
@@ -52,7 +52,9 @@ describe('handleNarrativePartialEvent', () => {
 
   it('applies partial narrative payloads to the store', () => {
     const before = useReviewStore.getState().lastEventAt;
-    handleNarrativePartialEvent(mkMessageEvent({ pr: mkPr(), narrative: mkNarrative('streamed-title') }));
+    handleNarrativePartialEvent(
+      mkMessageEvent({ pr: mkPr(), narrative: mkNarrative('streamed-title'), files: [], comments: [] }),
+    );
     const after = useReviewStore.getState();
     expect(after.narrative?.title).toBe('streamed-title');
     expect(after.pr?.number).toBe(1);
@@ -69,9 +71,11 @@ describe('handleNarrativePartialEvent', () => {
   });
 
   it('preserves user-set chapter states across partial updates', () => {
-    handleNarrativePartialEvent(mkMessageEvent({ pr: mkPr(), narrative: mkNarrative() }));
+    handleNarrativePartialEvent(mkMessageEvent({ pr: mkPr(), narrative: mkNarrative(), files: [], comments: [] }));
     useReviewStore.setState({ chapterStates: { 'ch-0': 'reviewed' } });
-    handleNarrativePartialEvent(mkMessageEvent({ pr: mkPr(), narrative: mkNarrative('updated') }));
+    handleNarrativePartialEvent(
+      mkMessageEvent({ pr: mkPr(), narrative: mkNarrative('updated'), files: [], comments: [] }),
+    );
     expect(useReviewStore.getState().chapterStates['ch-0']).toBe('reviewed');
     expect(useReviewStore.getState().narrative?.title).toBe('updated');
   });

--- a/packages/web/src/hooks/useLiveStream.ts
+++ b/packages/web/src/hooks/useLiveStream.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { type SseEvent, sseEventSchema } from '@diffdad/contracts';
 import { useReviewStore } from '../state/review-store';
-import type { CheckRun, LiveEvent, LiveEventKind, PRReview } from '../state/types';
+import type { CheckRun, LiveEvent, LiveEventKind } from '../state/types';
 import type { ConfigResponse } from '../lib/config-client';
 
 /** The `data` payload type for a given SSE event name, drawn from the contract union. */


### PR DESCRIPTION
Review-sweep findings on the stack, fixed together because they share the regen path and the local-server trust posture:

- **Regen state race:** regeneration advanced `ctx.headSha`/`files`/`pr` before generating; a throw left the next poll seeing 'no change', permanently pinning the PR to a stale narrative paired with fresh files (mis-anchoring every diff section). Fresh state now lives in locals and commits atomically on success. The standalone `pr` SSE event is suppressed mid-regen — an edit converges via its own regen next poll instead of racing the snapshot.
- **Retry policy:** failed regens back off 5 minutes per SHA instead of burning an LLM call every 10s poll tick.
- **Last-good actually serves:** when regen fails with nothing in memory, the sealed last-good revision is served, not just logged.
- **Local trust posture:** both HTTP servers bind `127.0.0.1` and reject foreign `Host` headers — DNS rebinding could otherwise read local endpoints, including session prompts from `/api/trace/intent`.
- **Trace matching:** sessions need an identity rung (branch, cwd, or file overlap); recency alone no longer qualifies, so prompts from unrelated projects can't surface on the wrong PR.