### PR TITLE
feat(server): real thread resolution via the GraphQL reviewThreads API

### DIFF
--- a/packages/cli/src/__tests__/github-client.test.ts
+++ b/packages/cli/src/__tests__/github-client.test.ts
@@ -267,6 +267,79 @@ describe('GitHubClient.getComments', () => {
   });
 });
 
+describe('GitHubClient.getReviewThreadResolution', () => {
+  function threadsPage(
+    nodes: Array<{ isResolved: boolean; ids: number[] }>,
+    page: { hasNextPage: boolean; endCursor: string | null } = { hasNextPage: false, endCursor: null },
+  ) {
+    return {
+      data: {
+        repository: {
+          pullRequest: {
+            reviewThreads: {
+              pageInfo: page,
+              nodes: nodes.map((n) => ({
+                isResolved: n.isResolved,
+                comments: { nodes: n.ids.map((id) => ({ databaseId: id })) },
+              })),
+            },
+          },
+        },
+      },
+    };
+  }
+
+  it('maps every comment databaseId to its thread resolution state', async () => {
+    setResponder((call) => {
+      expect(call.url).toBe('https://api.github.com/graphql');
+      expect(call.init.method).toBe('POST');
+      return jsonResponse(
+        threadsPage([
+          { isResolved: true, ids: [1, 2] },
+          { isResolved: false, ids: [3] },
+        ]),
+      );
+    });
+    const map = await new GitHubClient('t').getReviewThreadResolution('o', 'r', 5);
+    expect(map).not.toBeNull();
+    expect(map!.get(1)).toBe(true);
+    expect(map!.get(2)).toBe(true);
+    expect(map!.get(3)).toBe(false);
+    expect(map!.size).toBe(3);
+  });
+
+  it('forwards the endCursor when a second page is available', async () => {
+    let page = 0;
+    setResponder(() => {
+      page++;
+      if (page === 1) {
+        return jsonResponse(
+          threadsPage([{ isResolved: false, ids: [1] }], { hasNextPage: true, endCursor: 'CURSOR2' }),
+        );
+      }
+      return jsonResponse(threadsPage([{ isResolved: true, ids: [2] }]));
+    });
+    const map = await new GitHubClient('t').getReviewThreadResolution('o', 'r', 5);
+    expect(map!.get(1)).toBe(false);
+    expect(map!.get(2)).toBe(true);
+    expect(calls).toHaveLength(2);
+    expect(JSON.parse(String(calls[1]?.init.body)).variables.cursor).toBe('CURSOR2');
+    expect(JSON.parse(String(calls[0]?.init.body)).variables.cursor).toBeNull();
+  });
+
+  it('returns null when GraphQL responds with an errors array', async () => {
+    setResponder(() => jsonResponse({ data: null, errors: [{ message: 'Bad credentials' }] }));
+    expect(await new GitHubClient('t').getReviewThreadResolution('o', 'r', 5)).toBeNull();
+  });
+
+  it('returns null on a network failure', async () => {
+    setResponder(() => {
+      throw new Error('network down');
+    });
+    expect(await new GitHubClient('t').getReviewThreadResolution('o', 'r', 5)).toBeNull();
+  });
+});
+
 describe('GitHubClient.getReviews', () => {
   it('keeps only the latest review per user', async () => {
     setResponder(() =>

--- a/packages/cli/src/__tests__/review-round.test.ts
+++ b/packages/cli/src/__tests__/review-round.test.ts
@@ -168,6 +168,87 @@ describe('answered-thread heuristic', () => {
   });
 });
 
+describe('reviewThreads resolution map (GraphQL isResolved)', () => {
+  test('a resolved thread wins over the last-word heuristic', () => {
+    // Reviewer got the last word -> heuristic would call this unresolved; GitHub says resolved.
+    const round = deriveReviewRound({
+      headSha: 'a',
+      lastNarratedSha: 'a',
+      comments: [comment({ id: 1, author: REVIEWER, createdAt: '2024-01-01T00:00:00Z' })],
+      reviews: [],
+      prAuthor: AUTHOR,
+      resolutionByCommentId: new Map([[1, true]]),
+    });
+    expect(round.unresolvedThreads).toBe(0);
+  });
+
+  test('an unresolved thread wins over an author last word', () => {
+    // Author replied last -> heuristic would call this answered; GitHub says still open.
+    const round = deriveReviewRound({
+      headSha: 'a',
+      lastNarratedSha: 'a',
+      comments: [
+        comment({ id: 1, author: REVIEWER, createdAt: '2024-01-01T00:00:00Z' }),
+        comment({ id: 2, author: AUTHOR, createdAt: '2024-01-02T00:00:00Z', inReplyToId: 1 }),
+      ],
+      reviews: [],
+      prAuthor: AUTHOR,
+      resolutionByCommentId: new Map([[1, false]]),
+    });
+    expect(round.unresolvedThreads).toBe(1);
+  });
+
+  test('any comment in the thread appearing in the map decides it', () => {
+    // Reviewer got the last word (heuristic unresolved); the map only carries the MIDDLE comment,
+    // and it maps to resolved -> the whole thread is resolved.
+    const round = deriveReviewRound({
+      headSha: 'a',
+      lastNarratedSha: 'a',
+      comments: [
+        comment({ id: 1, author: REVIEWER, createdAt: '2024-01-01T00:00:00Z' }),
+        comment({ id: 2, author: AUTHOR, createdAt: '2024-01-02T00:00:00Z', inReplyToId: 1 }),
+        comment({ id: 3, author: REVIEWER, createdAt: '2024-01-03T00:00:00Z', inReplyToId: 1 }),
+      ],
+      reviews: [],
+      prAuthor: AUTHOR,
+      resolutionByCommentId: new Map([[2, true]]),
+    });
+    expect(round.unresolvedThreads).toBe(0);
+  });
+
+  test('a partial map decides covered threads and leaves the rest to the heuristic', () => {
+    const round = deriveReviewRound({
+      headSha: 'a',
+      lastNarratedSha: 'a',
+      comments: [
+        // Thread A: reviewer-only (heuristic unresolved) but the map marks it resolved.
+        comment({ id: 1, author: REVIEWER, createdAt: '2024-01-01T00:00:00Z', path: 'src/a.ts' }),
+        // Thread B: reviewer-only, absent from the map -> heuristic keeps it unresolved.
+        comment({ id: 2, author: REVIEWER, createdAt: '2024-01-01T00:00:00Z', path: 'src/b.ts' }),
+      ],
+      reviews: [],
+      prAuthor: AUTHOR,
+      resolutionByCommentId: new Map([[1, true]]),
+    });
+    expect(round.unresolvedThreads).toBe(1);
+  });
+
+  test('carriedOver honors the same per-thread resolution decision', () => {
+    // Head advanced past the narrated SHA, no commit timestamps -> every unresolved thread would carry
+    // over. The map resolves the only thread, so both counts collapse to zero.
+    const round = deriveReviewRound({
+      headSha: 'b',
+      lastNarratedSha: 'a',
+      comments: [comment({ id: 1, author: REVIEWER, createdAt: '2024-01-01T00:00:00Z' })],
+      reviews: [],
+      prAuthor: AUTHOR,
+      resolutionByCommentId: new Map([[1, true]]),
+    });
+    expect(round.unresolvedThreads).toBe(0);
+    expect(round.carriedOverThreads).toBe(0);
+  });
+});
+
 describe('carriedOverThreads', () => {
   test('is zero when head has not moved past the narrated SHA', () => {
     const round = deriveReviewRound({

--- a/packages/cli/src/__tests__/server-sse.test.ts
+++ b/packages/cli/src/__tests__/server-sse.test.ts
@@ -168,6 +168,7 @@ type GhStub = {
   getCheckRuns: (...args: unknown[]) => Promise<CheckRun[]>;
   getReviews: (...args: unknown[]) => Promise<PRReview[]>;
   getDiff: (...args: unknown[]) => Promise<DiffFile[]>;
+  getReviewThreadResolution?: (...args: unknown[]) => Promise<Map<number, boolean> | null>;
 };
 
 function defaultGh(state: {
@@ -183,6 +184,7 @@ function defaultGh(state: {
     getCheckRuns: async () => state.checks ?? [],
     getReviews: async () => state.reviews ?? [],
     getDiff: async () => state.files ?? [],
+    getReviewThreadResolution: async () => null,
   };
 }
 
@@ -683,6 +685,7 @@ describe('GET /api/events — polling cycle', () => {
       getComments: async () => [],
       getCheckRuns: async () => [],
       getReviews: async () => [],
+      getReviewThreadResolution: async () => null,
       getDiff: async () => {
         await diffGate;
         return [];
@@ -738,6 +741,7 @@ describe('GET /api/events — polling cycle', () => {
       getComments: async () => [],
       getCheckRuns: async () => [],
       getReviews: async () => [],
+      getReviewThreadResolution: async () => null,
       getDiff: async () => [],
     };
     const ctx = mkContext({ github: gh as unknown as GitHubClient });

--- a/packages/cli/src/github/client.ts
+++ b/packages/cli/src/github/client.ts
@@ -401,6 +401,76 @@ export class GitHubClient {
     return [...latestByUser.values()];
   }
 
+  /**
+   * Map every review comment's `databaseId` to its thread's GitHub resolution state (`isResolved`),
+   * the real signal the last-word heuristic only approximates. GraphQL-only (the REST API doesn't
+   * expose thread resolution), so it stands apart from the calls above.
+   *
+   * Returns null on ANY failure \u2014 a GraphQL `errors` array, an unexpected/missing shape, a token
+   * without the scope the GraphQL API needs, or a network throw. The caller falls back to the
+   * heuristic, so a resolution lookup can degrade but never blocks.
+   *
+   * ponytail: capped at 3 pages / 300 threads. A PR with more review threads than that keeps the
+   * heuristic for the overflow rather than fanning unbounded GraphQL pages out on every poll.
+   */
+  async getReviewThreadResolution(owner: string, repo: string, number: number): Promise<Map<number, boolean> | null> {
+    const query = `query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          reviewThreads(first: 100, after: $cursor) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              isResolved
+              comments(first: 50) { nodes { databaseId } }
+            }
+          }
+        }
+      }
+    }`;
+
+    const out = new Map<number, boolean>();
+    let cursor: string | null = null;
+    try {
+      for (let page = 0; page < 3; page++) {
+        const res = await this.fetch('https://api.github.com/graphql', {
+          method: 'POST',
+          body: JSON.stringify({ query, variables: { owner, repo, number, cursor } }),
+          headers: { 'Content-Type': 'application/json' },
+        });
+        const json = (await res.json()) as {
+          data?: {
+            repository?: {
+              pullRequest?: {
+                reviewThreads?: {
+                  pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+                  nodes?: Array<{
+                    isResolved?: boolean;
+                    comments?: { nodes?: Array<{ databaseId?: number | null }> };
+                  }>;
+                };
+              };
+            };
+          };
+          errors?: unknown[];
+        };
+        if (Array.isArray(json.errors) && json.errors.length > 0) return null;
+        const threads = json.data?.repository?.pullRequest?.reviewThreads;
+        if (!threads || !Array.isArray(threads.nodes)) return null;
+        for (const thread of threads.nodes) {
+          const resolved = thread.isResolved === true;
+          for (const c of thread.comments?.nodes ?? []) {
+            if (typeof c.databaseId === 'number') out.set(c.databaseId, resolved);
+          }
+        }
+        if (!threads.pageInfo?.hasNextPage || !threads.pageInfo.endCursor) break;
+        cursor = threads.pageInfo.endCursor;
+      }
+      return out;
+    } catch {
+      return null;
+    }
+  }
+
   async submitReview(
     owner: string,
     repo: string,

--- a/packages/cli/src/review-round.ts
+++ b/packages/cli/src/review-round.ts
@@ -24,6 +24,13 @@ export type DeriveReviewRoundInput = {
    * through from the PR metadata.
    */
   prAuthor: string;
+  /**
+   * GitHub's real per-thread resolution state, keyed by comment `databaseId` (from the GraphQL
+   * `reviewThreads` API). When present, a thread whose comments appear here is decided by GitHub
+   * (resolved iff any of its comments maps to `true`), overriding the last-word heuristic. Threads
+   * with no comment in the map still fall back to the heuristic. Omitted entirely = pure heuristic.
+   */
+  resolutionByCommentId?: Map<number, boolean>;
 };
 
 /**
@@ -38,9 +45,9 @@ export type DeriveReviewRoundInput = {
  * With no reviews at all, the round is `awaiting-review`.
  */
 export function deriveReviewRound(input: DeriveReviewRoundInput): ReviewRound {
-  const { headSha, lastNarratedSha, comments, reviews, commits = [], prAuthor } = input;
+  const { headSha, lastNarratedSha, comments, reviews, commits = [], prAuthor, resolutionByCommentId } = input;
 
-  const threads = groupInlineThreads(comments, prAuthor);
+  const threads = groupInlineThreads(comments, prAuthor, resolutionByCommentId);
   const unresolvedThreads = threads.filter((t) => t.unresolved).length;
 
   // Only submitted reviews carry a decision; PENDING is a draft the author hasn't sent, DISMISSED is a
@@ -91,13 +98,21 @@ type InlineThread = { rootId: number; rootCreatedAt: string; unresolved: boolean
  * Group inline review comments into threads: a root is an inline comment (has `path`) with no
  * `inReplyToId`; replies chain to it via `inReplyToId`. Non-inline (PR-level) comments are ignored.
  *
- * ponytail: "unresolved" here is a heuristic, not GitHub's real resolution state. GitHub only exposes
- * thread resolution through the GraphQL `reviewThreads` API (`isResolved`), which diff dad doesn't use.
- * We approximate: a thread is answered when its LAST comment is by the PR author, otherwise unresolved.
- * A reviewer marking a thread resolved on GitHub won't clear it here, and an author's reply that doesn't
- * actually resolve anything will. Swap this for `reviewThreads.isResolved` when GraphQL lands.
+ * Resolution precedence: when `resolution` carries GitHub's real `isResolved` (keyed by comment
+ * databaseId), any thread with a comment in that map is decided by GitHub (resolved iff any of its
+ * comments maps to `true`). Two ceilings remain where the heuristic still runs:
+ *   1. Pagination cap — the GraphQL fetch stops at 3 pages / 300 threads, so threads past that cap
+ *      carry no map entry and fall back here.
+ *   2. Per-thread fallback — a thread with no comment in the map (map omitted, or a partial map that
+ *      never covers this thread) is answered when its LAST comment is by the PR author, otherwise
+ *      unresolved. A reviewer marking such a thread resolved on GitHub won't clear it, and an author's
+ *      reply that doesn't actually resolve anything will.
  */
-function groupInlineThreads(comments: PRComment[], prAuthor: string): InlineThread[] {
+function groupInlineThreads(
+  comments: PRComment[],
+  prAuthor: string,
+  resolution?: Map<number, boolean>,
+): InlineThread[] {
   const byId = new Map<number, PRComment>(comments.map((c) => [c.id, c]));
 
   function rootOf(c: PRComment): PRComment {
@@ -124,7 +139,10 @@ function groupInlineThreads(comments: PRComment[], prAuthor: string): InlineThre
     const sorted = [...members].sort((a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt));
     const last = sorted[sorted.length - 1]!;
     const root = byId.get(rootId)!;
-    threads.push({ rootId, rootCreatedAt: root.createdAt, unresolved: last.author !== prAuthor });
+    const mapped = resolution ? sorted.map((c) => c.id).filter((id) => resolution.has(id)) : [];
+    const unresolved =
+      mapped.length > 0 ? !mapped.some((id) => resolution!.get(id) === true) : last.author !== prAuthor;
+    threads.push({ rootId, rootCreatedAt: root.createdAt, unresolved });
   }
   return threads;
 }

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -68,6 +68,12 @@ export type ServerContext = {
   /** Last derived review-round status, cached so the poll only broadcasts `review-round` when it changes. */
   reviewRound?: ReviewRound | null;
   /**
+   * GitHub's real per-thread resolution state (comment `databaseId` -> `isResolved`), fetched via
+   * GraphQL and fed to `deriveReviewRound`. `undefined`/`null` means the derivation falls back to the
+   * last-word heuristic — either never fetched, the fetch failed, or the last-known map went stale.
+   */
+  reviewThreadResolution?: Map<number, boolean> | null;
+  /**
    * Local authoring-session intent, mined once per server process from ~/.claude/projects. `undefined`
    * means not looked yet; an empty array means looked and found nothing (feature stays invisible).
    */
@@ -91,6 +97,13 @@ type PostCommentBody = {
  * malformed payload must still reach the wire so the bug is observable in the browser, not swallowed.
  */
 const SSE_VALIDATE = Boolean(process.env.DIFFDAD_DEBUG);
+
+/**
+ * How long a last-known review-thread resolution map survives after a GraphQL fetch starts failing.
+ * Until then the poll keeps serving the stale map (better than snapping back to the heuristic on one
+ * transient failure); past it, the map is dropped so the round falls back to the heuristic.
+ */
+const RESOLUTION_STALE_MS = 5 * 60_000;
 function validateSseData(event: SseEventName, data: unknown): void {
   const schema = sseDataSchemaFor(event);
   if (!schema) {
@@ -125,6 +138,7 @@ export function createServer(ctx: ServerContext) {
       reviews: ctx.reviews,
       commits,
       prAuthor: ctx.pr.author.login,
+      ...(ctx.reviewThreadResolution ? { resolutionByCommentId: ctx.reviewThreadResolution } : {}),
     });
     const changed = JSON.stringify(round) !== JSON.stringify(ctx.reviewRound ?? null);
     ctx.reviewRound = round;
@@ -429,6 +443,13 @@ export function createServer(ctx: ServerContext) {
         let regenFailedSha: string | null = null;
         let regenFailedAt = 0;
         const REGEN_RETRY_MS = 5 * 60_000;
+        // Review-thread resolution fetch state. The GraphQL call is expensive relative to the 10s tick,
+        // so it only fires on the first poll and whenever the comment set or review signature changes —
+        // never on idle ticks. `resolutionFailedAt` marks when the last-known map started going stale.
+        let resolutionInitialDone = false;
+        let resolutionCommentSig = '';
+        let resolutionReviewSig = '';
+        let resolutionFailedAt: number | null = null;
         const interval = setInterval(async () => {
           try {
             const gh = ctx.github;
@@ -482,6 +503,37 @@ export function createServer(ctx: ServerContext) {
             } catch {
               // degrade the round (no push boundary) rather than aborting the poll
             }
+            // Thread resolution is the one signal only GraphQL carries. Refetch only when the inputs
+            // that could change it moved (a new/removed comment, or a review submitted) or once at
+            // startup; idle ticks reuse the cached map so the poll stays a single REST round-trip.
+            const commentSig = [...freshIds].sort((a, b) => a - b).join(',');
+            const reviewSig = freshReviews
+              .map((r) => `${r.id}:${r.state}:${r.submittedAt}`)
+              .sort()
+              .join('|');
+            if (!resolutionInitialDone || commentSig !== resolutionCommentSig || reviewSig !== resolutionReviewSig) {
+              resolutionInitialDone = true;
+              resolutionCommentSig = commentSig;
+              resolutionReviewSig = reviewSig;
+              const map = await gh.getReviewThreadResolution(ctx.owner, ctx.repo, ctx.pr.number);
+              if (map) {
+                ctx.reviewThreadResolution = map;
+                resolutionFailedAt = null;
+              } else if (resolutionFailedAt === null) {
+                // Keep the last-known map for now; start the staleness clock.
+                resolutionFailedAt = Date.now();
+              }
+            }
+            // Once a failed fetch has gone unrecovered past the stale window, drop the map so the round
+            // falls back to the heuristic instead of trusting an increasingly old snapshot.
+            if (
+              resolutionFailedAt !== null &&
+              ctx.reviewThreadResolution &&
+              Date.now() - resolutionFailedAt > RESOLUTION_STALE_MS
+            ) {
+              ctx.reviewThreadResolution = null;
+            }
+
             const round = recomputeReviewRound(freshCommits);
 
             const regenCoolingDown = regenFailedSha === freshPr.headSha && Date.now() - regenFailedAt < REGEN_RETRY_MS;


### PR DESCRIPTION
Thread resolution was approximated by 'the PR author had the last
word' — wrong when an author says 'fixed, PTAL' without resolving,
when a bot comments last, or when a reviewer resolves silently in the
GitHub UI. The review-round derivation now uses ground truth:

- getReviewThreadResolution() maps every thread comment databaseId to
  its thread's isResolved via GraphQL (paginated, capped at 300
  threads)
- deriveReviewRound prefers the map per thread; threads absent from
  the map (or a failed fetch) fall back to the heuristic
- the poll refetches only when the comment set or review signature
  changes; a failed fetch keeps the last-known map for 5 minutes
- unresolvedThreads and carriedOverThreads share the same decision