### PR TITLE
feat(narrative): sequence diagram section type with guided tour

### DIFF
--- a/packages/cli/src/__tests__/normalize-narrative.test.ts
+++ b/packages/cli/src/__tests__/normalize-narrative.test.ts
@@ -103,6 +103,116 @@ describe('normalizeNarrative', () => {
     }
   });
 
+  it('accepts a sequence section, dedupes/caps participants and keeps valid messages', () => {
+    const out = normalizeNarrative({
+      chapters: [
+        {
+          title: 'C',
+          summary: 's',
+          whyMatters: 'w',
+          risk: 'low',
+          sections: [
+            {
+              type: 'sequence',
+              title: 'flow',
+              participants: ['Client', 'Client', 'Gateway'], // dupe dropped
+              messages: [
+                { from: 'Client', to: 'Gateway', label: 'GET /x', note: 'now retried', file: 'f.ts', hunkIndex: 2 },
+                { from: 'Gateway', to: 'Gateway', label: 'self-check' }, // self-message allowed
+                { from: 'Gateway', to: 'Client', label: '', note: 'x' }, // empty label dropped
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const section = out.chapters[0]?.sections[0];
+    expect(section?.type).toBe('sequence');
+    if (section?.type === 'sequence') {
+      expect(section.title).toBe('flow');
+      expect(section.participants).toEqual(['Client', 'Gateway']);
+      expect(section.messages).toHaveLength(2);
+      expect(section.messages[0]).toEqual({
+        from: 'Client',
+        to: 'Gateway',
+        label: 'GET /x',
+        note: 'now retried',
+        file: 'f.ts',
+        hunkIndex: 2,
+      });
+      expect(section.messages[1]).toEqual({
+        from: 'Gateway',
+        to: 'Gateway',
+        label: 'self-check',
+        note: undefined,
+        file: undefined,
+        hunkIndex: undefined,
+      });
+    }
+  });
+
+  it('auto-adds an unknown participant under the cap and drops the message once the cap is hit', () => {
+    const out = normalizeNarrative({
+      chapters: [
+        {
+          title: 'C',
+          summary: '',
+          whyMatters: '',
+          risk: 'low',
+          sections: [
+            {
+              type: 'sequence',
+              title: 't',
+              participants: ['A', 'B', 'C', 'D', 'E'], // 5 of 6
+              messages: [
+                { from: 'A', to: 'F', label: 'auto-adds F' }, // F auto-added (6th)
+                { from: 'A', to: 'G', label: 'drops, cap reached' }, // G would be 7th -> message dropped
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const section = out.chapters[0]?.sections[0];
+    expect(section?.type).toBe('sequence');
+    if (section?.type === 'sequence') {
+      expect(section.participants).toEqual(['A', 'B', 'C', 'D', 'E', 'F']);
+      expect(section.messages).toHaveLength(1);
+      expect(section.messages[0]?.label).toBe('auto-adds F');
+    }
+  });
+
+  it('caps messages at 20 and clears a lone file/hunkIndex half', () => {
+    const messages = [
+      { from: 'A', to: 'B', label: 'lone file', file: 'f.ts' }, // no hunkIndex -> link cleared
+      ...Array.from({ length: 25 }, (_, i) => ({ from: 'A', to: 'B', label: `m${i}` })),
+    ];
+    const out = normalizeNarrative({
+      chapters: [
+        {
+          title: 'C',
+          summary: '',
+          whyMatters: '',
+          risk: 'low',
+          sections: [{ type: 'sequence', title: 't', participants: ['A', 'B'], messages }],
+        },
+      ],
+    });
+    const section = out.chapters[0]?.sections[0];
+    expect(section?.type).toBe('sequence');
+    if (section?.type === 'sequence') {
+      expect(section.messages).toHaveLength(20);
+      expect(section.messages[0]).toEqual({
+        from: 'A',
+        to: 'B',
+        label: 'lone file',
+        note: undefined,
+        file: undefined,
+        hunkIndex: undefined,
+      });
+    }
+  });
+
   it('upgrades old narratives missing the new fields', () => {
     const oldShape = {
       title: 'Old',

--- a/packages/cli/src/__tests__/repair.test.ts
+++ b/packages/cli/src/__tests__/repair.test.ts
@@ -178,6 +178,50 @@ describe('repairNarrative', () => {
     expect(dropped.map((d) => d.kind).sort()).toEqual(['invalid-hunk-index', 'unknown-file']);
   });
 
+  it('nulls out a sequence message dead link but keeps the message and its prose', () => {
+    const files = [file('a.ts', 1)];
+    const n = narrative([
+      {
+        title: 'A',
+        summary: '',
+        whyMatters: '',
+        risk: 'low',
+        sections: [
+          diffSection('a.ts', 0),
+          {
+            type: 'sequence',
+            title: 'flow',
+            participants: ['A', 'B'],
+            messages: [
+              { from: 'A', to: 'B', label: 'plain' },
+              { from: 'A', to: 'B', label: 'gone', note: 'why', file: 'ghost.ts', hunkIndex: 0 },
+              { from: 'B', to: 'A', label: 'oob', file: 'a.ts', hunkIndex: 9 },
+              { from: 'A', to: 'B', label: 'good', file: 'a.ts', hunkIndex: 0 },
+            ],
+          },
+        ],
+      },
+    ]);
+    const { narrative: out, dropped } = repairNarrative(n, files);
+    const section = out.chapters[0]!.sections[1]!;
+    expect(section.type).toBe('sequence');
+    if (section.type === 'sequence') {
+      expect(section.messages).toHaveLength(4); // no message dropped
+      expect(section.messages[1]).toEqual({
+        from: 'A',
+        to: 'B',
+        label: 'gone',
+        note: 'why',
+        file: undefined,
+        hunkIndex: undefined,
+      });
+      expect(section.messages[2]).toEqual({ from: 'B', to: 'A', label: 'oob', file: undefined, hunkIndex: undefined });
+      expect(section.messages[3]).toEqual({ from: 'A', to: 'B', label: 'good', file: 'a.ts', hunkIndex: 0 });
+    }
+    expect(dropped).toHaveLength(2);
+    expect(dropped.map((d) => d.kind).sort()).toEqual(['invalid-hunk-index', 'unknown-file']);
+  });
+
   it('produces a narrative with no unresolvable refs left (validator agrees)', () => {
     const files = [file('a.ts', 2)];
     const n = narrative([

--- a/packages/cli/src/__tests__/validator.test.ts
+++ b/packages/cli/src/__tests__/validator.test.ts
@@ -238,6 +238,38 @@ describe('validateNarrative', () => {
     expect(findKind(r.violations, 'invalid-hunk-index')).toMatchObject([{ file: 'a.ts', hunkIndex: 9, chapter: 0 }]);
   });
 
+  it('flags a sequence message linking an unknown file or out-of-range hunkIndex', () => {
+    const files = [file('a.ts', 1)];
+    const n = narrative([
+      {
+        title: '1',
+        summary: '',
+        whyMatters: '',
+        risk: 'low',
+        sections: [
+          diffSection('a.ts', 0),
+          {
+            type: 'sequence',
+            title: 'flow',
+            participants: ['A', 'B'],
+            messages: [
+              { from: 'A', to: 'B', label: 'unlinked' }, // no link — ignored
+              { from: 'A', to: 'B', label: 'gone', file: 'ghost.ts', hunkIndex: 0 }, // unknown-file
+              { from: 'B', to: 'A', label: 'oob', file: 'a.ts', hunkIndex: 9 }, // invalid-hunk-index
+              { from: 'A', to: 'B', label: 'good', file: 'a.ts', hunkIndex: 0 }, // valid
+            ],
+          },
+        ],
+      },
+    ]);
+    const r = validateNarrative(n, files);
+    expect(findKind(r.violations, 'unknown-file')).toMatchObject([{ file: 'ghost.ts', chapter: 0 }]);
+    expect(findKind(r.violations, 'invalid-hunk-index')).toMatchObject([{ file: 'a.ts', hunkIndex: 9, chapter: 0 }]);
+    // A sequence link is never a primary ref, so the good link does not create a duplicate/orphan.
+    expect(findKind(r.violations, 'duplicate-primary')).toEqual([]);
+    expect(findKind(r.violations, 'orphan-hunk')).toEqual([]);
+  });
+
   it('formatViolation produces a non-empty string for every kind', () => {
     const samples: ValidationViolation[] = [
       { kind: 'duplicate-primary', file: 'a', hunkIndex: 0, chapters: [0, 1] },

--- a/packages/cli/src/eval/judge.ts
+++ b/packages/cli/src/eval/judge.ts
@@ -75,6 +75,8 @@ function summarizeNarrative(narrative: NarrativeResponse): string {
         parts.push(`    narrative: ${s.content}`);
       } else if (s.type === 'callstack') {
         parts.push(`    callstack[${s.frames.length}]: ${s.title}`);
+      } else if (s.type === 'sequence') {
+        parts.push(`    sequence-ref[${s.participants.length}p/${s.messages.length}m]: ${s.title}`);
       } else {
         parts.push(`    diff-ref: ${s.file}:${s.startLine}-${s.endLine}`);
       }

--- a/packages/cli/src/narrative/prompt.ts
+++ b/packages/cli/src/narrative/prompt.ts
@@ -72,8 +72,10 @@ const MAX_THEMES = 7;
 // Bumped again for the new `callstack` section type in the writer/single-pass JSON contract: cached
 // narratives predate it and would never carry call-tree sections, so they regenerate against the new
 // instructions. Plans are untouched (the section type never appears in a plan), so PLANNER stays put.
+// Bumped again for the new `sequence` section type added to both prose JSON contracts, same reasoning:
+// cached narratives predate it, plans are untouched.
 export const PLANNER_PROMPT_REVISION = 3;
-export const NARRATIVE_PROMPT_REVISION = 5;
+export const NARRATIVE_PROMPT_REVISION = 6;
 
 // Shared reader-contract + omission mandate injected into every prompt that produces reader-facing
 // prose. (a) forces the model to spend its budget deciding what to leave out; (b) pins the reader's
@@ -127,6 +129,21 @@ const RESPONSE_SCHEMA = `{
               "change": "added | removed | unchanged | modified",
               "depth": "number — 0-based indent; caller is shallower than callee",
               "file": "string? — only when this frame's change is visible in the diff",
+              "hunkIndex": "number? — 0-based hunk index; only alongside file"
+            }
+          ]
+        },
+        {
+          "type": "sequence",
+          "title": "string — short label for the interaction, e.g. 'Client retries through the gateway'",
+          "participants": ["string — 2-6 real component names, in the order they first act"],
+          "messages": [
+            {
+              "from": "string — a participant name",
+              "to": "string — a participant name (from === to is a self-message)",
+              "label": "string — the call/event/response for this step",
+              "note": "string? — one line on what changed about this step",
+              "file": "string? — only when this step's change is visible in the diff",
               "hunkIndex": "number? — 0-based hunk index; only alongside file"
             }
           ]
@@ -217,6 +234,21 @@ const CHAPTER_RESPONSE_SCHEMA = `{
           "hunkIndex": "number? — 0-based hunk index for this theme; only alongside file"
         }
       ]
+    },
+    {
+      "type": "sequence",
+      "title": "string — short label for the interaction",
+      "participants": ["string — 2-6 real component names, in the order they first act"],
+      "messages": [
+        {
+          "from": "string — a participant name",
+          "to": "string — a participant name (from === to is a self-message)",
+          "label": "string — the call/event/response for this step",
+          "note": "string? — one line on what changed about this step",
+          "file": "string? — only when this step's change is visible in this theme's diff",
+          "hunkIndex": "number? — 0-based hunk index for this theme; only alongside file"
+        }
+      ]
     }
   ],
   "callouts": [
@@ -234,6 +266,17 @@ A \`callstack\` section renders a base-vs-head call tree with +/- gutter markers
 - **Mark only frames that actually changed.** \`change\` is 'added' (newly in the chain), 'removed' (no longer called), 'modified' (still called but its body changed), or 'unchanged' (context frame shown for orientation). Most frames in a typical tree are 'unchanged'.
 - **3-12 frames is typical.** Fewer than 3 is not a tree; more than ~12 is noise.
 - **Link frames only when the change is visible in the diff.** Set \`file\`+\`hunkIndex\` (both, or neither) so the reviewer can jump to the hunk. Omit them for orientation-only frames.`;
+
+// Strict guidance for the optional `sequence` section, injected into both prose prompts. Renders a
+// hand-laid sequence diagram: participant columns, lifelines, top-down message arrows.
+const SEQUENCE_GUIDANCE = `## Sequence sections (use rarely)
+
+A \`sequence\` section renders a sequence diagram: participant columns with lifelines and top-down message arrows. Use it ONLY when the chapter's central change IS an interaction BETWEEN components: a request flow across services, an event-ordering change, a handshake, a retry path. For a call chain inside ONE component, prefer a \`callstack\` section; for anything else, a \`diff\` section is right.
+
+- **2-6 participants, named after real components** (services, modules, queues), in the order they first act.
+- **3-12 messages in temporal order.** Each \`from\`/\`to\` must be one of the participants. \`from === to\` is a self-message. \`label\` is the call, event, or response for that step.
+- **\`note\` is one line on what changed about that step** — omit it when the step is unchanged context.
+- **Link a step only when its change is visible in the diff.** Set \`file\`+\`hunkIndex\` (both, or neither) so the reviewer can jump to the hunk.`;
 
 const SHARED_PRINCIPLES = `Your job is to help a reviewer find the things they would otherwise miss. Empirical research on code review (Mantyla & Lassenius 2009) shows that human reviewers reliably catch style and structure issues but miss bugs in **logic, state, timing, and input validation**. Your value is on the slip set — not the obvious stuff.
 
@@ -253,6 +296,8 @@ ${SHARED_PRINCIPLES}
 ${READER_CONTRACT}
 
 ${CALLSTACK_GUIDANCE}
+
+${SEQUENCE_GUIDANCE}
 
 ## What to produce
 
@@ -486,7 +531,9 @@ Same as the planner pass: \`hunkIndex\` is per-file 0-based; \`startLine\`/\`end
 
 ${CALLSTACK_GUIDANCE}
 
-When a callstack frame links into the diff, its \`file\`+\`hunkIndex\` must come from this theme's hunks, exactly like a diff section.
+${SEQUENCE_GUIDANCE}
+
+When a callstack frame or sequence message links into the diff, its \`file\`+\`hunkIndex\` must come from this theme's hunks, exactly like a diff section.
 
 ## Output
 

--- a/packages/cli/src/narrative/types.ts
+++ b/packages/cli/src/narrative/types.ts
@@ -101,6 +101,23 @@ export type CallStackFrame = {
   hunkIndex?: number;
 };
 
+/**
+ * One message in a sequence diagram: `from` sends to `to` with `label`. Both endpoints must name a
+ * participant. `from === to` is a self-message (renders as a small loop). `note` is one line on what
+ * changed about that step. `file`+`hunkIndex` optionally link the step into a diff section the same way
+ * a callstack frame does; both must be present for the link to be live, and the validate/repair path
+ * nulls a dead link in place rather than re-resolving it (no anchor).
+ */
+export type SequenceMessage = {
+  from: string;
+  to: string;
+  label: string;
+  note?: string;
+  file?: string;
+  /** 0-based index into DiffFile.hunks — same semantics as a diff section. */
+  hunkIndex?: number;
+};
+
 export type NarrativeSection =
   | { type: 'narrative'; content: string }
   | {
@@ -112,7 +129,8 @@ export type NarrativeSection =
       /** Content-derived re-resolution anchor. Absent on narratives cached before this field existed. */
       anchor?: HunkAnchor;
     }
-  | { type: 'callstack'; title: string; frames: CallStackFrame[] };
+  | { type: 'callstack'; title: string; frames: CallStackFrame[] }
+  | { type: 'sequence'; title: string; participants: string[]; messages: SequenceMessage[] };
 
 const CONCERN_CATEGORIES: ConcernCategory[] = [
   'logic',
@@ -139,6 +157,8 @@ function normalizeReadingPlanStep(input: unknown): ReadingPlanStep | null {
 const CALLSTACK_CHANGES: CallStackFrame['change'][] = ['added', 'removed', 'unchanged', 'modified'];
 const MAX_FRAME_DEPTH = 8;
 const MAX_FRAMES = 30;
+const MAX_PARTICIPANTS = 6;
+const MAX_MESSAGES = 20;
 
 function normalizeCallStackFrame(input: unknown): CallStackFrame | null {
   if (!input || typeof input !== 'object') return null;
@@ -175,7 +195,64 @@ function normalizeSection(input: unknown): NarrativeSection {
       : [];
     return { type: 'callstack', title: typeof obj.title === 'string' ? obj.title : '', frames };
   }
+  if (input && typeof input === 'object' && (input as Record<string, unknown>).type === 'sequence') {
+    return normalizeSequenceSection(input as Record<string, unknown>);
+  }
   return input as NarrativeSection;
+}
+
+/**
+ * Defensive sequence handling: participants deduped and capped; messages with empty labels dropped;
+ * a message referencing an unknown participant auto-adds it while the participant list is under cap,
+ * otherwise the message is dropped; message count capped. `file`/`hunkIndex` kept as an all-or-nothing
+ * pair (a lone half is cleared) so the validate/repair path only ever sees a live link or none.
+ */
+function normalizeSequenceSection(obj: Record<string, unknown>): NarrativeSection {
+  const participants: string[] = [];
+  const seen = new Set<string>();
+  if (Array.isArray(obj.participants)) {
+    for (const p of obj.participants) {
+      if (typeof p !== 'string' || p.length === 0) continue;
+      if (seen.has(p)) continue;
+      if (participants.length >= MAX_PARTICIPANTS) break;
+      seen.add(p);
+      participants.push(p);
+    }
+  }
+
+  const messages: SequenceMessage[] = [];
+  const rawMessages = Array.isArray(obj.messages) ? obj.messages : [];
+  for (const raw of rawMessages) {
+    if (messages.length >= MAX_MESSAGES) break;
+    if (!raw || typeof raw !== 'object') continue;
+    const m = raw as Record<string, unknown>;
+    if (typeof m.from !== 'string' || m.from.length === 0) continue;
+    if (typeof m.to !== 'string' || m.to.length === 0) continue;
+    if (typeof m.label !== 'string' || m.label.length === 0) continue;
+    const endpoints = m.from === m.to ? [m.from] : [m.from, m.to];
+    let ok = true;
+    for (const e of endpoints) {
+      if (seen.has(e)) continue;
+      if (participants.length >= MAX_PARTICIPANTS) {
+        ok = false;
+        break;
+      }
+      seen.add(e);
+      participants.push(e);
+    }
+    if (!ok) continue;
+    const hasLink = typeof m.file === 'string' && m.file.length > 0 && typeof m.hunkIndex === 'number';
+    messages.push({
+      from: m.from,
+      to: m.to,
+      label: m.label,
+      note: typeof m.note === 'string' && m.note.length > 0 ? m.note : undefined,
+      file: hasLink ? (m.file as string) : undefined,
+      hunkIndex: hasLink ? (m.hunkIndex as number) : undefined,
+    });
+  }
+
+  return { type: 'sequence', title: typeof obj.title === 'string' ? obj.title : '', participants, messages };
 }
 
 function normalizeConcern(input: unknown): Concern | null {

--- a/packages/cli/src/narrative/validator.ts
+++ b/packages/cli/src/narrative/validator.ts
@@ -58,6 +58,29 @@ export function validateNarrative(narrative: NarrativeResponse, files: DiffFile[
         }
         continue;
       }
+      if (s.type === 'sequence') {
+        // A message links into the diff only when it carries BOTH file and hunkIndex; validate exactly
+        // like callstack frames. Sequence links are never primary refs, so they are excluded from the
+        // duplicate-primary / orphan-hunk accounting below.
+        for (const message of s.messages) {
+          if (message.file === undefined || message.hunkIndex === undefined) continue;
+          const norm = normalizePath(message.file);
+          const file = fileMap.get(norm);
+          if (!file) {
+            violations.push({ kind: 'unknown-file', file: message.file, chapter: ci });
+            continue;
+          }
+          if (message.hunkIndex < 0 || message.hunkIndex >= file.hunks.length) {
+            violations.push({
+              kind: 'invalid-hunk-index',
+              file: message.file,
+              hunkIndex: message.hunkIndex,
+              chapter: ci,
+            });
+          }
+        }
+        continue;
+      }
       if (s.type !== 'diff') continue;
       const norm = normalizePath(s.file);
       const file = fileMap.get(norm);
@@ -190,6 +213,23 @@ export function repairNarrative(narrative: NarrativeResponse, files: DiffFile[])
           return { ...frame, file: undefined, hunkIndex: undefined };
         });
         sections.push({ ...s, frames });
+        continue;
+      }
+      if (s.type === 'sequence') {
+        // Null out (never drop) a message's dead file/hunkIndex pair, mirroring the callstack repair:
+        // the message's prose stays, only the broken link is cleared. No anchor, so nothing to re-resolve.
+        const messages = s.messages.map((message) => {
+          if (message.file === undefined || message.hunkIndex === undefined) return message;
+          const norm = normalizePath(message.file);
+          const file = fileMap.get(norm);
+          const inRange = file ? message.hunkIndex >= 0 && message.hunkIndex < file.hunks.length : false;
+          if (file && inRange) return message;
+          if (!file) dropped.push({ kind: 'unknown-file', file: message.file, chapter: ci });
+          else
+            dropped.push({ kind: 'invalid-hunk-index', file: message.file, hunkIndex: message.hunkIndex, chapter: ci });
+          return { ...message, file: undefined, hunkIndex: undefined };
+        });
+        sections.push({ ...s, messages });
         continue;
       }
       if (s.type !== 'diff') {

--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -206,6 +206,70 @@ describe('narrative payload', () => {
     };
     expect(() => narrativeResponseSchema.parse(bad)).toThrow();
   });
+
+  test('round-trips a sequence section', () => {
+    const withSequence = {
+      ...narrative,
+      chapters: [
+        {
+          ...chapter,
+          sections: [
+            {
+              type: 'sequence' as const,
+              title: 'Client retries through the gateway',
+              participants: ['Client', 'Gateway', 'Service'],
+              messages: [
+                { from: 'Client', to: 'Gateway', label: 'POST /order' },
+                {
+                  from: 'Gateway',
+                  to: 'Service',
+                  label: 'forward',
+                  note: 'now wrapped in a retry',
+                  file: 'src/gateway.ts',
+                  hunkIndex: 0,
+                },
+                { from: 'Service', to: 'Service', label: 'validate' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(narrativeResponseSchema.parse(withSequence)).toEqual(withSequence);
+  });
+
+  test('rejects a sequence message missing its label', () => {
+    const bad = {
+      ...narrative,
+      chapters: [
+        {
+          ...chapter,
+          sections: [{ type: 'sequence', title: 't', participants: ['A'], messages: [{ from: 'A', to: 'A' }] }],
+        },
+      ],
+    };
+    expect(() => narrativeResponseSchema.parse(bad)).toThrow();
+  });
+
+  test('rejects a sequence message with a non-numeric hunkIndex', () => {
+    const bad = {
+      ...narrative,
+      chapters: [
+        {
+          ...chapter,
+          sections: [
+            {
+              type: 'sequence',
+              title: 't',
+              participants: ['A', 'B'],
+              messages: [{ from: 'A', to: 'B', label: 'x', file: 'a.ts', hunkIndex: 'nope' }],
+            },
+          ],
+        },
+      ],
+    };
+    expect(() => narrativeResponseSchema.parse(bad)).toThrow();
+  });
 });
 
 describe('comments', () => {

--- a/packages/contracts/src/narrative.ts
+++ b/packages/contracts/src/narrative.ts
@@ -67,6 +67,16 @@ export const callStackFrameSchema = z.object({
 });
 export type CallStackFrame = z.infer<typeof callStackFrameSchema>;
 
+export const sequenceMessageSchema = z.object({
+  from: z.string(),
+  to: z.string(),
+  label: z.string(),
+  note: z.string().optional(),
+  file: z.string().optional(),
+  hunkIndex: z.number().optional(),
+});
+export type SequenceMessage = z.infer<typeof sequenceMessageSchema>;
+
 export const narrativeSectionSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('narrative'), content: z.string() }),
   z.object({
@@ -81,6 +91,12 @@ export const narrativeSectionSchema = z.discriminatedUnion('type', [
     type: z.literal('callstack'),
     title: z.string(),
     frames: z.array(callStackFrameSchema),
+  }),
+  z.object({
+    type: z.literal('sequence'),
+    title: z.string(),
+    participants: z.array(z.string()),
+    messages: z.array(sequenceMessageSchema),
   }),
 ]);
 export type NarrativeSection = z.infer<typeof narrativeSectionSchema>;

--- a/packages/web/src/components/Chapter.tsx
+++ b/packages/web/src/components/Chapter.tsx
@@ -14,6 +14,7 @@ import type {
   HunkAnchor,
 } from '../state/types';
 import { CallStackSection } from './CallStackSection';
+import { SequenceSection } from './SequenceSection';
 import { Hunk } from './Hunk';
 import { IconCheck, IconChevron } from './Icons';
 import { NarrationAnchor } from './NarrationAnchor';
@@ -530,6 +531,17 @@ export function Chapter({ index, chapter, resolve, decision, callers }: Props) {
         if (section.type === 'callstack') {
           return (
             <CallStackSection key={i} title={section.title} frames={section.frames} resolveHunkId={resolveHunkId} />
+          );
+        }
+        if (section.type === 'sequence') {
+          return (
+            <SequenceSection
+              key={i}
+              title={section.title}
+              participants={section.participants}
+              messages={section.messages}
+              resolveHunkId={resolveHunkId}
+            />
           );
         }
         // Unknown section types (stale cache) render nothing.

--- a/packages/web/src/components/SequenceSection.tsx
+++ b/packages/web/src/components/SequenceSection.tsx
@@ -1,0 +1,270 @@
+import { useEffect, useState } from 'react';
+import { clampStep, currentMessage, nextStep, prevStep, type TourState } from '../lib/sequence-tour';
+import type { SequenceMessage } from '../state/types';
+
+type Props = {
+  title: string;
+  participants: string[];
+  messages: SequenceMessage[];
+  /**
+   * Resolve a message's `file`+`hunkIndex` to the DOM id of the hunk rendered in THIS chapter, or null
+   * when that hunk is not shown here. Identical contract to CallStackSection: only hunks actually shown
+   * in the chapter are scroll targets. Used by the tour to scroll the active step's hunk into view.
+   */
+  resolveHunkId?: (file: string, hunkIndex: number) => string | null;
+};
+
+// Fixed geometry so the diagram is deterministic and hand-laid (no layout library).
+const LANE_WIDTH = 160;
+const ROW_HEIGHT = 44;
+const HEADER_HEIGHT = 48;
+const TOP_PAD = 18;
+const BOTTOM_PAD = 16;
+const SELF_LOOP_WIDTH = 46;
+
+function scrollToHunk(id: string) {
+  const el = document.getElementById(id);
+  if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+}
+
+/** Center x of a participant column, or null when the name is not a known participant. */
+function laneX(participants: string[], name: string): number | null {
+  const i = participants.indexOf(name);
+  if (i < 0) return null;
+  return i * LANE_WIDTH + LANE_WIDTH / 2;
+}
+
+export function SequenceSection({ title, participants, messages, resolveHunkId }: Props) {
+  const [walking, setWalking] = useState(false);
+  const [tour, setTour] = useState<TourState>({ index: 0 });
+
+  const count = messages.length;
+  const activeIndex = walking ? clampStep(tour.index, count) : -1;
+  const active = walking ? currentMessage(messages, tour) : null;
+
+  // Scroll the active step's linked hunk into view, matching CallStackSection's mechanism.
+  useEffect(() => {
+    if (!walking || !active || active.file == null || active.hunkIndex == null) return;
+    const id = resolveHunkId?.(active.file, active.hunkIndex) ?? null;
+    if (id) scrollToHunk(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [walking, activeIndex]);
+
+  // Arrow keys step; Esc closes. Only while walking, so the diagram is inert until the tour starts.
+  useEffect(() => {
+    if (!walking) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        setTour((s) => nextStep(s, count));
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        setTour((s) => prevStep(s, count));
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        setWalking(false);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [walking, count]);
+
+  const width = Math.max(participants.length * LANE_WIDTH, LANE_WIDTH);
+  const height = HEADER_HEIGHT + TOP_PAD + count * ROW_HEIGHT + BOTTOM_PAD;
+  const lifelineBottom = height - BOTTOM_PAD / 2;
+
+  const startWalk = () => {
+    setTour({ index: 0 });
+    setWalking(true);
+  };
+
+  return (
+    <div
+      className="ml-[34px] mb-[14px] overflow-hidden rounded-[8px] bg-[var(--bg-panel)]"
+      style={{ boxShadow: 'inset 0 0 0 1px var(--gray-a5)' }}
+    >
+      <div
+        className="flex items-center gap-2 bg-[var(--gray-2)] px-3 py-2 font-mono text-[12.5px] text-[var(--fg-2)]"
+        style={{ boxShadow: 'inset 0 -1px 0 var(--gray-a4)' }}
+      >
+        <span aria-hidden className="text-[var(--fg-3)]">
+          ⇄
+        </span>
+        <span className="font-semibold text-[var(--fg-1)]">{title || 'Interaction'}</span>
+        <span className="text-[var(--fg-3)]">sequence</span>
+        {count > 0 ? (
+          <button
+            type="button"
+            onClick={() => (walking ? setWalking(false) : startWalk())}
+            className="ml-auto cursor-pointer rounded-[5px] px-2 py-1 text-[11.5px] font-medium"
+            style={{ color: 'var(--purple-11)', boxShadow: 'inset 0 0 0 1px var(--purple-a5)' }}
+          >
+            {walking ? 'Done' : 'Walk through'}
+          </button>
+        ) : null}
+      </div>
+
+      <div className="overflow-x-auto py-1">
+        <svg
+          width={width}
+          height={height}
+          viewBox={`0 0 ${width} ${height}`}
+          role="img"
+          aria-label={title || 'sequence diagram'}
+          style={{ display: 'block' }}
+        >
+          <defs>
+            <marker id="seq-arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+              <path d="M0,0 L6,3 L0,6 Z" fill="var(--fg-2)" />
+            </marker>
+            <marker id="seq-arrow-active" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+              <path d="M0,0 L6,3 L0,6 Z" fill="var(--brand)" />
+            </marker>
+          </defs>
+
+          {/* Participant boxes + lifelines */}
+          {participants.map((p, j) => {
+            const cx = j * LANE_WIDTH + LANE_WIDTH / 2;
+            return (
+              <g key={`p-${j}`}>
+                <rect
+                  x={cx - LANE_WIDTH / 2 + 10}
+                  y={8}
+                  width={LANE_WIDTH - 20}
+                  height={HEADER_HEIGHT - 16}
+                  rx={6}
+                  fill="var(--gray-3)"
+                  stroke="var(--gray-a5)"
+                />
+                <text
+                  x={cx}
+                  y={HEADER_HEIGHT / 2 + 1}
+                  textAnchor="middle"
+                  dominantBaseline="middle"
+                  fontFamily="monospace"
+                  fontSize="12"
+                  fontWeight="600"
+                  fill="var(--fg-1)"
+                >
+                  {p}
+                </text>
+                <line
+                  x1={cx}
+                  y1={HEADER_HEIGHT}
+                  x2={cx}
+                  y2={lifelineBottom}
+                  stroke="var(--gray-a5)"
+                  strokeDasharray="4 4"
+                />
+              </g>
+            );
+          })}
+
+          {/* Message arrows, top-down in array order */}
+          {messages.map((m, i) => {
+            const y = HEADER_HEIGHT + TOP_PAD + i * ROW_HEIGHT + ROW_HEIGHT / 2;
+            const fromX = laneX(participants, m.from);
+            const toX = laneX(participants, m.to);
+            if (fromX == null || toX == null) return null;
+            const isActive = i === activeIndex;
+            const dim = walking && !isActive;
+            const stroke = isActive ? 'var(--brand)' : 'var(--fg-2)';
+            const marker = isActive ? 'url(#seq-arrow-active)' : 'url(#seq-arrow)';
+            const labelFill = isActive ? 'var(--fg-1)' : 'var(--fg-2)';
+            const selfMessage = m.from === m.to;
+
+            return (
+              <g key={`m-${i}`} opacity={dim ? 0.32 : 1} data-message-index={i}>
+                {selfMessage ? (
+                  <>
+                    <path
+                      d={`M${fromX},${y - 7} h${SELF_LOOP_WIDTH} v14 h${-SELF_LOOP_WIDTH}`}
+                      fill="none"
+                      stroke={stroke}
+                      strokeWidth={isActive ? 2 : 1.25}
+                      markerEnd={marker}
+                    />
+                    <text
+                      x={fromX + SELF_LOOP_WIDTH + 6}
+                      y={y}
+                      dominantBaseline="middle"
+                      fontFamily="monospace"
+                      fontSize="11.5"
+                      fill={labelFill}
+                    >
+                      {m.label}
+                    </text>
+                  </>
+                ) : (
+                  <>
+                    <text
+                      x={(fromX + toX) / 2}
+                      y={y - 8}
+                      textAnchor="middle"
+                      fontFamily="monospace"
+                      fontSize="11.5"
+                      fill={labelFill}
+                    >
+                      {m.label}
+                    </text>
+                    <line
+                      x1={fromX}
+                      y1={y}
+                      x2={toX + (toX > fromX ? -7 : 7)}
+                      y2={y}
+                      stroke={stroke}
+                      strokeWidth={isActive ? 2 : 1.25}
+                      markerEnd={marker}
+                    />
+                  </>
+                )}
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+
+      {walking && active ? (
+        <div
+          className="flex items-start gap-3 border-t px-3.5 py-3 text-[13px]"
+          style={{ borderColor: 'var(--gray-a4)', background: 'var(--gray-2)' }}
+          data-sequence-tour
+        >
+          <div className="flex flex-shrink-0 items-center gap-1.5">
+            <button
+              type="button"
+              onClick={() => setTour((s) => prevStep(s, count))}
+              className="cursor-pointer rounded-[5px] px-2 py-1 text-[12px] font-medium text-[var(--fg-2)]"
+              style={{ boxShadow: 'inset 0 0 0 1px var(--gray-a5)' }}
+            >
+              Prev
+            </button>
+            <button
+              type="button"
+              onClick={() => setTour((s) => nextStep(s, count))}
+              className="cursor-pointer rounded-[5px] px-2 py-1 text-[12px] font-medium text-[var(--fg-2)]"
+              style={{ boxShadow: 'inset 0 0 0 1px var(--gray-a5)' }}
+            >
+              Next
+            </button>
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-[11px] font-bold uppercase tracking-[0.06em] text-[var(--fg-3)]">
+              Step {activeIndex + 1} of {count}
+            </div>
+            <div className="mt-0.5 font-mono text-[12.5px] text-[var(--fg-1)]">{active.label}</div>
+            {active.note ? <div className="mt-0.5 text-[12.5px] text-[var(--fg-2)]">{active.note}</div> : null}
+          </div>
+          <button
+            type="button"
+            onClick={() => setWalking(false)}
+            className="flex-shrink-0 cursor-pointer rounded-[5px] px-2 py-1 text-[12px] font-medium"
+            style={{ color: 'var(--purple-11)', boxShadow: 'inset 0 0 0 1px var(--purple-a5)' }}
+          >
+            Done
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/web/src/components/__tests__/sequence-render.test.tsx
+++ b/packages/web/src/components/__tests__/sequence-render.test.tsx
@@ -1,0 +1,34 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import type { SequenceMessage } from '../../state/types';
+import { SequenceSection } from '../SequenceSection';
+
+/**
+ * Server-rendered markup smoke test (props-only component, no store) matching the callstack suite's
+ * approach. Asserts participant boxes and arrow labels reach the SVG, and the tour toggle renders.
+ */
+
+const participants = ['Client', 'Gateway', 'Service'];
+const messages: SequenceMessage[] = [
+  { from: 'Client', to: 'Gateway', label: 'POST /order' },
+  { from: 'Gateway', to: 'Service', label: 'forward', note: 'now retried', file: 'src/gw.ts', hunkIndex: 0 },
+  { from: 'Service', to: 'Service', label: 'validate' },
+];
+
+describe('SequenceSection markup', () => {
+  it('renders participant names and every message label', () => {
+    const html = renderToStaticMarkup(
+      <SequenceSection title="Order flow" participants={participants} messages={messages} />,
+    );
+    expect(html).toContain('Order flow');
+    for (const p of participants) expect(html).toContain(p);
+    for (const m of messages) expect(html).toContain(m.label);
+    // Tour entry point is present when there are messages to walk.
+    expect(html).toContain('Walk through');
+  });
+
+  it('omits the walk-through control when there are no messages', () => {
+    const html = renderToStaticMarkup(<SequenceSection title="Empty" participants={['A']} messages={[]} />);
+    expect(html).not.toContain('Walk through');
+  });
+});

--- a/packages/web/src/lib/__tests__/sequence-tour.test.ts
+++ b/packages/web/src/lib/__tests__/sequence-tour.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { clampStep, currentMessage, nextStep, prevStep } from '../sequence-tour';
+import type { SequenceMessage } from '../../state/types';
+
+function msg(label: string): SequenceMessage {
+  return { from: 'A', to: 'B', label };
+}
+
+describe('sequence-tour', () => {
+  it('clamps into range and handles empty lists', () => {
+    expect(clampStep(-3, 4)).toBe(0);
+    expect(clampStep(9, 4)).toBe(3);
+    expect(clampStep(2, 4)).toBe(2);
+    expect(clampStep(1, 0)).toBe(0);
+  });
+
+  it('advances without wrapping past the last step', () => {
+    expect(nextStep({ index: 0 }, 3)).toEqual({ index: 1 });
+    expect(nextStep({ index: 2 }, 3)).toEqual({ index: 2 }); // saturates
+  });
+
+  it('steps back without wrapping past the first step', () => {
+    expect(prevStep({ index: 2 }, 3)).toEqual({ index: 1 });
+    expect(prevStep({ index: 0 }, 3)).toEqual({ index: 0 }); // saturates
+  });
+
+  it('resolves the current message and returns null when empty', () => {
+    const messages = [msg('one'), msg('two'), msg('three')];
+    expect(currentMessage(messages, { index: 1 })?.label).toBe('two');
+    expect(currentMessage(messages, { index: 99 })?.label).toBe('three'); // clamped
+    expect(currentMessage([], { index: 0 })).toBeNull();
+  });
+});

--- a/packages/web/src/lib/find.ts
+++ b/packages/web/src/lib/find.ts
@@ -16,7 +16,15 @@ export type FindOptions = {
 };
 
 /** Which slice of a chapter a target's text came from — kept for debugging/tests, not shown to users. */
-export type FindField = 'title' | 'summary' | 'whyMatters' | 'narrative' | 'diff' | 'callstack' | 'callout';
+export type FindField =
+  | 'title'
+  | 'summary'
+  | 'whyMatters'
+  | 'narrative'
+  | 'diff'
+  | 'callstack'
+  | 'sequence'
+  | 'callout';
 
 /**
  * A single searchable string plus where it lives. `chapterIndex` / `chid` are what navigation needs to
@@ -106,6 +114,9 @@ export function collectTargets(narrative: NarrativeResponse | null, files: DiffF
       } else if (section.type === 'callstack') {
         push(idx, chid, 'callstack', section.title ?? '');
         for (const frame of section.frames) push(idx, chid, 'callstack', frame.label ?? '');
+      } else if (section.type === 'sequence') {
+        push(idx, chid, 'sequence', section.title ?? '');
+        for (const message of section.messages) push(idx, chid, 'sequence', message.label ?? '');
       } else if (section.type === 'diff') {
         const norm = normalizePath(section.file);
         const diffFile = files.find((f) => normalizePath(f.file) === norm);

--- a/packages/web/src/lib/sequence-tour.ts
+++ b/packages/web/src/lib/sequence-tour.ts
@@ -1,0 +1,31 @@
+/**
+ * Pure stepper logic for the sequence-diagram guided tour. Kept DOM-free so the next/prev/clamp and
+ * current-message rules are unit-testable in isolation from the SVG renderer and its keyboard wiring.
+ */
+import type { SequenceMessage } from '../state/types';
+
+export type TourState = { index: number };
+
+/** Clamp a step index into `[0, count)`. An empty message list clamps to 0. */
+export function clampStep(index: number, count: number): number {
+  if (count <= 0) return 0;
+  if (index < 0) return 0;
+  if (index >= count) return count - 1;
+  return index;
+}
+
+/** Advance one step, saturating at the last message (no wraparound). */
+export function nextStep(state: TourState, count: number): TourState {
+  return { index: clampStep(state.index + 1, count) };
+}
+
+/** Step back one, saturating at the first message (no wraparound). */
+export function prevStep(state: TourState, count: number): TourState {
+  return { index: clampStep(state.index - 1, count) };
+}
+
+/** The message the tour currently points at, or null when there are none. */
+export function currentMessage(messages: SequenceMessage[], state: TourState): SequenceMessage | null {
+  if (messages.length === 0) return null;
+  return messages[clampStep(state.index, messages.length)] ?? null;
+}

--- a/packages/web/src/state/types.ts
+++ b/packages/web/src/state/types.ts
@@ -35,6 +35,7 @@ export type {
   PRReview,
   ReadingPlanStep,
   ReviewRound,
+  SequenceMessage,
   TriagedFile,
   TriageKind,
   TriageSummary,


### PR DESCRIPTION
Callstack sections cover single-component call chains; nothing could
show an interaction changing BETWEEN components. Sections gain a
fourth variant:

  { type: 'sequence', title, participants (2-6),
    messages: [{ from, to, label, note?, file?, hunkIndex? }] }

- writer prompt documents it with strict guidance: cross-component
  interactions only (prefer callstack within one component), real
  component names, 3-12 messages in temporal order; revision bumped
- normalize dedupes/caps participants, drops unknown endpoints when
  full, keeps file/hunkIndex all-or-nothing
- validator checks message links like callstack frames; repair nulls
  dead links, keeps the message
- hand-laid SVG renderer, no new dependencies: lanes, dashed
  lifelines, top-down arrows, self-message loops; CSS-var colors
- 'Walk through' tour: docked step panel, arrow-key navigation,
  active-arrow highlight, scrolls linked hunks into view in-chapter