### PR TITLE
feat: verified trace quotes, staleness banner, and re-narrate

### DIFF
--- a/packages/cli/src/__tests__/server-sse.test.ts
+++ b/packages/cli/src/__tests__/server-sse.test.ts
@@ -727,6 +727,59 @@ describe('GET /api/events — polling cycle', () => {
     await cleanFixtureCache(newSha);
   });
 
+  it('POST /api/renarrate forces a regeneration on the next poll even when the SHA is unchanged', async () => {
+    const { cacheNarrative, computePromptMetaHash } = await import('../narrative/cache');
+    const { resolveProviderKey } = await import('../narrative/engine');
+    const { readConfig } = await import('../config');
+    const providerKey = await resolveProviderKey(await readConfig());
+    const sha = `sha-renarrate-${Date.now()}`;
+    const pr = mkPR({ headSha: sha });
+    const metaHash = computePromptMetaHash(pr);
+    // Seed the cache at the current head so the forced regen re-anchors instead of calling the LLM.
+    await cacheNarrative('o', 'r', 1, sha, metaHash, providerKey, { ...baseNarrative, title: 'renarrated' });
+
+    const state = { pr };
+    const ctx = mkContext({
+      headSha: sha,
+      pr: mkPR({ headSha: sha }),
+      narratedSha: sha,
+      github: defaultGh(state) as unknown as GitHubClient,
+    });
+    const { app } = createServer(ctx);
+    const ctrl = new AbortController();
+    const res = await app.request('/api/events', { signal: ctrl.signal });
+    const reader = new StreamReader(res.body!);
+    await reader.drain();
+
+    // Baseline: an unchanged SHA never regenerates on its own.
+    await runPoll();
+    await new Promise((r) => setTimeout(r, 30));
+    let events = (await reader.drain(80)) as SseEvent[];
+    expect(events.find((e) => e.event === 'regenerating')).toBeUndefined();
+
+    // Ask for a forced re-narration.
+    const renarrateRes = await app.request('/api/renarrate', { method: 'POST' });
+    expect(renarrateRes.status).toBe(202);
+    expect(await renarrateRes.json()).toEqual({ queued: true });
+    expect(ctx.renarrateRequested).toBe(true);
+
+    // The next poll tick starts a regeneration even though the SHA hasn't moved.
+    await runPoll();
+    await new Promise((r) => setTimeout(r, 30));
+    events = (await reader.drain(80)) as SseEvent[];
+    expect(events.find((e) => e.event === 'regenerating')).toBeDefined();
+    const narrEvt = events.find((e) => e.event === 'narrative');
+    expect(narrEvt).toBeDefined();
+    expect((narrEvt!.data as { narrative: { title: string } }).narrative.title).toBe('renarrated');
+    // Flag cleared once the attempt started.
+    expect(ctx.renarrateRequested).toBe(false);
+
+    ctrl.abort();
+    await reader.cancel();
+
+    await cleanFixtureCache(sha);
+  });
+
   it('swallows polling errors and keeps the loop alive', async () => {
     let pollCount = 0;
     const gh: GhStub = {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,7 +5,7 @@ import { GitHubClient } from './github/client';
 import { type ParsedPr, parsePrRef } from './github/pr-ref';
 import { cacheNarrative, clearCache, computePromptMetaHash, getCachedNarrative } from './narrative/cache';
 import { generateNarrative, resolveAiPath, resolveProviderKey, setCliOverride } from './narrative/engine';
-import { reanchorNarrative } from './narrative/validator';
+import { reanchorNarrativeWithDrops } from './narrative/validator';
 import { migrateLegacyData } from './paths';
 import { getCachedRecap } from './recap/cache';
 import { describeRepoContext, resolveRepoContext } from './repo/snapshot';
@@ -228,9 +228,17 @@ async function reviewCommand(prArg: string | undefined): Promise<number> {
     : await getCachedNarrative(parsed.owner, parsed.repo, parsed.number, metadata.headSha, metaHash, providerKey);
   const cachedRecap = noCache ? null : await getCachedRecap(parsed.owner, parsed.repo, parsed.number, metadata.headSha);
 
+  // Re-resolve any stale hunk refs against the diff just fetched for this SHA before serving, and
+  // record how many references the cached narrative could not re-anchor.
+  const reanchored = cached ? reanchorNarrativeWithDrops(cached, files) : null;
+  if (reanchored && reanchored.droppedRefs > 0) {
+    console.warn(
+      `\n  ${a.dim}⚠ ${reanchored.droppedRefs} narrative reference(s) could not be re-anchored to the current diff.${a.reset}`,
+    );
+  }
+
   const ctx: ServerContext = {
-    // Re-resolve any stale hunk refs against the diff just fetched for this SHA before serving.
-    narrative: cached ? reanchorNarrative(cached, files) : null,
+    narrative: reanchored ? reanchored.narrative : null,
     pr: metadata,
     files,
     comments,
@@ -242,6 +250,7 @@ async function reviewCommand(prArg: string | undefined): Promise<number> {
     headSha: metadata.headSha,
     // A cached narrative was generated against this head; a fresh generation sets it below once done.
     narratedSha: cached ? metadata.headSha : null,
+    droppedRefs: reanchored ? reanchored.droppedRefs : undefined,
     recap: cachedRecap,
     recapGenerating: false,
     recapError: null,

--- a/packages/cli/src/narrative/cache.ts
+++ b/packages/cli/src/narrative/cache.ts
@@ -22,6 +22,12 @@ export type PromptRelevantMeta = {
   labels: string[];
 };
 
+/** Outcome of re-anchoring a narrative against its diff at seal time. Sealed alongside the revision. */
+export type ValidationSummary = {
+  /** How many code references could not be re-anchored to the diff (0 = the narration fully covers it). */
+  droppedRefs: number;
+};
+
 // Short stable hash over the PR fields the narrative prompt actually consumes.
 // If any of these change on GitHub, the cached narrative is no longer valid.
 export function computePromptMetaHash(meta: PromptRelevantMeta): string {
@@ -121,7 +127,7 @@ export async function cacheNarrative(
   metaHash: string,
   providerKey: string,
   narrative: NarrativeResponse,
-  opts: { cacheDir?: string } = {},
+  opts: { cacheDir?: string; validation?: ValidationSummary } = {},
 ): Promise<void> {
   const cacheDir = opts.cacheDir ?? CACHE_DIR;
   const path = join(cacheDir, narrativeCacheFileName(owner, repo, number, sha, metaHash, providerKey));
@@ -130,7 +136,10 @@ export async function cacheNarrative(
   // The revision log is a best-effort safety net layered on top of the primary cache. A failure to
   // seal a revision must never fail the narrative write the rest of the app depends on.
   try {
-    await appendNarrativeRevision(owner, repo, number, sha, metaHash, providerKey, narrative, { cacheDir });
+    await appendNarrativeRevision(owner, repo, number, sha, metaHash, providerKey, narrative, {
+      cacheDir,
+      validation: opts.validation,
+    });
   } catch {
     // swallow — the primary cache write already succeeded.
   }
@@ -141,6 +150,8 @@ export type RevisionMeta = {
   metaHash: string;
   providerKey: string;
   savedAt: number;
+  /** Re-anchor outcome recorded when the revision was sealed, when the caller measured one. */
+  validation?: ValidationSummary;
 };
 
 type RevisionRecord = {
@@ -187,7 +198,7 @@ export async function appendNarrativeRevision(
   metaHash: string,
   providerKey: string,
   narrative: NarrativeResponse,
-  opts: { cacheDir?: string } = {},
+  opts: { cacheDir?: string; validation?: ValidationSummary } = {},
 ): Promise<void> {
   const cacheDir = opts.cacheDir ?? CACHE_DIR;
   const dir = revisionsDir(cacheDir, owner, repo, number);
@@ -197,7 +208,16 @@ export async function appendNarrativeRevision(
     .update(canonicalJson({ narrative, sha, metaHash, providerKey }))
     .digest('hex')
     .slice(0, 12);
-  const record: RevisionRecord = { narrative, meta: { sha, metaHash, providerKey, savedAt: Date.now() } };
+  const record: RevisionRecord = {
+    narrative,
+    meta: {
+      sha,
+      metaHash,
+      providerKey,
+      savedAt: Date.now(),
+      ...(opts.validation ? { validation: opts.validation } : {}),
+    },
+  };
   await writeAtomic(join(dir, `${revision}.json`), JSON.stringify(record));
 
   await withLock(join(dir, '.lock'), async () => {

--- a/packages/cli/src/narrative/validator.ts
+++ b/packages/cli/src/narrative/validator.ts
@@ -289,8 +289,20 @@ export function repairNarrative(narrative: NarrativeResponse, files: DiffFile[])
  * carry no anchors — those simply fall through to the existing drop behavior.
  */
 export function reanchorNarrative(narrative: NarrativeResponse, files: DiffFile[]): NarrativeResponse {
-  const { narrative: repaired } = repairNarrative(narrative, files);
-  return enrichNarrativeAnchors(repaired, files);
+  return reanchorNarrativeWithDrops(narrative, files).narrative;
+}
+
+/**
+ * Same reshape as {@link reanchorNarrative}, but also reports how many code references the repair pass
+ * had to drop because no anchor could place them on the current diff. `droppedRefs > 0` means the
+ * narration no longer fully covers the diff — the caller can surface that to the reviewer.
+ */
+export function reanchorNarrativeWithDrops(
+  narrative: NarrativeResponse,
+  files: DiffFile[],
+): { narrative: NarrativeResponse; droppedRefs: number } {
+  const { narrative: repaired, dropped } = repairNarrative(narrative, files);
+  return { narrative: enrichNarrativeAnchors(repaired, files), droppedRefs: dropped.length };
 }
 
 /** One-line human-readable summary of a violation, for warning logs. */

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -11,7 +11,7 @@ import type { GitHubClient } from './github/client';
 import { mapCommentsToChapters } from './github/comments';
 import type { CheckRun, DiffFile, PRComment, PRMetadata, PRReview } from './github/types';
 import { cacheNarrative, computePromptMetaHash, getCachedNarrative, getLastGoodNarrative } from './narrative/cache';
-import { reanchorNarrative } from './narrative/validator';
+import { reanchorNarrative, reanchorNarrativeWithDrops } from './narrative/validator';
 import { chapterCallers, resolveCollapse } from './narrative/collapse';
 import { callAi, generateNarrative, resolveAiPath, resolveProviderKey } from './narrative/engine';
 import { buildChapterAiPrompt } from './narrative/chapter-ai';
@@ -65,6 +65,14 @@ export type ServerContext = {
    * until the first narrative is narrated.
    */
   narratedSha?: string | null;
+  /**
+   * Set by `POST /api/renarrate` to force the next poll tick to regenerate even when the SHA is
+   * unchanged. Treated as SHA-changed-equivalent by the poll: it bypasses the failure cool-down and
+   * skips the plan cache. Cleared the moment the regen attempt starts.
+   */
+  renarrateRequested?: boolean;
+  /** References the last (re)narration could not re-anchor to the diff. Shipped with the narrative payload. */
+  droppedRefs?: number;
   /** Last derived review-round status, cached so the poll only broadcasts `review-round` when it changes. */
   reviewRound?: ReviewRound | null;
   /**
@@ -231,6 +239,8 @@ export function createServer(ctx: ServerContext) {
       ...blastRadius(),
       // Absent on a cache hit, and deliberately so — see `ServerContext.capStats`.
       capStats: ctx.capStats ?? undefined,
+      narratedSha: ctx.narratedSha ?? null,
+      droppedRefs: ctx.droppedRefs ?? undefined,
     } satisfies SseDataFor<'narrative'>;
     return c.json({
       ...narrativePayload,
@@ -298,6 +308,13 @@ export function createServer(ctx: ServerContext) {
     if (ctx.recapError) return c.json({ status: 'error', error: ctx.recapError });
     if (ctx.recapGenerating) return c.json({ status: 'generating' });
     return c.json({ status: 'idle' });
+  });
+
+  // Force a re-narration of the current head even when the SHA hasn't moved (the staleness banner's
+  // Re-narrate button). Sets a flag the poll honors on its next tick; returns immediately.
+  app.post('/api/renarrate', (c) => {
+    ctx.renarrateRequested = true;
+    return c.json({ queued: true }, 202);
   });
 
   app.post('/api/recap', async (c) => {
@@ -435,6 +452,8 @@ export function createServer(ctx: ServerContext) {
             if (!gh) return;
             const freshPr = await gh.getPR(ctx.owner, ctx.repo, ctx.pr.number);
             const shaChanged = freshPr.headSha !== ctx.headSha;
+            // A forced re-narration (staleness banner) regenerates even when the SHA hasn't moved.
+            const forceRenarrate = ctx.renarrateRequested === true;
 
             // These fields feed into the narrative prompt — changes here mean
             // the cached narrative is stale and we need to regenerate.
@@ -447,7 +466,7 @@ export function createServer(ctx: ServerContext) {
             // alongside the new narrative — skip the standalone 'pr' event then.
             // Also skip while a regen is in flight: mutating ctx.pr mid-regen would race the
             // snapshot the regen commits on success; the edit converges via its own regen next poll.
-            const willRegenerate = (shaChanged || promptMetaChanged) && !regenerating;
+            const willRegenerate = (shaChanged || promptMetaChanged || forceRenarrate) && !regenerating;
             if ((promptMetaChanged || otherMetaChanged) && !shaChanged && !willRegenerate && !regenerating) {
               ctx.pr = freshPr;
               send('pr', ctx.pr);
@@ -484,13 +503,19 @@ export function createServer(ctx: ServerContext) {
             }
             const round = recomputeReviewRound(freshCommits);
 
-            const regenCoolingDown = regenFailedSha === freshPr.headSha && Date.now() - regenFailedAt < REGEN_RETRY_MS;
-            if ((shaChanged || promptMetaChanged) && !regenerating && !regenCoolingDown) {
+            // A forced re-narration bypasses the failure cool-down (the reviewer explicitly asked).
+            const regenCoolingDown =
+              !forceRenarrate && regenFailedSha === freshPr.headSha && Date.now() - regenFailedAt < REGEN_RETRY_MS;
+            if ((shaChanged || promptMetaChanged || forceRenarrate) && !regenerating && !regenCoolingDown) {
               regenerating = true;
+              // Clear the flag the moment the attempt starts, so a later poll doesn't re-fire it.
+              if (forceRenarrate) ctx.renarrateRequested = false;
               const prevSha = ctx.headSha.slice(0, 7);
               const newSha = freshPr.headSha.slice(0, 7);
               if (shaChanged) {
                 console.log(`\n  \x1b[38;5;221m↻\x1b[0m New commits detected \x1b[2m(${prevSha} → ${newSha})\x1b[0m`);
+              } else if (forceRenarrate) {
+                console.log(`\n  \x1b[38;5;221m↻\x1b[0m Re-narration requested`);
               } else {
                 console.log(`\n  \x1b[38;5;221m↻\x1b[0m PR title/description/labels changed`);
               }
@@ -534,7 +559,14 @@ export function createServer(ctx: ServerContext) {
                   // The cached narrative was anchored against a prior diff; the SHA just changed and
                   // `freshFiles` may have shifted hunk indices. Re-resolve via content anchors so refs
                   // survive the reshape instead of dropping.
-                  freshNarrative = reanchorNarrative(cached, freshFiles);
+                  const reanchored = reanchorNarrativeWithDrops(cached, freshFiles);
+                  freshNarrative = reanchored.narrative;
+                  ctx.droppedRefs = reanchored.droppedRefs;
+                  if (reanchored.droppedRefs > 0) {
+                    console.warn(
+                      `  \x1b[38;5;221m⚠\x1b[0m ${reanchored.droppedRefs} narrative reference(s) could not be re-anchored to the new diff.`,
+                    );
+                  }
                   // A cached narrative carries no budget stats, and inventing them would tell the
                   // reviewer a story built from a truncated diff was complete.
                   freshCapStats = null;
@@ -580,6 +612,9 @@ export function createServer(ctx: ServerContext) {
                       },
                       {
                         repoContext,
+                        // A forced re-narration skips the plan cache so the reviewer gets a genuine
+                        // regeneration rather than a replay of the stale plan.
+                        force: forceRenarrate || undefined,
                         cacheKey: {
                           owner: ctx.owner,
                           repo: ctx.repo,
@@ -617,6 +652,8 @@ export function createServer(ctx: ServerContext) {
                     if (isTty) process.stdout.write('\r\x1b[2K');
                   }
                   freshNarrative = generated;
+                  // A fresh generation is enriched against the current diff, so nothing was dropped.
+                  ctx.droppedRefs = 0;
                   await cacheNarrative(
                     ctx.owner,
                     ctx.repo,
@@ -657,6 +694,8 @@ export function createServer(ctx: ServerContext) {
                   // the browser holding a boundary that describes the previous plan.
                   ...blastRadius(),
                   capStats: ctx.capStats ?? undefined,
+                  narratedSha: ctx.narratedSha ?? null,
+                  droppedRefs: ctx.droppedRefs ?? undefined,
                 });
               } catch (err) {
                 const msg = err instanceof Error ? err.message : String(err);
@@ -673,7 +712,14 @@ export function createServer(ctx: ServerContext) {
                   // surfacing a fatal error.
                   const lastGood = await getLastGoodNarrative(ctx.owner, ctx.repo, ctx.pr.number);
                   if (lastGood) {
-                    ctx.narrative = reanchorNarrative(lastGood.narrative, ctx.files);
+                    const reanchored = reanchorNarrativeWithDrops(lastGood.narrative, ctx.files);
+                    ctx.narrative = reanchored.narrative;
+                    ctx.droppedRefs = reanchored.droppedRefs;
+                    if (reanchored.droppedRefs > 0) {
+                      console.warn(
+                        `  \x1b[38;5;221m⚠\x1b[0m ${reanchored.droppedRefs} last-good reference(s) could not be re-anchored to the current diff.`,
+                      );
+                    }
                     console.warn(`  \x1b[38;5;221m⚠\x1b[0m Regeneration failed (${msg}); serving last-good narrative.`);
                     broadcast('narrative', {
                       narrative: ctx.narrative,
@@ -681,6 +727,8 @@ export function createServer(ctx: ServerContext) {
                       files: ctx.files,
                       comments: mapCommentsToChapters(ctx.comments, ctx.narrative),
                       ...blastRadius(),
+                      narratedSha: ctx.narratedSha ?? null,
+                      droppedRefs: ctx.droppedRefs ?? undefined,
                     });
                   } else {
                     console.error(`  \x1b[38;5;204m✗\x1b[0m Regeneration failed: ${msg}`);

--- a/packages/cli/src/trace/__tests__/local-sessions.test.ts
+++ b/packages/cli/src/trace/__tests__/local-sessions.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { findMatchingSessions } from '../local-sessions';
+import { collapseWhitespace, findMatchingSessions, verifyPromptText } from '../local-sessions';
 
 let root: string;
 
@@ -106,8 +106,45 @@ describe('findMatchingSessions', () => {
     expect(out).toHaveLength(1);
     const prompts = out[0]!.userPrompts;
     expect(prompts).toHaveLength(20); // list cap
-    expect(prompts).not.toContain('/clear'); // slash command dropped
-    expect(prompts[0]!).toHaveLength(2000); // per-prompt cap
+    expect(prompts.map((p) => p.text)).not.toContain('/clear'); // slash command dropped
+    expect(prompts[0]!.text).toHaveLength(2000); // per-prompt cap
+    expect(prompts[0]!.truncated).toBe(true); // capped display is a truncated prefix
+  });
+
+  it('extracts prompts as all-verified quotes on a clean fixture', async () => {
+    await writeSession('clean-proj', 'g.jsonl', [
+      { ...userLine({ content: 'first prompt' }), cwd: '/x/repo' },
+      { ...userLine({ content: 'second prompt' }), cwd: '/x/repo' },
+    ]);
+    const out = await findMatchingSessions({ repoDirHints: ['repo'], changedFiles: [], logRoot: root });
+    expect(out).toHaveLength(1);
+    const prompts = out[0]!.userPrompts;
+    expect(prompts.map((p) => p.text)).toEqual(['first prompt', 'second prompt']);
+    expect(prompts.every((p) => p.verified)).toBe(true);
+    expect(prompts.every((p) => !p.truncated)).toBe(true);
+  });
+});
+
+describe('verifyPromptText', () => {
+  it('verifies an exact match', () => {
+    expect(verifyPromptText('fix the bug', 'fix the bug')).toEqual({ verified: true });
+  });
+
+  it('verifies a whitespace-collapsed match', () => {
+    expect(verifyPromptText('fix   the\n\tbug', 'fix the bug')).toEqual({ verified: true });
+    expect(collapseWhitespace('fix   the\n\tbug')).toBe('fix the bug');
+  });
+
+  it('flags a truncated prefix', () => {
+    expect(verifyPromptText('fix the', 'fix the bug now')).toEqual({ verified: true, truncated: true });
+  });
+
+  it('returns false for corrupted text not in the transcript', () => {
+    expect(verifyPromptText('delete everything', 'fix the bug')).toEqual({ verified: false });
+  });
+
+  it('returns false for empty text', () => {
+    expect(verifyPromptText('', 'fix the bug')).toEqual({ verified: false });
   });
 
   it('takes at most the top 3 scoring sessions', async () => {

--- a/packages/cli/src/trace/local-sessions.ts
+++ b/packages/cli/src/trace/local-sessions.ts
@@ -1,8 +1,30 @@
 import { readdir, readFile } from 'fs/promises';
 import { homedir } from 'os';
 import { basename, join } from 'path';
-import type { TraceSessionSummary } from '@diffdad/contracts';
+import type { TracePrompt, TraceSessionSummary } from '@diffdad/contracts';
 import { normalizeSession } from './normalize';
+
+/** Collapse every run of whitespace to a single space and trim the ends. Pure; exported for tests. */
+export function collapseWhitespace(s: string): string {
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Prove that `text` is a verbatim quote from `transcript`, comparing after collapsing whitespace runs to
+ * single spaces on both sides. An exact (whitespace-collapsed) substring verifies; a display-capped
+ * prefix of the full transcript verifies AND reports `truncated: true`. Anything else — corrupted or
+ * empty — fails, and a failed prompt is never quoted. Pure; exported for tests.
+ */
+export function verifyPromptText(text: string, transcript: string): { verified: boolean; truncated?: boolean } {
+  const needle = collapseWhitespace(text);
+  const haystack = collapseWhitespace(transcript);
+  if (!needle || !haystack) return { verified: false };
+  if (needle === haystack) return { verified: true };
+  // A truncated display is a proper prefix of the full transcript.
+  if (haystack.startsWith(needle)) return { verified: true, truncated: true };
+  if (haystack.includes(needle)) return { verified: true };
+  return { verified: false };
+}
 
 export type FindMatchingSessionsOptions = {
   /** Repo-name hints; a session whose cwd basename matches one scores the cwd rung. */
@@ -75,13 +97,17 @@ function isNoise(text: string): boolean {
   return false;
 }
 
-function extractPrompts(jsonlText: string): string[] {
-  const out: string[] = [];
+function extractPrompts(jsonlText: string): TracePrompt[] {
+  const out: TracePrompt[] = [];
   for (const ev of normalizeSession(jsonlText)) {
     if (ev.kind !== 'user') continue;
-    const text = ev.text.trim();
-    if (!text || isNoise(text)) continue;
-    out.push(text.length > MAX_PROMPT_CHARS ? text.slice(0, MAX_PROMPT_CHARS) : text);
+    const full = ev.text.trim();
+    if (!full || isNoise(full)) continue;
+    const display = full.length > MAX_PROMPT_CHARS ? full.slice(0, MAX_PROMPT_CHARS) : full;
+    // Verify the shown text against the full message it was sliced from, so a display-cap truncation
+    // surfaces as `truncated` and any mangling surfaces as `verified: false`.
+    const { verified, truncated } = verifyPromptText(display, full);
+    out.push({ text: display, verified, ...(truncated ? { truncated: true } : {}) });
     if (out.length >= MAX_PROMPTS) break;
   }
   return out;

--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from 'bun:test';
-import { narrativeResponseSchema, prCommentSchema, planSchema, recapResponseSchema, sseEventSchema } from './index';
+import {
+  narrativeResponseSchema,
+  prCommentSchema,
+  planSchema,
+  recapResponseSchema,
+  renarrateResponseSchema,
+  sseEventSchema,
+  traceSessionSummarySchema,
+} from './index';
 
 const chapter = {
   title: 'Auth boundary moves',
@@ -229,6 +237,43 @@ describe('plan and recap', () => {
   });
 });
 
+describe('trace + renarrate', () => {
+  test('round-trips a trace session with verified/truncated prompts', () => {
+    const session = {
+      sessionId: 's1',
+      path: '/tmp/s1.jsonl',
+      startedAt: '2024-01-01T00:00:00Z',
+      endedAt: '2024-01-01T01:00:00Z',
+      branch: 'feat/auth',
+      cwd: '/work/repo',
+      score: 6,
+      userPrompts: [
+        { text: 'move auth into middleware', verified: true },
+        { text: 'a very long prompt', verified: true, truncated: true },
+        { text: '', verified: false },
+      ],
+    };
+    expect(traceSessionSummarySchema.parse(session)).toEqual(session);
+  });
+
+  test('rejects a prompt missing the verified flag', () => {
+    const bad = {
+      sessionId: 's1',
+      path: '/tmp/s1.jsonl',
+      startedAt: '',
+      endedAt: '',
+      score: 0,
+      userPrompts: [{ text: 'hi' }],
+    };
+    expect(() => traceSessionSummarySchema.parse(bad)).toThrow();
+  });
+
+  test('round-trips a renarrate response', () => {
+    expect(renarrateResponseSchema.parse({ queued: true })).toEqual({ queued: true });
+    expect(() => renarrateResponseSchema.parse({ queued: 'yes' })).toThrow();
+  });
+});
+
 // One representative payload per SSE event kind.
 const sseCases: { event: string; data: unknown }[] = [
   { event: 'connected', data: { timestamp: 123 } },
@@ -265,6 +310,8 @@ const sseCases: { event: string; data: unknown }[] = [
       comments: [{ ...comment, chapterIndices: [0] }],
       collapse: { available: true, decisions: [], dividerBefore: null },
       callers: [{ chapterIndex: 0, callers: [], total: 0 }],
+      narratedSha: 'abc1234',
+      droppedRefs: 2,
     },
   },
   { event: 'collapse', data: { collapse: { available: false, reason: 'size-cap' }, callers: [] } },

--- a/packages/contracts/src/sse.ts
+++ b/packages/contracts/src/sse.ts
@@ -29,7 +29,15 @@ const narrativePayloadSchema = z.object({
   capStats: capStatsSchema.optional(),
   /** Derived review-round status for the PR, when the server has computed one. */
   round: reviewRoundSchema.optional(),
+  /** The SHA the on-screen narrative was generated against. Null until the first narrative is narrated. */
+  narratedSha: z.string().nullable().optional(),
+  /** How many code references could not be re-anchored to the current diff on the last (re)narration. */
+  droppedRefs: z.number().optional(),
 });
+
+/** Response to `POST /api/renarrate`: the force-regeneration request was accepted and queued. */
+export const renarrateResponseSchema = z.object({ queued: z.boolean() });
+export type RenarrateResponse = z.infer<typeof renarrateResponseSchema>;
 
 export const sseEventSchema = z.discriminatedUnion('event', [
   z.object({ event: z.literal('connected'), data: z.object({ timestamp: z.number() }) }),

--- a/packages/contracts/src/trace.ts
+++ b/packages/contracts/src/trace.ts
@@ -5,6 +5,18 @@ import { z } from 'zod';
  * logs on the reviewer's machine. Read-only and best-effort: `userPrompts` are the human prompts that
  * drove the change, never uploaded or persisted — they exist only in this HTTP response.
  */
+/**
+ * One extracted human prompt. `verified` is the guarantee: the text is a proven verbatim substring of the
+ * session transcript, so the UI may quote it. `truncated` marks a display-capped prefix. An unverified
+ * prompt is NEVER shown — the UI renders a placeholder in its place.
+ */
+export const tracePromptSchema = z.object({
+  text: z.string(),
+  verified: z.boolean(),
+  truncated: z.boolean().optional(),
+});
+export type TracePrompt = z.infer<typeof tracePromptSchema>;
+
 export const traceSessionSummarySchema = z.object({
   sessionId: z.string(),
   path: z.string(),
@@ -13,7 +25,7 @@ export const traceSessionSummarySchema = z.object({
   branch: z.string().optional(),
   cwd: z.string().optional(),
   score: z.number(),
-  userPrompts: z.array(z.string()),
+  userPrompts: z.array(tracePromptSchema),
 });
 export type TraceSessionSummary = z.infer<typeof traceSessionSummarySchema>;
 

--- a/packages/web/src/components/RecapView.tsx
+++ b/packages/web/src/components/RecapView.tsx
@@ -96,11 +96,19 @@ function TraceSessionCard({ session }: { session: TraceSessionSummary }) {
         <span className="ml-auto tabular-nums">score {session.score}</span>
       </div>
       <div className="mt-3 space-y-2">
-        {session.userPrompts.map((prompt, i) => (
-          <blockquote key={i} className="border-l-[3px] pl-3" style={{ borderColor: 'var(--purple-a5)' }}>
-            <Markdown source={prompt} />
-          </blockquote>
-        ))}
+        {session.userPrompts.map((prompt, i) =>
+          prompt.verified ? (
+            <blockquote key={i} className="border-l-[3px] pl-3" style={{ borderColor: 'var(--purple-a5)' }}>
+              <Markdown source={prompt.text} />
+              {prompt.truncated && <span className="mt-1 block text-[11.5px] text-[var(--fg-3)]">(truncated)</span>}
+            </blockquote>
+          ) : (
+            // Never show — or paraphrase — text we could not tie back to the transcript.
+            <p key={i} className="border-l-[3px] border-[var(--gray-a4)] pl-3 text-[13px] italic text-[var(--fg-3)]">
+              trace unavailable
+            </p>
+          ),
+        )}
       </div>
     </li>
   );

--- a/packages/web/src/components/StoryView.tsx
+++ b/packages/web/src/components/StoryView.tsx
@@ -222,6 +222,65 @@ function RegeneratingBanner() {
 }
 
 /**
+ * A slim notice that the narration was generated against an older diff than the one now on screen.
+ * Shown only when both SHAs are known and differ, and hidden while a regeneration is already running.
+ * The Re-narrate button forces the server to regenerate the current head (POST /api/renarrate).
+ */
+function StalenessBanner() {
+  const pr = useReviewStore((s) => s.pr);
+  const narratedSha = useReviewStore((s) => s.narratedSha);
+  const droppedRefs = useReviewStore((s) => s.droppedRefs);
+  const regenerating = useReviewStore((s) => s.regenerating);
+  const [queued, setQueued] = useState(false);
+
+  const headSha = pr?.headSha ?? null;
+  useEffect(() => {
+    // A fresh narration catching up clears the queued state (the banner unmounts too).
+    if (narratedSha && headSha && narratedSha === headSha) setQueued(false);
+  }, [narratedSha, headSha]);
+
+  if (regenerating) return null;
+  if (!headSha || !narratedSha || headSha === narratedSha) return null;
+
+  const onRenarrate = () => {
+    setQueued(true);
+    void fetch('/api/renarrate', { method: 'POST' }).catch(() => {});
+  };
+
+  return (
+    <div
+      className="mb-6 flex items-center gap-3 rounded-[10px] px-4 py-2.5 text-[12.5px]"
+      style={{ background: 'var(--amber-2)', boxShadow: 'inset 0 0 0 1px var(--amber-a5)', color: 'var(--amber-11)' }}
+      data-staleness-banner
+    >
+      <span aria-hidden>⚠</span>
+      <span className="flex-1">
+        Narration covers <span className="font-mono">{narratedSha.slice(0, 7)}</span>; the diff is now at{' '}
+        <span className="font-mono">{headSha.slice(0, 7)}</span>
+        {droppedRefs > 0
+          ? ` — ${droppedRefs} ${droppedRefs === 1 ? 'reference' : 'references'} could not be re-anchored`
+          : ''}
+      </span>
+      <button
+        type="button"
+        onClick={onRenarrate}
+        disabled={queued}
+        className="shrink-0 rounded-md px-2.5 py-1 text-[12px] font-medium"
+        style={{
+          background: 'var(--amber-3)',
+          boxShadow: 'inset 0 0 0 1px var(--amber-a5)',
+          color: 'var(--amber-11)',
+          opacity: queued ? 0.6 : 1,
+          cursor: queued ? 'default' : 'pointer',
+        }}
+      >
+        {queued ? 'queued…' : 'Re-narrate'}
+      </button>
+    </div>
+  );
+}
+
+/**
  * The one collapse boundary, stated as a fact: how many chapters sit below it, how many diff lines they
  * hold, and what the collapse rests on. Lines rather than chapters because lines are what a reviewer
  * actually spends; chapter counts are gameable and say nothing about the reading saved.
@@ -374,6 +433,7 @@ export function StoryView() {
   const body = (
     <main className="min-w-0">
       <RegeneratingBanner />
+      <StalenessBanner />
       <TruncationBanner capStats={capStats} />
       <CollapseUnavailableNotice collapse={collapse} />
       <Overview />

--- a/packages/web/src/hooks/useLiveStream.ts
+++ b/packages/web/src/hooks/useLiveStream.ts
@@ -264,6 +264,7 @@ export function useLiveStream() {
           { collapse: data.collapse ?? null, callers: data.callers ?? [], capStats: data.capStats ?? null },
         );
         if (data.round) useReviewStore.getState().setReviewRound(data.round);
+        useReviewStore.getState().setStaleness(data.narratedSha ?? null, data.droppedRefs ?? 0);
         useReviewStore.getState().setRegenerating(false);
         useReviewStore.getState().setNarrativeProgressChars(0);
         setLastEventAt(Date.now());

--- a/packages/web/src/hooks/useNarrative.ts
+++ b/packages/web/src/hooks/useNarrative.ts
@@ -36,6 +36,10 @@ type NarrativeApiResponse = {
   capStats?: CapStats;
   /** Derived review-round status, when the server has computed one. Purely additive; never blocks. */
   round?: ReviewRound;
+  /** The SHA the narrative was generated against; drives the staleness banner. */
+  narratedSha?: string | null;
+  /** References the narration could not re-anchor to the current diff. */
+  droppedRefs?: number;
   /** Command-center bootstrap: the daemon seeds the initial queue so the dashboard paints at once. */
   units?: Unit[];
   /** Command-center bootstrap: rows ✕ has hidden until their author pushes. Counted, never rendered inline. */
@@ -117,6 +121,7 @@ export function useNarrative() {
           );
           useReviewStore.getState().setAiPath(data.aiPath ?? null);
           if (data.round) useReviewStore.getState().setReviewRound(data.round);
+          useReviewStore.getState().setStaleness(data.narratedSha ?? null, data.droppedRefs ?? 0);
         }
 
         useReviewStore.getState().setMode(data.mode ?? 'pr');

--- a/packages/web/src/state/review-store.ts
+++ b/packages/web/src/state/review-store.ts
@@ -121,6 +121,10 @@ type ReviewState = {
   clusterBots: boolean;
   regenerating: boolean;
   narrativeProgressChars: number;
+  /** The SHA the on-screen narrative was generated against; null until a narrative payload lands. */
+  narratedSha: string | null;
+  /** References the last narration could not re-anchor to the current diff (0 = full coverage). */
+  droppedRefs: number;
   narrationOverrides: Record<string, string>;
   /** Resolve-item ids the reviewer has marked done (walkthrough resolve strips). */
   resolved: Record<string, boolean>;
@@ -235,6 +239,8 @@ type ReviewState = {
   setClusterBots: (v: boolean) => void;
   setRegenerating: (v: boolean) => void;
   setNarrativeProgressChars: (chars: number) => void;
+  /** Set the narrated SHA + dropped-ref count together (they always arrive on the same payload). */
+  setStaleness: (narratedSha: string | null, droppedRefs: number) => void;
   setAiPath: (path: 'api' | 'local-cli' | null) => void;
   setPr: (pr: PRData) => void;
   setNarrationOverride: (chapterKey: string, text: string) => void;
@@ -515,6 +521,8 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   clusterBots: true,
   regenerating: false,
   narrativeProgressChars: 0,
+  narratedSha: null,
+  droppedRefs: 0,
   aiPath: null,
   narrationOverrides: {} as Record<string, string>,
   resolved: {},
@@ -769,6 +777,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   setRegenerating: (regenerating) => set({ regenerating }),
   setNarrativeProgressChars: (narrativeProgressChars) =>
     set((state) => (state.narrativeProgressChars === narrativeProgressChars ? state : { narrativeProgressChars })),
+  setStaleness: (narratedSha, droppedRefs) => set({ narratedSha, droppedRefs }),
   setAiPath: (aiPath) => set({ aiPath }),
   setPr: (pr) => set({ pr }),
   applyPartialNarrative: (pr, narrative, files, comments) =>


### PR DESCRIPTION
Two halves of the same guarantee — what the UI claims is checkable:

Trace quotes: every extracted prompt is verified as a verbatim
(whitespace-collapsed) substring of the session transcript before it
renders with quote styling; display-truncated prompts verify as a
prefix and are labeled. Unverified text renders as a dim 'trace
unavailable' placeholder — never the text, never a paraphrase. Today
extraction is deterministic so verification always passes; it exists
as a tripwire for future pipeline changes.

Staleness: the narrative payload carries narratedSha + droppedRefs.
When the diff moves past the narration, a banner says exactly which
SHAs are involved (and how many refs failed to re-anchor, when any
did) with a Re-narrate button. POST /api/renarrate sets a flag the
poll honors as SHA-change-equivalent — bypassing the failure
cool-down, skipping the plan cache — worst-case 10s latency by
design. Sealed revisions record a validation summary at seal time.